### PR TITLE
Discriminator refactoring

### DIFF
--- a/src/Dahomey.Cbor.Tests/DiscriminatorTests.cs
+++ b/src/Dahomey.Cbor.Tests/DiscriminatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
 using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.Serialization;
@@ -41,8 +42,6 @@ namespace Dahomey.Cbor.Tests
                 om.AutoMap();
                 om.SetDiscriminatorPolicy(discriminatorPolicy);
             });
-
-            options.Registry.RegisterType(typeof(NameObject));
 
             BaseObjectHolder obj = new BaseObjectHolder
             {
@@ -103,6 +102,11 @@ namespace Dahomey.Cbor.Tests
                 writer.WriteString(MemberName);
                 writer.WriteInt32(discriminator);
             }
+
+            public bool IsDiscriminatedType(Type type)
+            {
+                return true;
+            }
         }
 
         [Fact]
@@ -110,7 +114,7 @@ namespace Dahomey.Cbor.Tests
         {
             CborOptions options = new CborOptions();
             options.Registry.DiscriminatorConventionRegistry.RegisterConvention(new CustomDiscriminatorConvention());
-            options.Registry.RegisterType(typeof(NameObject));
+            options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(NameObject));
 
             const string hexBuffer = "A16A426173654F626A656374A364747970651A22134C83644E616D6563666F6F62496401";
             BaseObjectHolder obj = Helper.Read<BaseObjectHolder>(hexBuffer, options);
@@ -121,7 +125,7 @@ namespace Dahomey.Cbor.Tests
         {
             CborOptions options = new CborOptions();
             options.Registry.DiscriminatorConventionRegistry.RegisterConvention(new CustomDiscriminatorConvention());
-            options.Registry.RegisterType(typeof(NameObject));
+            options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(NameObject));
 
             const string hexBuffer = "A26A426173654F626A656374A364747970651A22134C83644E616D6563666F6F624964016A4E616D654F626A656374F6";
 

--- a/src/Dahomey.Cbor.Tests/DiscriminatorTests.cs
+++ b/src/Dahomey.Cbor.Tests/DiscriminatorTests.cs
@@ -92,7 +92,7 @@ namespace Dahomey.Cbor.Tests
                 return type;
             }
 
-            public void WriteDiscriminator<T>(ref CborWriter writer, Type actualType) where T : class
+            public void WriteDiscriminator(ref CborWriter writer, Type actualType)
             {
                 if (!_discriminatorsByType.TryGetValue(actualType, out int discriminator))
                 {

--- a/src/Dahomey.Cbor.Tests/DiscriminatorTests.cs
+++ b/src/Dahomey.Cbor.Tests/DiscriminatorTests.cs
@@ -22,6 +22,11 @@ namespace Dahomey.Cbor.Tests
         {
             const string hexBuffer = "A16A426173654F626A656374A3625F746A4E616D654F626A656374644E616D6563666F6F62496401";
             BaseObjectHolder obj = Helper.Read<BaseObjectHolder>(hexBuffer);
+
+            Assert.NotNull(obj);
+            Assert.IsType<NameObject>(obj.BaseObject);
+            Assert.Equal("foo", ((NameObject)obj.BaseObject).Name);
+            Assert.Equal(1, obj.BaseObject.Id);
         }
 
         [Theory]
@@ -112,6 +117,11 @@ namespace Dahomey.Cbor.Tests
 
             const string hexBuffer = "A16A426173654F626A656374A364747970651A22134C83644E616D6563666F6F62496401";
             BaseObjectHolder obj = Helper.Read<BaseObjectHolder>(hexBuffer, options);
+
+            Assert.NotNull(obj);
+            Assert.IsType<NameObject>(obj.BaseObject);
+            Assert.Equal("foo", ((NameObject)obj.BaseObject).Name);
+            Assert.Equal(1, obj.BaseObject.Id);
         }
 
         [Fact]

--- a/src/Dahomey.Cbor.Tests/DiscriminatorTests.cs
+++ b/src/Dahomey.Cbor.Tests/DiscriminatorTests.cs
@@ -99,13 +99,7 @@ namespace Dahomey.Cbor.Tests
                     throw new CborException($"Unknown discriminator for type: {actualType}");
                 }
 
-                writer.WriteString(MemberName);
                 writer.WriteInt32(discriminator);
-            }
-
-            public bool IsDiscriminatedType(Type type)
-            {
-                return true;
             }
         }
 

--- a/src/Dahomey.Cbor.Tests/Helper.cs
+++ b/src/Dahomey.Cbor.Tests/Helper.cs
@@ -85,7 +85,7 @@ namespace Dahomey.Cbor.Tests
             }
         }
 
-        public static void TestWrite<T>(T value, string hexBuffer, Type expectedExceptionType = null, CborOptions options = null)
+        public static void TestWrite<T>(T value, string expectedHexBuffer, Type expectedExceptionType = null, CborOptions options = null)
         {
             if (expectedExceptionType != null)
             {
@@ -100,7 +100,8 @@ namespace Dahomey.Cbor.Tests
             }
             else
             {
-                Assert.Equal(hexBuffer, Write(value, options));
+                string actualHexBuffer = Write(value, options);
+                Assert.Equal(expectedHexBuffer, actualHexBuffer);
             }
         }
 

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0020.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0020.cs
@@ -47,8 +47,7 @@ namespace Dahomey.Cbor.Tests.Issues
         public void TestWrite()
         {
             CborOptions options = new CborOptions();
-            options.Registry.RegisterType(typeof(Apple));
-            options.Registry.RegisterType(typeof(Orange));
+            options.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(Fruit).Assembly);
 
             Tree tree = new Tree(10, new Apple());
 
@@ -60,8 +59,7 @@ namespace Dahomey.Cbor.Tests.Issues
         public void TestRead()
         {
             CborOptions options = new CborOptions();
-            options.Registry.RegisterType(typeof(Apple));
-            options.Registry.RegisterType(typeof(Orange));
+            options.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(Fruit).Assembly);
 
             const string hexBuffer = "A2636167650A656672756974A3625F74654170706C6564747970656D4920616D20616E206170706C6563696432646D796964";
             Tree tree = Helper.Read<Tree>(hexBuffer, options);

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0020.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0020.cs
@@ -1,4 +1,5 @@
 ﻿using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization.Conventions;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -47,6 +48,7 @@ namespace Dahomey.Cbor.Tests.Issues
         public void TestWrite()
         {
             CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterConvention(new AttributeBasedDiscriminatorConvention<string>(options.Registry));
             options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(Apple));
             options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(Orange));
 
@@ -60,6 +62,7 @@ namespace Dahomey.Cbor.Tests.Issues
         public void TestRead()
         {
             CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterConvention(new AttributeBasedDiscriminatorConvention<string>(options.Registry));
             options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(Apple));
             options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(Orange));
 

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0020.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0020.cs
@@ -47,7 +47,8 @@ namespace Dahomey.Cbor.Tests.Issues
         public void TestWrite()
         {
             CborOptions options = new CborOptions();
-            options.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(Fruit).Assembly);
+            options.Registry.RegisterType(typeof(Apple));
+            options.Registry.RegisterType(typeof(Orange));
 
             Tree tree = new Tree(10, new Apple());
 
@@ -59,7 +60,8 @@ namespace Dahomey.Cbor.Tests.Issues
         public void TestRead()
         {
             CborOptions options = new CborOptions();
-            options.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(Fruit).Assembly);
+            options.Registry.RegisterType(typeof(Apple));
+            options.Registry.RegisterType(typeof(Orange));
 
             const string hexBuffer = "A2636167650A656672756974A3625F74654170706C6564747970656D4920616D20616E206170706C6563696432646D796964";
             Tree tree = Helper.Read<Tree>(hexBuffer, options);

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0020.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0020.cs
@@ -47,7 +47,7 @@ namespace Dahomey.Cbor.Tests.Issues
         public void TestWrite()
         {
             CborOptions options = new CborOptions();
-            options.Registry.DefaultDiscriminatorConvention.RegisterAssembly(typeof(Fruit).Assembly);
+            options.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(Fruit).Assembly);
 
             Tree tree = new Tree(10, new Apple());
 
