### PR TITLE
Extended collection and nullable support

### DIFF
--- a/src/Dahomey.Cbor.Tests/InterfaceCollectionTests.cs
+++ b/src/Dahomey.Cbor.Tests/InterfaceCollectionTests.cs
@@ -4,9 +4,29 @@ using System.Linq;
 
 namespace Dahomey.Cbor.Tests
 {
-
     public class InterfaceCollectionTests
     {
+        private class ObjectWithIList
+        {
+            public IList<int> Collection { get; set; }
+        }
+
+        [Fact]
+        public void IList()
+        {
+            const string hexBuffer = "A16A436F6C6C656374696F6E820C0D";
+            var obj = Helper.Read<ObjectWithIList>(hexBuffer);
+
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.Collection);
+            Assert.IsType<List<int>>(obj.Collection);
+            Assert.Equal(2, obj.Collection.Count);
+            Assert.Equal(12, obj.Collection.ElementAt(0));
+            Assert.Equal(13, obj.Collection.ElementAt(1));
+
+            Helper.TestWrite(obj, hexBuffer);
+        }
+
         private class ObjectWithICollection
         {
             public ICollection<int> Collection { get; set; }
@@ -16,12 +36,75 @@ namespace Dahomey.Cbor.Tests
         public void ICollection()
         {
             const string hexBuffer = "A16A436F6C6C656374696F6E820C0D";
-            ObjectWithICollection obj = Helper.Read<ObjectWithICollection>(hexBuffer);
+            var obj = Helper.Read<ObjectWithICollection>(hexBuffer);
 
             Assert.NotNull(obj);
             Assert.NotNull(obj.Collection);
             Assert.IsType<List<int>>(obj.Collection);
             Assert.Equal(2, obj.Collection.Count);
+            Assert.Equal(12, obj.Collection.ElementAt(0));
+            Assert.Equal(13, obj.Collection.ElementAt(1));
+
+            Helper.TestWrite(obj, hexBuffer);
+        }
+
+        private class ObjectWithIEnumerable
+        {
+            public IEnumerable<int> Collection { get; set; }
+        }
+
+        [Fact]
+        public void IEnumerable()
+        {
+            const string hexBuffer = "A16A436F6C6C656374696F6E820C0D";
+            var obj = Helper.Read<ObjectWithIEnumerable>(hexBuffer);
+
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.Collection);
+            Assert.IsType<List<int>>(obj.Collection);
+            Assert.Equal(2, obj.Collection.Count());
+            Assert.Equal(12, obj.Collection.ElementAt(0));
+            Assert.Equal(13, obj.Collection.ElementAt(1));
+
+            Helper.TestWrite(obj, hexBuffer);
+        }
+
+        private class ObjectWithIReadOnlyList
+        {
+            public IReadOnlyList<int> Collection { get; set; }
+        }
+
+        [Fact]
+        public void IReadOnlyList()
+        {
+            const string hexBuffer = "A16A436F6C6C656374696F6E820C0D";
+            var obj = Helper.Read<ObjectWithIReadOnlyList>(hexBuffer);
+
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.Collection);
+            Assert.IsType<List<int>>(obj.Collection);
+            Assert.Equal(2, obj.Collection.Count());
+            Assert.Equal(12, obj.Collection.ElementAt(0));
+            Assert.Equal(13, obj.Collection.ElementAt(1));
+
+            Helper.TestWrite(obj, hexBuffer);
+        }
+
+        private class ObjectWithIReadOnlyCollection
+        {
+            public IReadOnlyCollection<int> Collection { get; set; }
+        }
+
+        [Fact]
+        public void IReadOnlyCollection()
+        {
+            const string hexBuffer = "A16A436F6C6C656374696F6E820C0D";
+            var obj = Helper.Read<ObjectWithIReadOnlyCollection>(hexBuffer);
+
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.Collection);
+            Assert.IsType<List<int>>(obj.Collection);
+            Assert.Equal(2, obj.Collection.Count());
             Assert.Equal(12, obj.Collection.ElementAt(0));
             Assert.Equal(13, obj.Collection.ElementAt(1));
 

