### PR TITLE
Add type forward for System.Half on NET 5.0

### DIFF
--- a/src/Dahomey.Cbor/Util/Half.cs
+++ b/src/Dahomey.Cbor/Util/Half.cs
@@ -8,7 +8,11 @@ using System.Globalization;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
-#if !NET5_0
+#if NET5_0
+
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Half))]
+
+#else
 
 namespace System
 {


### PR DESCRIPTION
When using an assembly that was compiled against .NET Standard 2.0 it expects to find the `System.Half` type in _Dahomey.Cbor_ assembly, but in .NET 5.0 it is part of dotnet runtime.

The type forward is to prevent `TypeNotFoundException` in such a case.