@@ -59,7 +59,7 @@ namespace Dahomey.Cbor.Tests.Issues
         public void TestRead()
         {
             CborOptions options = new CborOptions();
-            options.Registry.DefaultDiscriminatorConvention.RegisterAssembly(typeof(Fruit).Assembly);
+            options.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(Fruit).Assembly);
 
             const string hexBuffer = "A2636167650A656672756974A3625F74654170706C6564747970656D4920616D20616E206170706C6563696432646D796964";
             Tree tree = Helper.Read<Tree>(hexBuffer, options);

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0020.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0020.cs
@@ -47,7 +47,8 @@ namespace Dahomey.Cbor.Tests.Issues
         public void TestWrite()
         {
             CborOptions options = new CborOptions();
-            options.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(Fruit).Assembly);
+            options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(Apple));
+            options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(Orange));
 
             Tree tree = new Tree(10, new Apple());
 
@@ -59,7 +60,8 @@ namespace Dahomey.Cbor.Tests.Issues
         public void TestRead()
         {
             CborOptions options = new CborOptions();
-            options.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(Fruit).Assembly);
+            options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(Apple));
+            options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(Orange));
 
             const string hexBuffer = "A2636167650A656672756974A3625F74654170706C6564747970656D4920616D20616E206170706C6563696432646D796964";
             Tree tree = Helper.Read<Tree>(hexBuffer, options);

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0027.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0027.cs
@@ -1,4 +1,5 @@
 ﻿using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization.Conventions;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests.Issues
@@ -14,13 +15,16 @@ namespace Dahomey.Cbor.Tests.Issues
         [Fact]
         public void Test()
         {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterConvention(new AttributeBasedDiscriminatorConvention<string>(options.Registry));
+
             var car = new Car()
             {
                 Description = "n"
             };
 
             string hexBuffer = "A2625F7471736F6D656469736372696D696E61746F726B4465736372697074696F6E616E";
-            Helper.TestWrite(car, hexBuffer);
+            Helper.TestWrite(car, hexBuffer, null, options);
         }
     }
 }

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0029.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0029.cs
@@ -1,4 +1,5 @@
 ﻿using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization.Conventions;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests.Issues