--- a/src/Dahomey.Cbor.Tests/NullableTests.cs
+++ b/src/Dahomey.Cbor.Tests/NullableTests.cs
@@ -1,0 +1,43 @@
+﻿using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    public class NullableTests
+    {
+        public class ObjectWithNullable
+        {
+            public int Id { get; set; }
+            public int? Nullable1 { get; set; }
+            public int? Nullable2 { get; set; }
+        }
+
+        [Fact]
+        public void TestRead()
+        {
+            CborOptions options = new CborOptions();
+
+            const string hexBuffer = "A36249640C694E756C6C61626C65310D694E756C6C61626C6532F6";
+            var obj = Helper.Read<ObjectWithNullable>(hexBuffer, options);
+
+            Assert.NotNull(obj);
+            Assert.Equal(12, obj.Id);
+            Assert.Equal(13, obj.Nullable1);
+            Assert.Null(obj.Nullable2);
+        }
+
+        [Fact]
+        public void TestWrite()
+        {
+            CborOptions options = new CborOptions();
+
+            const string hexBuffer = "A36249640C694E756C6C61626C65310D694E756C6C61626C6532F6";
+            var obj = new ObjectWithNullable
+            {
+                Id = 12,
+                Nullable1 = 13
+            };
+
+            Helper.TestWrite(obj, hexBuffer, null, options);
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Dahomey.Cbor.Serialization.Converters
 {
@@ -6,7 +7,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         CborConverterBase<TC>,
         ICborArrayReader<AbstractCollectionConverter<TC, TI>.ReaderContext>,
         ICborArrayWriter<AbstractCollectionConverter<TC, TI>.WriterContext>
-        where TC : ICollection<TI>
+        where TC : IEnumerable<TI>
     {
         public struct ReaderContext
         {
@@ -53,7 +54,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             WriterContext context = new WriterContext
             {
-                count = value.Count,
+                count = value.Count(),
                 enumerator = value.GetEnumerator(),
                 lengthMode = lengthMode != LengthMode.Default
                     ? lengthMode : writer.Options.ArrayLengthMode

--- a/src/Dahomey.Cbor/Serialization/Converters/InterfaceCollectionConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/InterfaceCollectionConverter.cs
@@ -4,8 +4,8 @@ namespace Dahomey.Cbor.Serialization.Converters
 {
     public class InterfaceCollectionConverter<TCollection, TInterface, TItem> :
         AbstractCollectionConverter<TInterface, TItem>
-        where TInterface : ICollection<TItem>
-        where TCollection : class, TInterface, new()
+        where TInterface : IEnumerable<TItem>
+        where TCollection : class, ICollection<TItem>, new()
     {
         public InterfaceCollectionConverter(SerializationRegistry registry)
             : base(registry)

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
@@ -186,7 +186,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
         private void ValidateDefaultValue()
         {
-            if ((DefaultValue == null && MemberType.IsValueType)
+            if ((DefaultValue == null && MemberType.IsValueType && Nullable.GetUnderlyingType(MemberType) == null)
                 || (DefaultValue != null && DefaultValue.GetType() != MemberType))
             {
                 throw new CborException($"Default value type mismatch");

--- a/src/Dahomey.Cbor/Serialization/Converters/NullableConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/NullableConverter.cs
@@ -1,0 +1,34 @@
+﻿namespace Dahomey.Cbor.Serialization.Converters
+{
+    public sealed class NullableConverter<T> : CborConverterBase<T?> where T : struct
+    {
+        private readonly ICborConverter<T> _cborConverter;
+
+        public NullableConverter(SerializationRegistry registry)
+        {
+            this._cborConverter = registry.ConverterRegistry.Lookup<T>();
+        }
+
+        public override T? Read(ref CborReader reader)
+        { 
+            if (reader.ReadNull())
+            {
+                return default;
+            }
+
+            return this._cborConverter.Read(ref reader);
+        }
+
+
+        public override void Write(ref CborWriter writer, T? value)
+        {
+            if (value is null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            this._cborConverter.Write(ref writer, value.Value);
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -383,7 +383,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             if (reader.Options.UnhandledNameMode == UnhandledNameMode.ThrowException)
             {
-                throw reader.BuildException("Unhandled name [{Encoding.ASCII.GetString(rawName)}] in class [{type.Name}] while deserializing.");
+                throw reader.BuildException($"Unhandled name [{Encoding.ASCII.GetString(rawName)}] in class [{type.Name}] while deserializing.");
             }
         }
     }

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/CollectionConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/CollectionConverterProvider.cs
@@ -74,6 +74,21 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
                         typeof(HashSet<>).MakeGenericType(itemType), type, itemType);
                 }
 
+                if (type.IsInterface
+                    && type.IsGenericType
+                    && (type.GetGenericTypeDefinition() == typeof(IList<>)
+                        || type.GetGenericTypeDefinition() == typeof(ICollection<>)
+                        || type.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+                        || type.GetGenericTypeDefinition() == typeof(IReadOnlyList<>)
+                        || type.GetGenericTypeDefinition() == typeof(IReadOnlyCollection<>)))
+                {
+                    Type itemType = type.GetGenericArguments()[0];
+                    return CreateGenericConverter(
+                        registry,
+                        typeof(InterfaceCollectionConverter<,,>),
+                        typeof(List<>).MakeGenericType(itemType), type, itemType);
+                }
+
                 if (type.GetInterfaces()
                     .Any(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(ICollection<>)))
                 {
@@ -81,17 +96,6 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
                     return CreateGenericConverter(
                         registry,
                         typeof(CollectionConverter<,>), type, itemType);
-                }
-
-                if (type.IsInterface 
-                    && type.IsGenericType
-                    && type.GetGenericTypeDefinition() == typeof(ICollection<>))
-                {
-                    Type itemType = type.GetGenericArguments()[0];
-                    return CreateGenericConverter(
-                        registry,
-                        typeof(InterfaceCollectionConverter<,,>),
-                        typeof(List<>).MakeGenericType(itemType), type, itemType);
                 }
             }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/ObjectConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/ObjectConverterProvider.cs
@@ -6,6 +6,11 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
     {
         public override ICborConverter GetConverter(Type type, SerializationRegistry registry)
         {
+            if (Nullable.GetUnderlyingType(type) != null)
+            {
+                return CreateGenericConverter(registry, typeof(NullableConverter<>), Nullable.GetUnderlyingType(type));
+            }
+
             if (type.IsClass || type.IsInterface)
             {
                 return CreateGenericConverter(registry, typeof(ObjectConverter<>), type);


### PR DESCRIPTION
This copies over some improvements from Dahomey.Json including support for nullables and IList, IEnumerable, IReadOnlyList, IReadOnlyCollection.
Contains also a small fix in ObjectConverter where exception text was not prefixed with $.

P.S.: I love your serializers 😃 