### PR TITLE
Implemented writing of empty arrays.

### DIFF
--- a/src/Dahomey.Cbor.Tests/CborWriterValueTests.cs
+++ b/src/Dahomey.Cbor.Tests/CborWriterValueTests.cs
@@ -142,5 +142,12 @@ namespace Dahomey.Cbor.Tests
             };
             Helper.TestWrite(array, hexBuffer);
         }
+
+        [Fact]
+        public void WriteEmptyArray()
+        {
+            CborArray array = new CborArray();
+            Helper.TestWrite(array);
+        }
     }
 }

--- a/src/Dahomey.Cbor.Tests/CborWriterValueTests.cs
+++ b/src/Dahomey.Cbor.Tests/CborWriterValueTests.cs
@@ -146,8 +146,11 @@ namespace Dahomey.Cbor.Tests
         [Fact]
         public void WriteEmptyArray()
         {
+            const string hexBuffer = "80";
+
             CborArray array = new CborArray();
-            Helper.TestWrite(array);
+            
+            Helper.TestWrite(array, hexBuffer);
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -191,8 +191,13 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         bool ICborArrayWriter<ArrayWriterContext>.WriteArrayItem(ref CborWriter writer, ref ArrayWriterContext context)
         {
-            Write(ref writer, context.array[context.index++]);
-            return context.index < context.array.Count;
+            if (context.array.Count > 0)
+            {
+                Write(ref writer, context.array[context.index++]);
+                return context.index < context.array.Count;
+            }
+
+            return false;
         }
 
         CborObject? ICborConverter<CborObject?>.Read(ref CborReader reader)


### PR DESCRIPTION
Does this makes sense or is there an alternative way of writing empty arrays.
It was possible in version 1.4.9.