@@ -20,6 +21,7 @@ namespace Dahomey.Cbor.Tests.Issues
         public void Test()
         {
             CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterConvention(new AttributeBasedDiscriminatorConvention<string>(options.Registry));
             options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(DummyMessageParticle));
 
             // {"nonce": 2181035975144481159, "_t": "radix.particles.message"}

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0029.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0029.cs
@@ -20,7 +20,7 @@ namespace Dahomey.Cbor.Tests.Issues
         public void Test()
         {
             CborOptions options = new CborOptions();
-            options.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(DummyParticle).Assembly);
+            options.Registry.RegisterType(typeof(DummyMessageParticle));
 
             // {"nonce": 2181035975144481159, "_t": "radix.particles.message"}
             const string hexBuffer = "A2656E6F6E63651B1E4498A9ECD5A187625F747772616469782E7061727469636C65732E6D657373616765";

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0029.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0029.cs
@@ -20,7 +20,7 @@ namespace Dahomey.Cbor.Tests.Issues
         public void Test()
         {
             CborOptions options = new CborOptions();
-            options.Registry.DefaultDiscriminatorConvention.RegisterAssembly(typeof(DummyParticle).Assembly);
+            options.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(DummyParticle).Assembly);
 
             // {"nonce": 2181035975144481159, "_t": "radix.particles.message"}
             const string hexBuffer = "A2656E6F6E63651B1E4498A9ECD5A187625F747772616469782E7061727469636C65732E6D657373616765";

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0029.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0029.cs
@@ -20,7 +20,7 @@ namespace Dahomey.Cbor.Tests.Issues
         public void Test()
         {
             CborOptions options = new CborOptions();
-            options.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(DummyParticle).Assembly);
+            options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(DummyMessageParticle));
 
             // {"nonce": 2181035975144481159, "_t": "radix.particles.message"}
             const string hexBuffer = "A2656E6F6E63651B1E4498A9ECD5A187625F747772616469782E7061727469636C65732E6D657373616765";

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0029.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0029.cs
@@ -20,7 +20,7 @@ namespace Dahomey.Cbor.Tests.Issues
         public void Test()
         {
             CborOptions options = new CborOptions();
-            options.Registry.RegisterType(typeof(DummyMessageParticle));
+            options.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(DummyParticle).Assembly);
 
             // {"nonce": 2181035975144481159, "_t": "radix.particles.message"}
             const string hexBuffer = "A2656E6F6E63651B1E4498A9ECD5A187625F747772616469782E7061727469636C65732E6D657373616765";

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0046.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0046.cs
@@ -21,7 +21,7 @@ namespace Dahomey.Cbor.Tests.Issues
         public void Test()
         {
             CborOptions options = new CborOptions();
-            options.Registry.DiscriminatorConventionRegistry.RegisterConvention(new DefaultDiscriminatorConvention(options.Registry, "serializer"));
+            options.Registry.DiscriminatorConventionRegistry.RegisterConvention(new AttributeBasedDiscriminatorConvention<string>(options.Registry, "serializer"));
             options.Registry.ObjectMappingRegistry.Register<Atom>(objectMapping =>
             {
                 objectMapping.AutoMap();

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0046.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0046.cs
@@ -1,0 +1,41 @@
+﻿using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Serialization.Conventions;
+using System;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    public class Issue0046
+    {
+        [CborDiscriminator("atom", Policy = CborDiscriminatorPolicy.Always)]
+        public class Atom
+        {
+            public int Z { get; set; }
+            public int A { get; set; }
+        }
+
+        [Fact]
+        public void Test()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterConvention(new DefaultDiscriminatorConvention(options.Registry, "serializer"));
+            options.Registry.ObjectMappingRegistry.Register<Atom>(objectMapping =>
+            {
+                objectMapping.AutoMap();
+                objectMapping.SetOrderBy(m => m.MemberName);
+            });
+
+            Atom obj = new Atom
+            {
+                A = 10,
+                Z = 10
+            };
+
+            const string hexBuffer = "A361410A6A73657269616C697A65726461746F6D615A0A";
+            Helper.TestWrite(obj, hexBuffer, null, options);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/ObjectMappingTests.cs
+++ b/src/Dahomey.Cbor.Tests/ObjectMappingTests.cs
@@ -193,8 +193,8 @@ namespace Dahomey.Cbor.Tests
             CborOptions options = new CborOptions();
             options.Registry.ObjectMappingRegistry.Register<InheritedObject>(objectMapping =>
                 objectMapping
-                    .AutoMap()
                     .SetDiscriminator("inherited")
+                    .AutoMap()
             );
 
             InheritedObject obj = new InheritedObject

--- a/src/Dahomey.Cbor.Tests/ObjectMappingTests.cs
+++ b/src/Dahomey.Cbor.Tests/ObjectMappingTests.cs
@@ -177,6 +177,7 @@ namespace Dahomey.Cbor.Tests
                     .AutoMap()
                     .SetDiscriminator("inherited")
             );
+            options.Registry.RegisterType(typeof(InheritedObject));
 
             const string hexBuffer = "A3625F7469696E686572697465646E496E6865726974656456616C75650D694261736556616C75650C";
             BaseObject obj = Helper.Read<BaseObject>(hexBuffer, options);
@@ -196,6 +197,7 @@ namespace Dahomey.Cbor.Tests
                     .AutoMap()
                     .SetDiscriminator("inherited")
             );
+            options.Registry.RegisterType(typeof(InheritedObject));
 
             InheritedObject obj = new InheritedObject
             {

--- a/src/Dahomey.Cbor.Tests/ObjectMappingTests.cs
+++ b/src/Dahomey.Cbor.Tests/ObjectMappingTests.cs
@@ -172,6 +172,7 @@ namespace Dahomey.Cbor.Tests
         public void ReadWithDiscriminator()
         {
             CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterConvention(new AttributeBasedDiscriminatorConvention<string>(options.Registry));
             options.Registry.ObjectMappingRegistry.Register<InheritedObject>(objectMapping =>
                 objectMapping
                     .AutoMap()
@@ -191,6 +192,7 @@ namespace Dahomey.Cbor.Tests
         public void WriteWithDiscriminator()
         {
             CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterConvention(new AttributeBasedDiscriminatorConvention<string>(options.Registry));
             options.Registry.ObjectMappingRegistry.Register<InheritedObject>(objectMapping =>
                 objectMapping
                     .SetDiscriminator("inherited")
@@ -226,7 +228,7 @@ namespace Dahomey.Cbor.Tests
 
                 // restrict to members holding CborPropertyAttribute
                 objectMapping.SetMemberMappings(objectMapping.MemberMappings
-                    .Where(m => m.MemberInfo.IsDefined(typeof(CborPropertyAttribute)))
+                    .Where(m => m.MemberInfo != null && m.MemberInfo.IsDefined(typeof(CborPropertyAttribute)))
                     .ToList());
             }
         }

--- a/src/Dahomey.Cbor.Tests/ObjectMappingTests.cs
+++ b/src/Dahomey.Cbor.Tests/ObjectMappingTests.cs
@@ -89,7 +89,7 @@ namespace Dahomey.Cbor.Tests
                     .AutoMap()
                     .ClearMemberMappings()
                     .MapMember(o => o.Guid)
-                        .SetMemberConverter(new GuidConverter())
+                        .SetConverter(new GuidConverter())
                         .SetMemberName("g")
             );
 
@@ -109,7 +109,7 @@ namespace Dahomey.Cbor.Tests
                     .AutoMap()
                     .ClearMemberMappings()
                     .MapMember(o => o.Guid)
-                        .SetMemberConverter(new GuidConverter())
+                        .SetConverter(new GuidConverter())
                         .SetMemberName("g")
             );
 
@@ -177,7 +177,6 @@ namespace Dahomey.Cbor.Tests
                     .AutoMap()
                     .SetDiscriminator("inherited")
             );
-            options.Registry.RegisterType(typeof(InheritedObject));
 
             const string hexBuffer = "A3625F7469696E686572697465646E496E6865726974656456616C75650D694261736556616C75650C";
             BaseObject obj = Helper.Read<BaseObject>(hexBuffer, options);
@@ -197,7 +196,6 @@ namespace Dahomey.Cbor.Tests
                     .AutoMap()
                     .SetDiscriminator("inherited")
             );
-            options.Registry.RegisterType(typeof(InheritedObject));
 
             InheritedObject obj = new InheritedObject
             {

--- a/src/Dahomey.Cbor.Tests/SampleClasses.cs
+++ b/src/Dahomey.Cbor.Tests/SampleClasses.cs
@@ -10,7 +10,9 @@ namespace Dahomey.Cbor.Tests
     {
         static SampleClasses()
         {
-            CborOptions.Default.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(SampleClasses).Assembly);
+            CborOptions.Default.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(NameObject));
+            CborOptions.Default.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(DescriptionObject));
+            CborOptions.Default.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(EmptyObjectWithDiscriminator));
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/SampleClasses.cs
+++ b/src/Dahomey.Cbor.Tests/SampleClasses.cs
@@ -10,9 +10,7 @@ namespace Dahomey.Cbor.Tests
     {
         static SampleClasses()
         {
-            CborOptions.Default.Registry.RegisterType(typeof(NameObject));
-            CborOptions.Default.Registry.RegisterType(typeof(DescriptionObject));
-            CborOptions.Default.Registry.RegisterType(typeof(EmptyObjectWithDiscriminator));
+            CborOptions.Default.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(SampleClasses).Assembly);
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/SampleClasses.cs
+++ b/src/Dahomey.Cbor.Tests/SampleClasses.cs
@@ -10,7 +10,7 @@ namespace Dahomey.Cbor.Tests
     {
         static SampleClasses()
         {
-            CborOptions.Default.Registry.DefaultDiscriminatorConvention.RegisterAssembly(typeof(SampleClasses).Assembly);
+            CborOptions.Default.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(SampleClasses).Assembly);
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/SampleClasses.cs
+++ b/src/Dahomey.Cbor.Tests/SampleClasses.cs
@@ -10,7 +10,9 @@ namespace Dahomey.Cbor.Tests
     {
         static SampleClasses()
         {
-            CborOptions.Default.Registry.DiscriminatorConventionRegistry.RegisterAssembly(typeof(SampleClasses).Assembly);
+            CborOptions.Default.Registry.RegisterType(typeof(NameObject));
+            CborOptions.Default.Registry.RegisterType(typeof(DescriptionObject));
+            CborOptions.Default.Registry.RegisterType(typeof(EmptyObjectWithDiscriminator));
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor/CborOptions.cs
+++ b/src/Dahomey.Cbor/CborOptions.cs
@@ -31,12 +31,6 @@ namespace Dahomey.Cbor
         public ValueFormat EnumFormat { get; set; }
         public DateTimeFormat DateTimeFormat { get; set; }
         public bool IsIndented { get; set; }
-        public IDiscriminatorConvention DiscriminatorConvention { get; set; }
         public CborDiscriminatorPolicy DiscriminatorPolicy { get; set; }
-
-        public CborOptions()
-        {
-            DiscriminatorConvention = Registry.DefaultDiscriminatorConvention;
-        }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Conventions/AttributeBasedDiscriminatorConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/AttributeBasedDiscriminatorConvention.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using System;
+using System.Text;
+using Dahomey.Cbor.Serialization.Converters.Mappings;
+using Dahomey.Cbor.Serialization.Converters;
+
+namespace Dahomey.Cbor.Serialization.Conventions
+{
+    public class AttributeBasedDiscriminatorConvention<T> : IDiscriminatorConvention
+    {
+        private readonly SerializationRegistry _serializationRegistry;
+        private readonly ReadOnlyMemory<byte> _memberName;
+        private readonly Dictionary<T, Type> _typesByDiscriminator = new Dictionary<T, Type>();
+        private readonly Dictionary<Type, T> _discriminatorsByType = new Dictionary<Type, T>();
+        private readonly ICborConverter<T> _converter;
+
+        public ReadOnlySpan<byte> MemberName => _memberName.Span;
+
+        public AttributeBasedDiscriminatorConvention(SerializationRegistry serializationRegistry)
+            : this(serializationRegistry, "_t")
+        {
+        }
+
+        public AttributeBasedDiscriminatorConvention(SerializationRegistry serializationRegistry, string memberName)
+        {
+            _serializationRegistry = serializationRegistry;
+            _memberName = Encoding.UTF8.GetBytes(memberName);
+            _converter = serializationRegistry.ConverterRegistry.Lookup<T>();
+        }
+
+        public bool TryRegisterType(Type type)
+        {
+            IObjectMapping objectMapping = _serializationRegistry.ObjectMappingRegistry.Lookup(type);
+
+            if (objectMapping.Discriminator == null || !(objectMapping.Discriminator is T discriminator))
+            {
+                return false;
+            }
+
+            _discriminatorsByType[type] = discriminator;
+            _typesByDiscriminator.Add(discriminator, type);
+            return true;
+        }
+
+        public Type ReadDiscriminator(ref CborReader reader)
+        {
+            T discriminator = _converter.Read(ref reader);
+            if (!_typesByDiscriminator.TryGetValue(discriminator, out Type type))
+            {
+                throw new CborException($"Unknown type discriminator: {discriminator}");
+            }
+            return type;
+        }
+
+        public void WriteDiscriminator(ref CborWriter writer, Type actualType)
+        {
+            if (!_discriminatorsByType.TryGetValue(actualType, out T discriminator))
+            {
+                throw new CborException($"Unknown discriminator for type: {actualType}");
+            }
+
+            _converter.Write(ref writer, discriminator);
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Conventions/DefaultDiscriminatorConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/DefaultDiscriminatorConvention.cs
@@ -52,26 +52,16 @@ namespace Dahomey.Cbor.Serialization.Conventions
 
         public bool TryRegisterType(Type type)
         {
-            string discriminator = null;
-            CborDiscriminatorAttribute discriminatorAttribute = type.GetCustomAttribute<CborDiscriminatorAttribute>();
+            IObjectMapping objectMapping = _serializationRegistry.ObjectMappingRegistry.Lookup(type);
 
-            if (discriminatorAttribute != null)
-            {
-                discriminator = discriminatorAttribute.Discriminator;
-            }
-            else if (_serializationRegistry.ObjectMappingRegistry.TryLookup(type, out IObjectMapping objectMapping))
-            {
-                discriminator = objectMapping.Discriminator;
-            }
-
-            if (string.IsNullOrEmpty(discriminator))
+            if (string.IsNullOrEmpty(objectMapping.Discriminator))
             {
                 return false;
             }
 
-            ReadOnlyMemory<byte> discriminatorMemory = discriminator.AsBinaryMemory();
-            _discriminatorsByType[type] = discriminatorMemory;
-            _typesByDiscriminator.Add(discriminatorMemory.Span, type);
+            ReadOnlyMemory<byte> discriminator = objectMapping.Discriminator.AsBinaryMemory();
+            _discriminatorsByType[type] = discriminator;
+            _typesByDiscriminator.Add(discriminator.Span, type);
             return true;
         }
     }

--- a/src/Dahomey.Cbor/Serialization/Conventions/DefaultDiscriminatorConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/DefaultDiscriminatorConvention.cs
@@ -1,7 +1,10 @@
-﻿using Dahomey.Cbor.Serialization.Converters.Mappings;
+﻿using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization.Converters.Mappings;
 using Dahomey.Cbor.Util;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Text;
 
 namespace Dahomey.Cbor.Serialization.Conventions
@@ -40,6 +43,11 @@ namespace Dahomey.Cbor.Serialization.Conventions
 
             writer.WriteString(MemberName);
             writer.WriteString(discriminator.Span);
+        }
+
+        public bool IsDiscriminatedType(Type type)
+        {
+            return type.IsDefined(typeof(CborDiscriminatorAttribute));
         }
 
         public bool TryRegisterType(Type type)

--- a/src/Dahomey.Cbor/Serialization/Conventions/DefaultDiscriminatorConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/DefaultDiscriminatorConvention.cs
@@ -39,8 +39,7 @@ namespace Dahomey.Cbor.Serialization.Conventions
             return type;
         }
 
-        public void WriteDiscriminator<T>(ref CborWriter writer, Type actualType)
-            where T : class
+        public void WriteDiscriminator(ref CborWriter writer, Type actualType)
         {
             if (!_discriminatorsByType.TryGetValue(actualType, out ReadOnlyMemory<byte> discriminator))
             {

--- a/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
@@ -36,6 +36,11 @@ namespace Dahomey.Cbor.Serialization.Conventions
             _conventions.Push(convention);
         }
 
+        public void ClearConventions()
+        {
+            _conventions.Clear();
+        }
+
         public IDiscriminatorConvention GetConvention(Type type)
         {
             return _conventionsByType.GetOrAdd(type, t => InternalGetConvention(t));
@@ -46,6 +51,8 @@ namespace Dahomey.Cbor.Serialization.Conventions
             // First call will force the registration.
             GetConvention(type);
         }
+
+        public void RegisterType<T>() where T : class => RegisterType(typeof(T));
 
         private IDiscriminatorConvention InternalGetConvention(Type type)
         {

--- a/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
@@ -49,23 +49,12 @@ namespace Dahomey.Cbor.Serialization.Conventions
             }
 
             foreach (Type type in assembly.GetTypes()
-                .Where(t => t.IsClass 
-                    && !t.IsAbstract 
+                .Where(t => t.IsClass
+                    && !t.IsAbstract
                     && !t.IsGenericTypeDefinition
                     && !t.IsDefined(typeof(CompilerGeneratedAttribute))))
             {
-                IDiscriminatorConvention convention = _conventions.FirstOrDefault(c => c.IsDiscriminatedType(type));
-
-                if (convention != null)
-                {
-                    convention.TryRegisterType(type);
-
-                    // setup discriminator for all base types
-                    for (Type currentType = type.BaseType; currentType != null && currentType != typeof(object); currentType = currentType.BaseType)
-                    {
-                        _conventionsByType.TryAdd(currentType, convention);
-                    }
-                }
+                RegisterType(type);
             }
         }
 

--- a/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
@@ -41,23 +41,6 @@ namespace Dahomey.Cbor.Serialization.Conventions
             return _conventionsByType.GetOrAdd(type, t => InternalGetConvention(t));
         }
 
-        public void RegisterAssembly(Assembly assembly)
-        {
-            if (assembly == null)
-            {
-                throw new ArgumentNullException(nameof(assembly));
-            }
-
-            foreach (Type type in assembly.GetTypes()
-                .Where(t => t.IsClass
-                    && !t.IsAbstract
-                    && !t.IsGenericTypeDefinition
-                    && !t.IsDefined(typeof(CompilerGeneratedAttribute))))
-            {
-                RegisterType(type);
-            }
-        }
-
         public void RegisterType(Type type)
         {
             // First call will force the registration.

--- a/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
@@ -1,0 +1,58 @@
+﻿using Dahomey.Cbor.Serialization.Converters;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+
+namespace Dahomey.Cbor.Serialization.Conventions
+{
+    public class DiscriminatorConventionRegistry
+    {
+        private readonly SerializationRegistry _serializationRegistry;
+        private readonly ConcurrentStack<IDiscriminatorConvention> _conventions = new ConcurrentStack<IDiscriminatorConvention>();
+        public DefaultDiscriminatorConvention DefaultDiscriminatorConvention { get; }
+
+        public DiscriminatorConventionRegistry(SerializationRegistry serializationRegistry)
+        {
+            _serializationRegistry = serializationRegistry;
+            DefaultDiscriminatorConvention = new DefaultDiscriminatorConvention(_serializationRegistry);
+
+            // order matters. It's in reverse order of how they'll get consumed
+            RegisterConvention(DefaultDiscriminatorConvention);
+        }
+
+        /// <summary>
+        /// Registers the convention.This behaves like a stack, so the 
+        /// last convention registered is the first convention consulted.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="convention">The convention.</param>
+        public void RegisterConvention(IDiscriminatorConvention convention)
+        {
+            if (convention == null)
+            {
+                throw new ArgumentNullException(nameof(convention));
+            }
+
+            _conventions.Push(convention);
+        }
+
+        public void RegisterAssembly(Assembly assembly)
+        {
+            if (assembly == null)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            foreach (Type type in assembly.GetTypes().Where(t => t.IsClass))
+            {
+                IDiscriminatorConvention discriminatorConvention = _conventions.FirstOrDefault(c => c.TryRegisterType(type));
+
+                if (discriminatorConvention == null)
+                {
+                    continue;
+                }
+            }
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Conventions/IDiscriminatorConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/IDiscriminatorConvention.cs
@@ -6,7 +6,7 @@ namespace Dahomey.Cbor.Serialization.Conventions
     {
         ReadOnlySpan<byte> MemberName { get; }
         Type ReadDiscriminator(ref CborReader reader);
-        void WriteDiscriminator<T>(ref CborWriter writer, Type actualType) where T : class;
+        void WriteDiscriminator(ref CborWriter writer, Type actualType);
         bool TryRegisterType(Type type);
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Conventions/IDiscriminatorConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/IDiscriminatorConvention.cs
@@ -7,7 +7,6 @@ namespace Dahomey.Cbor.Serialization.Conventions
         ReadOnlySpan<byte> MemberName { get; }
         Type ReadDiscriminator(ref CborReader reader);
         void WriteDiscriminator<T>(ref CborWriter writer, Type actualType) where T : class;
-        bool IsDiscriminatedType(Type type);
         bool TryRegisterType(Type type);
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Conventions/IDiscriminatorConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/IDiscriminatorConvention.cs
@@ -7,6 +7,6 @@ namespace Dahomey.Cbor.Serialization.Conventions
         ReadOnlySpan<byte> MemberName { get; }
         Type ReadDiscriminator(ref CborReader reader);
         void WriteDiscriminator<T>(ref CborWriter writer, Type actualType) where T : class;
-        bool IsTypeDiscriminated(Type type);
+        bool TryRegisterType(Type type);
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Conventions/IDiscriminatorConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/IDiscriminatorConvention.cs
@@ -7,6 +7,7 @@ namespace Dahomey.Cbor.Serialization.Conventions
         ReadOnlySpan<byte> MemberName { get; }
         Type ReadDiscriminator(ref CborReader reader);
         void WriteDiscriminator<T>(ref CborWriter writer, Type actualType) where T : class;
+        bool IsDiscriminatedType(Type type);
         bool TryRegisterType(Type type);
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/CborConverterRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborConverterRegistry.cs
@@ -1,5 +1,4 @@
-﻿using Dahomey.Cbor.Serialization.Converters.Mappings;
-using Dahomey.Cbor.Serialization.Converters.Providers;
+﻿using Dahomey.Cbor.Serialization.Converters.Providers;
 using System;
 using System.Collections.Concurrent;
 using System.Linq;

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/CreatorMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/CreatorMapping.cs
@@ -130,5 +130,9 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                 }
             }
         }
+
+        public void PostInitialize()
+        {
+        }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
@@ -23,7 +23,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
             if (discriminatorAttribute != null)
             {
-                registry.DiscriminatorConventionRegistry.DefaultDiscriminatorConvention.RegisterType(type, discriminatorAttribute.Discriminator);
+                objectMapping.SetDiscriminator(discriminatorAttribute.Discriminator);
                 objectMapping.SetDiscriminatorPolicy(discriminatorAttribute.Policy);
             }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
@@ -190,7 +190,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             }
         }
 
-        private void ProcessRequired(MemberInfo memberInfo, MemberMapping memberMapping)
+        private void ProcessRequired<T>(MemberInfo memberInfo, MemberMapping<T> memberMapping) where T : class
         {
             CborRequiredAttribute jsonRequiredAttribute = memberInfo.GetCustomAttribute<CborRequiredAttribute>();
             if (jsonRequiredAttribute != null)

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
@@ -19,17 +19,11 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             Type type = objectMapping.ObjectType;
             List<MemberMapping> memberMappings = new List<MemberMapping>();
 
-            ReadOnlyMemory<byte> typeName = Encoding.ASCII.GetBytes($"{type.FullName}, {type.Assembly.GetName().Name}");
             CborDiscriminatorAttribute discriminatorAttribute = type.GetCustomAttribute<CborDiscriminatorAttribute>();
-
-            ReadOnlyMemory<byte> discriminator = Encoding.UTF8.GetBytes(discriminatorAttribute != null ?
-                discriminatorAttribute.Discriminator :
-                $"{type.FullName}, {type.Assembly.GetName().Name}");
-
-            registry.DefaultDiscriminatorConvention.RegisterType(type, discriminator);
 
             if (discriminatorAttribute != null)
             {
+                registry.DiscriminatorConventionRegistry.DefaultDiscriminatorConvention.RegisterType(type, discriminatorAttribute.Discriminator);
                 objectMapping.SetDiscriminatorPolicy(discriminatorAttribute.Policy);
             }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
@@ -17,7 +17,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         public void Apply<T>(SerializationRegistry registry, ObjectMapping<T> objectMapping) where T : class
         {
             Type type = objectMapping.ObjectType;
-            List<MemberMapping> memberMappings = new List<MemberMapping>();
+            List<MemberMapping<T>> memberMappings = new List<MemberMapping<T>>();
 
             CborDiscriminatorAttribute discriminatorAttribute = type.GetCustomAttribute<CborDiscriminatorAttribute>();
 
@@ -54,7 +54,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                     continue;
                 }
 
-                MemberMapping memberMapping = new MemberMapping(registry.ConverterRegistry, objectMapping, propertyInfo, propertyInfo.PropertyType);
+                MemberMapping<T> memberMapping = new MemberMapping<T>(registry.ConverterRegistry, objectMapping, propertyInfo, propertyInfo.PropertyType);
                 ProcessDefaultValue(propertyInfo, memberMapping);
                 ProcessShouldSerializeMethod(memberMapping);
                 ProcessLengthMode(propertyInfo, memberMapping);
@@ -75,7 +75,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
                 Type fieldType = fieldInfo.FieldType;
 
-                MemberMapping memberMapping = new MemberMapping(registry.ConverterRegistry, objectMapping, fieldInfo, fieldInfo.FieldType);
+                MemberMapping<T> memberMapping = new MemberMapping<T>(registry.ConverterRegistry, objectMapping, fieldInfo, fieldInfo.FieldType);
                 ProcessDefaultValue(fieldInfo, memberMapping);
                 ProcessShouldSerializeMethod(memberMapping);
                 ProcessLengthMode(fieldInfo, memberMapping);
@@ -83,7 +83,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                 memberMappings.Add(memberMapping);
             }
 
-            objectMapping.SetMemberMappings(memberMappings);
+            objectMapping.AddMemberMappings(memberMappings);
 
             ConstructorInfo[] constructorInfos = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
 
@@ -143,7 +143,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             }
         }
 
-        private void ProcessDefaultValue(MemberInfo memberInfo, MemberMapping memberMapping)
+        private void ProcessDefaultValue<T>(MemberInfo memberInfo, MemberMapping<T> memberMapping) where T : class
         {
             DefaultValueAttribute defaultValueAttribute = memberInfo.GetCustomAttribute<DefaultValueAttribute>();
             if (defaultValueAttribute != null)
@@ -157,7 +157,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             }
         }
 
-        private void ProcessShouldSerializeMethod(MemberMapping memberMapping)
+        private void ProcessShouldSerializeMethod<T>(MemberMapping<T> memberMapping) where T : class
         {
             string shouldSerializeMethodName = "ShouldSerialize" + memberMapping.MemberInfo.Name;
             Type objectType = memberMapping.MemberInfo.DeclaringType;
@@ -179,7 +179,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             }
         }
 
