### PR TITLE
Added decimal type support to CborReader & CborWriter

### DIFF
--- a/src/Dahomey.Cbor.Tests/CborReaderTests.cs
+++ b/src/Dahomey.Cbor.Tests/CborReaderTests.cs
@@ -213,6 +213,25 @@ namespace Dahomey.Cbor.Tests
         }
 
         [Theory]
+        [InlineData("FC00013D2B9C2D125A0000000000080000", 3487324.89798234, null)]
+        public void ReadDecimal(string hexBuffer, decimal expectedValue, Type expectedExceptionType)
+        {
+            Helper.TestRead(nameof(CborReader.ReadDecimal), hexBuffer, expectedValue, expectedExceptionType);
+        }
+
+        [Theory]
+        [InlineData("FC0DED017037E8D1950000000000100000", "100.3459873459458453", null)]
+        [InlineData("FCFFFFFFFFFFFFFFFFFFFFFFFF80000000", "-79228162514264337593543950335", null)]
+        [InlineData("FCFFFFFFFFFFFFFFFFFFFFFFFF00000000", "79228162514264337593543950335", null)]
+        public void ReadDecimal2(string hexBuffer, string expectedValue, Type expectedExceptionType)
+        {
+            if (!decimal.TryParse(expectedValue, out decimal decimalValue)) throw new InvalidCastException("Specified string cannot be cast to a decimal value");
+
+            Helper.TestRead(nameof(CborReader.ReadDecimal), hexBuffer, decimalValue, expectedExceptionType);
+        }
+
+
+        [Theory]
         [InlineData("63666F6F", "foo", null)]
         [InlineData("7F6166616F616FFF", "foo", typeof(NotSupportedException))]
         [InlineData("F6", null, null)]

--- a/src/Dahomey.Cbor.Tests/CborWriterTests.cs
+++ b/src/Dahomey.Cbor.Tests/CborWriterTests.cs
@@ -209,6 +209,24 @@ namespace Dahomey.Cbor.Tests
         }
 
         [Theory]
+        [InlineData("FC00013D2B9C2D125A0000000000080000", 3487324.89798234, null)]
+        public void WriteDecimal(string hexBuffer, decimal value, Type expectedExceptionType)
+        {
+            Helper.TestWrite(nameof(CborWriter.WriteDecimal), value, hexBuffer, expectedExceptionType);
+        }
+
+        [Theory]
+        [InlineData("FC0DED017037E8D1950000000000100000", "100.3459873459458453", null)]
+        [InlineData("FCFFFFFFFFFFFFFFFFFFFFFFFF80000000", "-79228162514264337593543950335", null)]
+        [InlineData("FCFFFFFFFFFFFFFFFFFFFFFFFF00000000", "79228162514264337593543950335", null)]
+        public void WriteDecimal2(string hexBuffer, string value, Type expectedExceptionType)
+        {
+            if (!decimal.TryParse(value, out decimal decimalValue)) throw new InvalidCastException("Specified string cannot be cast to a decimal value");
+
+            Helper.TestWrite(nameof(CborWriter.WriteDecimal), decimalValue, hexBuffer, expectedExceptionType);
+        }
+
+        [Theory]
         [InlineData("63666F6F", "foo", null)]
         [InlineData("F6", null, null)]
         [InlineData("60", "", null)]

--- a/src/Dahomey.Cbor/Serialization/CborPrimitive.cs
+++ b/src/Dahomey.Cbor/Serialization/CborPrimitive.cs
@@ -10,6 +10,7 @@
         HalfFloat = 25,
         SingleFloat = 26,
         DoubleFloat = 27,
+        DecimalFloat = 28,
         Break = 31
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/DecimalConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/DecimalConverter.cs
@@ -1,0 +1,15 @@
+﻿namespace Dahomey.Cbor.Serialization.Converters
+{
+    public class DecimalConverter : CborConverterBase<decimal>
+    {
+        public override decimal Read(ref CborReader reader)
+        {
+            return reader.ReadDecimal();
+        }
+
+        public override void Write(ref CborWriter writer, decimal value)
+        {
+            writer.WriteDecimal(value);
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
@@ -19,6 +19,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
             [typeof(ulong)] = typeof(UInt64Converter),
             [typeof(float)] = typeof(SingleConverter),
             [typeof(double)] = typeof(DoubleConverter),
+            [typeof(decimal)] = typeof(DecimalConverter),
             [typeof(string)] = typeof(StringConverter),
             [typeof(DateTime)] = typeof(DateTimeConverter),
             [typeof(ReadOnlyMemory<byte>)] = typeof(ReadOnlyMemoryConverter),


### PR DESCRIPTION
Have added support for 128bit decimal types to the reader & writer.
It uses type 28 in the CborPrimitive enum which is suggested by the spec to use for 128bit floating point values.
Have tried to follow your coding style as closely as possible.
Note the little->big endian conversion is slightly odd due to the way decimal.GetBits returns the internal ulong value.
Could you take a look & merge if acceptable.