-        private void ProcessLengthMode(MemberInfo memberInfo, MemberMapping memberMapping)
+        private void ProcessLengthMode<T>(MemberInfo memberInfo, MemberMapping<T> memberMapping) where T : class
         {
             CborLengthModeAttribute lengthModeAttribute = memberInfo.GetCustomAttribute<CborLengthModeAttribute>();
             if (lengthModeAttribute != null)

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DiscriminatorMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DiscriminatorMapping.cs
@@ -1,0 +1,51 @@
+﻿using Dahomey.Cbor.Serialization.Conventions;
+using System;
+using System.Reflection;
+using System.Text;
+
+namespace Dahomey.Cbor.Serialization.Converters.Mappings
+{
+    public class DiscriminatorMapping<T> : IMemberMapping where T : class
+    {
+        private readonly DiscriminatorConventionRegistry _discriminatorConventionRegistry;
+        private readonly IObjectMapping _objectMapping;
+
+        public MemberInfo MemberInfo => null;
+        public Type MemberType => null;
+        public string MemberName { get; private set; }
+        public ICborConverter Converter => null;
+        public bool CanBeDeserialized => false;
+        public bool CanBeSerialized => true;
+        public object DefaultValue => null;
+        public bool IgnoreIfDefault => false;
+        public Func<object, bool> ShouldSerializeMethod => null;
+        public LengthMode LengthMode => LengthMode.Default;
+
+        public DiscriminatorMapping(DiscriminatorConventionRegistry discriminatorConventionRegistry, 
+            IObjectMapping objectMapping)
+        {
+            _discriminatorConventionRegistry = discriminatorConventionRegistry;
+            _objectMapping = objectMapping;
+        }
+
+        public void Initialize()
+        {
+        }
+
+        public void PostInitialize()
+        {
+            IDiscriminatorConvention discriminatorConvention = _discriminatorConventionRegistry.GetConvention(_objectMapping.ObjectType);
+            MemberName = Encoding.UTF8.GetString(discriminatorConvention.MemberName);
+        }
+
+        public IMemberConverter GenerateMemberConverter()
+        {
+            IDiscriminatorConvention discriminatorConvention = _discriminatorConventionRegistry.GetConvention(_objectMapping.ObjectType);
+
+            IMemberConverter memberConverter = new DiscriminatorMemberConverter<T>(
+                discriminatorConvention, _objectMapping.DiscriminatorPolicy);
+
+            return memberConverter;
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DiscriminatorMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DiscriminatorMapping.cs
@@ -1,4 +1,5 @@
-﻿using Dahomey.Cbor.Serialization.Conventions;
+﻿using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization.Conventions;
 using System;
 using System.Reflection;
 using System.Text;
@@ -20,6 +21,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         public bool IgnoreIfDefault => false;
         public Func<object, bool> ShouldSerializeMethod => null;
         public LengthMode LengthMode => LengthMode.Default;
+        public RequirementPolicy RequirementPolicy => RequirementPolicy.Never;
 
         public DiscriminatorMapping(DiscriminatorConventionRegistry discriminatorConventionRegistry, 
             IObjectMapping objectMapping)

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/IMappingInitialization.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/IMappingInitialization.cs
@@ -3,5 +3,6 @@
     public interface IMappingInitialization
     {
         void Initialize();
+        void PostInitialize();
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/IMemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/IMemberMapping.cs
@@ -15,5 +15,6 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         bool IgnoreIfDefault { get; }
         Func<object, bool> ShouldSerializeMethod { get; }
         LengthMode LengthMode { get; }
+        IMemberConverter GenerateMemberConverter();
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/IMemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/IMemberMapping.cs
@@ -8,7 +8,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         MemberInfo MemberInfo { get; }
         Type MemberType { get; }
         string MemberName { get; }
-        ICborConverter MemberConverter { get; }
+        ICborConverter Converter { get; }
         bool CanBeDeserialized { get; }
         bool CanBeSerialized { get; }
         object DefaultValue { get; }

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/IObjectMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/IObjectMapping.cs
@@ -16,6 +16,9 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         Delegate OnDeserializingMethod { get; }
         Delegate OnDeserializedMethod { get; }
         CborDiscriminatorPolicy DiscriminatorPolicy { get; }
+        string Discriminator { get; }
         LengthMode LengthMode { get; }
+
+        void AutoMap();
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace Dahomey.Cbor.Serialization.Converters.Mappings
 {
-    public class MemberMapping : IMemberMapping
+    public class MemberMapping<T> : IMemberMapping where T : class
     {
         private readonly IObjectMapping _objectMapping;
         private readonly CborConverterRegistry _converterRegistry;
@@ -31,37 +31,37 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             DefaultValue = (memberType.IsClass || memberType.IsInterface) ? null : Activator.CreateInstance(memberType);
         }
 
-        public MemberMapping SetMemberName(string memberName)
+        public MemberMapping<T> SetMemberName(string memberName)
         {
             MemberName = memberName;
             return this;
         }
 
-        public MemberMapping SetConverter(ICborConverter converter)
+        public MemberMapping<T> SetConverter(ICborConverter converter)
         {
             Converter = converter;
             return this;
         }
 
-        public MemberMapping SetDefaultValue(object defaultValue)
+        public MemberMapping<T> SetDefaultValue(object defaultValue)
         {
             DefaultValue = defaultValue;
             return this;
         }
 
-        public MemberMapping SetIngoreIfDefault(bool ignoreIfDefault)
+        public MemberMapping<T> SetIngoreIfDefault(bool ignoreIfDefault)
         {
             IgnoreIfDefault = ignoreIfDefault;
             return this;
         }
 
-        public MemberMapping SetShouldSerializeMethod(Func<object, bool> shouldSerializeMethod)
+        public MemberMapping<T> SetShouldSerializeMethod(Func<object, bool> shouldSerializeMethod)
         {
             ShouldSerializeMethod = shouldSerializeMethod;
             return this;
         }
 
-        public MemberMapping SetLengthMode(LengthMode lengthMode)
+        public MemberMapping<T> SetLengthMode(LengthMode lengthMode)
         {
             LengthMode = lengthMode;
             return this;
@@ -74,6 +74,19 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             InitializeCanBeDeserialized();
             InitializeCanBeSerialized();
             ValidateDefaultValue();
+        }
+
+        public void PostInitialize()
+        {
+        }
+
+        public IMemberConverter GenerateMemberConverter()
+        {
+            IMemberConverter memberConverter = (IMemberConverter)Activator.CreateInstance(
+                typeof(MemberConverter<,>).MakeGenericType(typeof(T), MemberType),
+                _converterRegistry, this);
+
+            return memberConverter;
         }
 
         private void InitializeMemberName()

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
@@ -68,7 +68,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             return this;
         }
 
-        public MemberMapping SetRequired(RequirementPolicy requirementPolicy)
+        public MemberMapping<T> SetRequired(RequirementPolicy requirementPolicy)
         {
             RequirementPolicy = requirementPolicy;
             return this;

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
@@ -13,7 +13,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         public MemberInfo MemberInfo { get; private set; }
         public Type MemberType { get; private set; }
         public string MemberName { get; private set; }
-        public ICborConverter MemberConverter { get; private set; }
+        public ICborConverter Converter { get; private set; }
         public bool CanBeDeserialized { get; private set; }
         public bool CanBeSerialized { get; private set; }
         public object DefaultValue { get; private set; }
@@ -37,9 +37,9 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             return this;
         }
 
-        public MemberMapping SetMemberConverter(ICborConverter converter)
+        public MemberMapping SetConverter(ICborConverter converter)
         {
-            MemberConverter = converter;
+            Converter = converter;
             return this;
         }
 
@@ -70,7 +70,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         public void Initialize()
         {
             InitializeMemberName();
-            InitializeMemberConverter();
+            InitializeConverter();
             InitializeCanBeDeserialized();
             InitializeCanBeSerialized();
             ValidateDefaultValue();
@@ -96,9 +96,9 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             }
         }
 
-        private void InitializeMemberConverter()
+        private void InitializeConverter()
         {
-            if (MemberConverter == null)
+            if (Converter == null)
             {
                 CborConverterAttribute converterAttribute = MemberInfo.GetCustomAttribute<CborConverterAttribute>();
                 if (converterAttribute != null)
@@ -106,16 +106,16 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                     Type converterType = converterAttribute.ConverterType;
                     VerifyMemberConverterType(converterType);
 
-                    MemberConverter = (ICborConverter)Activator.CreateInstance(converterType);
+                    Converter = (ICborConverter)Activator.CreateInstance(converterType);
                 }
                 else
                 {
-                    MemberConverter = _converterRegistry.Lookup(MemberType);
+                    Converter = _converterRegistry.Lookup(MemberType);
                 }
             }
             else
             {
-                VerifyMemberConverterType(MemberConverter.GetType());
+                VerifyMemberConverterType(Converter.GetType());
             }
         }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
@@ -1,6 +1,5 @@
 ﻿using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.Serialization.Conventions;
-using Dahomey.Cbor.Util;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,12 +29,18 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         public Delegate OnDeserializingMethod { get; private set; }
         public Delegate OnDeserializedMethod { get; private set; }
         public CborDiscriminatorPolicy DiscriminatorPolicy { get; private set; }
+        public string Discriminator { get; private set; }
         public LengthMode LengthMode { get; private set; }
 
         public ObjectMapping(SerializationRegistry registry)
         {
             _registry = registry;
             ObjectType = typeof(T);
+        }
+
+        void IObjectMapping.AutoMap()
+        {
+            AutoMap();
         }
 
         public ObjectMapping<T> AutoMap()
@@ -45,15 +50,10 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             return this;
         }
 
-        public ObjectMapping<T> SetDiscriminator(ReadOnlyMemory<byte> discriminator)
-        {
-            _registry.DiscriminatorConventionRegistry.DefaultDiscriminatorConvention.RegisterType(ObjectType, discriminator);
-            return this;
-        }
-
         public ObjectMapping<T> SetDiscriminator(string discriminator)
         {
-            return SetDiscriminator(discriminator.AsBinaryMemory());
+            Discriminator = discriminator;
+            return this;
         }
 
         public ObjectMapping<T> SetNamingConvention(INamingConvention namingConvention)

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
@@ -18,6 +18,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         private readonly SerializationRegistry _registry;
         private List<IMemberMapping> _memberMappings = new List<IMemberMapping>();
         private ICreatorMapping _creatorMapping = null;
+        private Action _orderByAction = null; 
 
         public Type ObjectType { get; private set; }
 
@@ -53,6 +54,8 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         public ObjectMapping<T> SetDiscriminator(string discriminator)
         {
             Discriminator = discriminator;
+            DiscriminatorMapping<T> memberMapping = new DiscriminatorMapping<T>(_registry.DiscriminatorConventionRegistry, this);
+            _memberMappings.Add(memberMapping);
             return this;
         }
 
@@ -68,30 +71,36 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         /// <typeparam name="TM">The member type.</typeparam>
         /// <param name="memberLambda">A lambda expression specifying the member.</param>
         /// <returns>The member map.</returns>
-        public MemberMapping MapMember<TM>(Expression<Func<T, TM>> memberLambda)
+        public MemberMapping<T> MapMember<TM>(Expression<Func<T, TM>> memberLambda)
         {
             (MemberInfo memberInfo, Type memberType) = GetMemberInfoFromLambda(memberLambda);
             return MapMember(memberInfo, memberType);
         }
 
-        public MemberMapping MapMember(MemberInfo memberInfo, Type memberType)
+        public MemberMapping<T> MapMember(MemberInfo memberInfo, Type memberType)
         {
-            MemberMapping memberMapping = new MemberMapping(_registry.ConverterRegistry, this, memberInfo, memberType);
+            MemberMapping<T> memberMapping = new MemberMapping<T>(_registry.ConverterRegistry, this, memberInfo, memberType);
             _memberMappings.Add(memberMapping);
             return memberMapping;
         }
 
-        public MemberMapping MapMember(FieldInfo fieldInfo)
+        public MemberMapping<T> MapMember(FieldInfo fieldInfo)
         {
             return MapMember(fieldInfo, fieldInfo.FieldType);
         }
 
-        public MemberMapping MapMember(PropertyInfo propertyInfo)
+        public MemberMapping<T> MapMember(PropertyInfo propertyInfo)
         {
             return MapMember(propertyInfo, propertyInfo.PropertyType);
         }
 
-        public ObjectMapping<T> SetMemberMappings(IReadOnlyCollection<IMemberMapping> memberMappings)
+        public ObjectMapping<T> AddMemberMappings(IReadOnlyCollection<IMemberMapping> memberMappings)
+        {
+            _memberMappings.AddRange(memberMappings);
+            return this;
+        }
+
+        public ObjectMapping<T> SetMemberMappings(IEnumerable<IMemberMapping> memberMappings)
         {
             _memberMappings = memberMappings.ToList();
             return this;
@@ -201,6 +210,16 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             return this;
         }
 
+        public void SetOrderBy<TP>(Func<IMemberMapping, TP> propertySelector)
+        {
+            _orderByAction = () =>
+            {
+                _memberMappings = _memberMappings
+                    .OrderBy(propertySelector)
+                    .ToList();
+            };
+        }
+
         public void Initialize()
         {
             foreach(IMemberMapping mapping in _memberMappings)
@@ -215,6 +234,24 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             {
                 creatorInitialization.Initialize();
             }
+        }
+
+        public void PostInitialize()
+        {
+            foreach (IMemberMapping mapping in _memberMappings)
+            {
+                if (mapping is IMappingInitialization memberInitialization)
+                {
+                    memberInitialization.PostInitialize();
+                }
+            }
+
+            if (CreatorMapping != null && CreatorMapping is IMappingInitialization creatorInitialization)
+            {
+                creatorInitialization.PostInitialize();
+            }
+
+            _orderByAction?.Invoke();
         }
 
         private static (MemberInfo, Type) GetMemberInfoFromLambda<TM>(Expression<Func<T, TM>> memberLambda)

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
@@ -46,7 +46,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
         public ObjectMapping<T> SetDiscriminator(ReadOnlyMemory<byte> discriminator)
         {
-            _registry.DefaultDiscriminatorConvention.RegisterType(ObjectType, discriminator);
+            _registry.DiscriminatorConventionRegistry.DefaultDiscriminatorConvention.RegisterType(ObjectType, discriminator);
             return this;
         }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
@@ -38,6 +38,12 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         {
             _registry = registry;
             ObjectType = typeof(T);
+
+            if (!ObjectType.IsAbstract && !ObjectType.IsInterface)
+            {
+                DiscriminatorMapping<T> memberMapping = new DiscriminatorMapping<T>(registry.DiscriminatorConventionRegistry, this);
+                _memberMappings.Add(memberMapping);
+            }
         }
 
         void IObjectMapping.AutoMap()
@@ -55,8 +61,6 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         public ObjectMapping<T> SetDiscriminator(string discriminator)
         {
             Discriminator = discriminator;
-            DiscriminatorMapping<T> memberMapping = new DiscriminatorMapping<T>(_registry.DiscriminatorConventionRegistry, this);
-            _memberMappings.Add(memberMapping);
             return this;
         }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMappingRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMappingRegistry.cs
@@ -16,7 +16,8 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
         public void Register(IObjectMapping objectMapping)
         {
-            if (objectMapping is IMappingInitialization mappingInitialization)
+            IMappingInitialization mappingInitialization = objectMapping as IMappingInitialization;
+            if (mappingInitialization != null)
             {
                 mappingInitialization.Initialize();
             }
@@ -27,6 +28,11 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             if (!string.IsNullOrEmpty(objectMapping.Discriminator))
             {
                 _registry.DiscriminatorConventionRegistry.RegisterType(objectMapping.ObjectType);
+            }
+
+            if (mappingInitialization != null)
+            {
+                mappingInitialization.PostInitialize();
             }
         }
 
@@ -51,6 +57,11 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         public IObjectMapping Lookup(Type type)
         {
             return _objectMappings.GetOrAdd(type, t => CreateDefaultObjectMapping(type));
+        }
+
+        public bool TryLookup(Type type, out IObjectMapping objectMapping)
+        {
+            return _objectMappings.TryGetValue(type, out objectMapping);
         }
 
         private IObjectMapping CreateDefaultObjectMapping(Type type)

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMappingRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMappingRegistry.cs
@@ -40,12 +40,19 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
         public IObjectMapping Lookup<T>() where T : class
         {
-            return _objectMappings.GetOrAdd(typeof(T), t => CreateDefaultObjectMapping<T>());
+            return Lookup(typeof(T));
         }
 
-        private IObjectMapping CreateDefaultObjectMapping<T>() where T : class
+        public IObjectMapping Lookup(Type type)
         {
-            ObjectMapping<T> objectMapping = new ObjectMapping<T>(_registry);
+            return _objectMappings.GetOrAdd(type, t => CreateDefaultObjectMapping(type));
+        }
+
+        private IObjectMapping CreateDefaultObjectMapping(Type type)
+        {
+            IObjectMapping objectMapping = 
+                (IObjectMapping)Activator.CreateInstance(typeof(ObjectMapping<>).MakeGenericType(type), _registry);
+
             objectMapping.AutoMap();
 
             if (objectMapping is IMappingInitialization mappingInitialization)

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMappingRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMappingRegistry.cs
@@ -59,11 +59,6 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             return _objectMappings.GetOrAdd(type, t => CreateDefaultObjectMapping(type));
         }
 
-        public bool TryLookup(Type type, out IObjectMapping objectMapping)
-        {
-            return _objectMappings.TryGetValue(type, out objectMapping);
-        }
-
         private IObjectMapping CreateDefaultObjectMapping(Type type)
         {
             IObjectMapping objectMapping =

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMappingRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMappingRegistry.cs
@@ -5,7 +5,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 {
     public class ObjectMappingRegistry
     {
-        private readonly ConcurrentDictionary<Type, IObjectMapping> _objectMappings 
+        private readonly ConcurrentDictionary<Type, IObjectMapping> _objectMappings
             = new ConcurrentDictionary<Type, IObjectMapping>();
         private readonly SerializationRegistry _registry;
 
@@ -13,7 +13,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         {
             _registry = registry;
         }
-        
+
         public void Register(IObjectMapping objectMapping)
         {
             if (objectMapping is IMappingInitialization mappingInitialization)
@@ -23,6 +23,11 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
             _objectMappings.AddOrUpdate(objectMapping.ObjectType, objectMapping,
                 (type, existingObjectMapping) => objectMapping);
+
+            if (!string.IsNullOrEmpty(objectMapping.Discriminator))
+            {
+                _registry.DiscriminatorConventionRegistry.RegisterType(objectMapping.ObjectType);
+            }
         }
 
         public void Register<T>() where T : class
@@ -50,7 +55,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
         private IObjectMapping CreateDefaultObjectMapping(Type type)
         {
-            IObjectMapping objectMapping = 
+            IObjectMapping objectMapping =
                 (IObjectMapping)Activator.CreateInstance(typeof(ObjectMapping<>).MakeGenericType(type), _registry);
 
             objectMapping.AutoMap();

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
@@ -1,4 +1,5 @@
-﻿using Dahomey.Cbor.Serialization.Converters.Mappings;
+﻿using Dahomey.Cbor.Serialization.Conventions;
+using Dahomey.Cbor.Serialization.Converters.Mappings;
 using Dahomey.Cbor.Util;
 using System;
 using System.Collections.Generic;
@@ -136,6 +137,46 @@ namespace Dahomey.Cbor.Serialization.Converters
                 default:
                     return null;
             }
+        }
+    }
+
+    public class DiscriminatorMemberConverter<T> : IMemberConverter
+        where T : class
+    {
+        private readonly IDiscriminatorConvention _discriminatorConvention;
+
+        public DiscriminatorMemberConverter(IDiscriminatorConvention discriminatorConvention)
+        {
+            _discriminatorConvention = discriminatorConvention;
+        }
+
+        public ReadOnlySpan<byte> MemberName => _discriminatorConvention.MemberName;
+
+        public bool IgnoreIfDefault => false;
+
+        public void Read(ref CborReader reader, object obj)
+        {
+            throw new NotSupportedException();
+        }
+
+        public object Read(ref CborReader reader)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Set(object obj, object value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool ShouldSerialize(object obj)
+        {
+            return true;
+        }
+
+        public void Write(ref CborWriter writer, object obj)
+        {
+            _discriminatorConvention.WriteDiscriminator<T>(ref writer, obj.GetType());
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
@@ -168,6 +168,7 @@ namespace Dahomey.Cbor.Serialization.Converters
     {
         private readonly IDiscriminatorConvention _discriminatorConvention;
         private readonly CborDiscriminatorPolicy _discriminatorPolicy;
+        private readonly ReadOnlyMemory<byte> _memberName;
 
         public DiscriminatorMemberConverter(
             IDiscriminatorConvention discriminatorConvention, 
@@ -175,9 +176,14 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             _discriminatorConvention = discriminatorConvention;
             _discriminatorPolicy = discriminatorPolicy;
+
+            if (discriminatorConvention != null)
+            {
+                _memberName = discriminatorConvention.MemberName.ToArray();
+            }
         }
 
-        public ReadOnlySpan<byte> MemberName => _discriminatorConvention.MemberName;
+        public ReadOnlySpan<byte> MemberName => _memberName.Span;
         public bool IgnoreIfDefault => false;
         public RequirementPolicy RequirementPolicy => RequirementPolicy.Never;
 
@@ -198,6 +204,11 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public bool ShouldSerialize(object obj, Type declaredType, CborOptions options)
         {
+            if (_discriminatorConvention == null)
+            {
+                return false;
+            }
+
             CborDiscriminatorPolicy discriminatorPolicy = _discriminatorPolicy != CborDiscriminatorPolicy.Default ? _discriminatorPolicy
                 : (options.DiscriminatorPolicy != CborDiscriminatorPolicy.Default ? options.DiscriminatorPolicy : CborDiscriminatorPolicy.Auto);
 

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
@@ -25,7 +25,7 @@ namespace Dahomey.Cbor.Serialization.Converters
     {
         private readonly Func<T, TM> _memberGetter;
         private readonly Action<T, TM> _memberSetter;
-        private readonly ICborConverter<TM> _memberConverter;
+        private readonly ICborConverter<TM> _converter;
         private ReadOnlyMemory<byte> _memberName;
         private readonly TM _defaultValue;
         private readonly bool _ignoreIfDefault;
@@ -42,7 +42,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             _memberName = Encoding.UTF8.GetBytes(memberMapping.MemberName);
             _memberGetter = GenerateGetter(memberInfo);
             _memberSetter = GenerateSetter(memberInfo);
-            _memberConverter = (ICborConverter<TM>)memberMapping.MemberConverter;
+            _converter = (ICborConverter<TM>)memberMapping.Converter;
             _defaultValue = (TM)memberMapping.DefaultValue;
             _ignoreIfDefault = memberMapping.IgnoreIfDefault;
             _shouldSeriliazeMethod = memberMapping.ShouldSerializeMethod;
@@ -51,17 +51,17 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public void Read(ref CborReader reader, object obj)
         {
-            _memberSetter((T)obj, _memberConverter.Read(ref reader));
+            _memberSetter((T)obj, _converter.Read(ref reader));
         }
 
         public void Write(ref CborWriter writer, object obj)
         {
-            _memberConverter.Write(ref writer, _memberGetter((T)obj), _lengthMode);
+            _converter.Write(ref writer, _memberGetter((T)obj), _lengthMode);
         }
 
         public object Read(ref CborReader reader)
         {
-            return _memberConverter.Read(ref reader);
+            return _converter.Read(ref reader);
         }
 
         public void Set(object obj, object value)

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
@@ -185,7 +185,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public void Write(ref CborWriter writer, object obj)
         {
-            _discriminatorConvention.WriteDiscriminator<T>(ref writer, obj.GetType());
+            _discriminatorConvention.WriteDiscriminator(ref writer, obj.GetType());
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -14,7 +14,6 @@ namespace Dahomey.Cbor.Serialization.Converters
         void ReadValue(ref CborReader reader, object obj, ReadOnlySpan<byte> memberName);
         bool ReadValue(ref CborReader reader, ReadOnlySpan<byte> memberName, out object value);
         IReadOnlyList<IMemberConverter> MemberConvertersForWrite { get; }
-        void SetDiscriminatorConvention(IDiscriminatorConvention discriminatorConvention);
     }
 
     public interface IObjectConverter<out T> : IObjectConverter
@@ -115,11 +114,8 @@ namespace Dahomey.Cbor.Serialization.Converters
 
                 _constructor = defaultConstructorInfo.CreateDelegate<T>();
             }
-        }
 
-        public void SetDiscriminatorConvention(IDiscriminatorConvention discriminatorConvention)
-        {
-            _discriminatorConvention = discriminatorConvention;
+            _discriminatorConvention = registry.DiscriminatorConventionRegistry.GetConvention(typeof(T));
         }
 
         public T CreateInstance()

--- a/src/Dahomey.Cbor/Serialization/SerializationRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/SerializationRegistry.cs
@@ -9,14 +9,14 @@ namespace Dahomey.Cbor.Serialization
         public CborConverterRegistry ConverterRegistry { get; }
         public ObjectMappingRegistry ObjectMappingRegistry { get; }
         public ObjectMappingConventionRegistry ObjectMappingConventionRegistry { get; }
-        public DefaultDiscriminatorConvention DefaultDiscriminatorConvention { get; }
+        public DiscriminatorConventionRegistry DiscriminatorConventionRegistry { get; }
 
         public SerializationRegistry()
         {
             ConverterRegistry = new CborConverterRegistry(this);
             ObjectMappingRegistry = new ObjectMappingRegistry(this);
             ObjectMappingConventionRegistry = new ObjectMappingConventionRegistry();
-            DefaultDiscriminatorConvention = new DefaultDiscriminatorConvention();
+            DiscriminatorConventionRegistry = new DiscriminatorConventionRegistry(this);
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/SerializationRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/SerializationRegistry.cs
@@ -22,25 +22,5 @@ namespace Dahomey.Cbor.Serialization
             ObjectMappingConventionRegistry = new ObjectMappingConventionRegistry();
             DiscriminatorConventionRegistry = new DiscriminatorConventionRegistry(this);
         }
-
-        public void RegisterAssembly(Assembly assembly)
-        {
-            if (assembly == null)
-            {
-                throw new ArgumentNullException(nameof(assembly));
-            }
-
-            foreach (Type type in assembly.GetTypes()
-                .Where(t => t.IsClass && !t.IsAbstract && !t.IsDefined(typeof(CompilerGeneratedAttribute))))
-            {
-                RegisterType(type);
-            }
-        }
-
-        public void RegisterType(Type type)
-        {
-            // First call will force the registration.
-            ConverterRegistry.Lookup(type);
-        }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/SerializationRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/SerializationRegistry.cs
@@ -1,6 +1,10 @@
 ﻿using Dahomey.Cbor.Serialization.Conventions;
 using Dahomey.Cbor.Serialization.Converters;
 using Dahomey.Cbor.Serialization.Converters.Mappings;
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Dahomey.Cbor.Serialization
 {
@@ -17,6 +21,26 @@ namespace Dahomey.Cbor.Serialization
             ObjectMappingRegistry = new ObjectMappingRegistry(this);
             ObjectMappingConventionRegistry = new ObjectMappingConventionRegistry();
             DiscriminatorConventionRegistry = new DiscriminatorConventionRegistry(this);
+        }
+
+        public void RegisterAssembly(Assembly assembly)
+        {
+            if (assembly == null)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            foreach (Type type in assembly.GetTypes()
+                .Where(t => t.IsClass && !t.IsAbstract && !t.IsDefined(typeof(CompilerGeneratedAttribute))))
+            {
+                RegisterType(type);
+            }
+        }
+
+        public void RegisterType(Type type)
+        {
+            // First call will force the registration.
+            ConverterRegistry.Lookup(type);
         }
     }
 }


### PR DESCRIPTION
- Default discriminator is based on type full qualified name
- Attribute based discriminator is based on an attribute and support multiple types
- Discriminator is now handled as a MemberMapping/MemberConverter 
- Possibility to set an order an member mappings, including the discriminator