### PR TITLE
Array and Map handling

### DIFF
--- a/src/Dahomey.Cbor/Serialization/CborWriter.cs
+++ b/src/Dahomey.Cbor/Serialization/CborWriter.cs
@@ -8,18 +8,6 @@ using System.Text;
 
 namespace Dahomey.Cbor.Serialization
 {
-    public interface ICborMapWriter<TC>
-    {
-        int GetMapSize(ref TC context);
-        bool WriteMapItem(ref CborWriter writer, ref TC context);
-    }
-
-    public interface ICborArrayWriter<TC>
-    {
-        int GetArraySize(ref TC context);
-        bool WriteArrayItem (ref CborWriter writer, ref TC context);
-    }
-
     public ref struct CborWriter
     {
         private const byte INDEFINITE_LENGTH = 31;
@@ -230,15 +218,6 @@ namespace Dahomey.Cbor.Serialization
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteMap<TC>(ICborMapWriter<TC> mapWriter, ref TC context)
-        {
-            int size = mapWriter.GetMapSize(ref context);
-            WriteBeginMap(size);
-            while (mapWriter.WriteMapItem(ref this, ref context));
-            WriteEndMap(size);
-        }
-
         public void WriteBeginArray(int size)
         {
             WriteSize(CborMajorType.Array, size);
@@ -250,15 +229,6 @@ namespace Dahomey.Cbor.Serialization
             {
                 WritePrimitive(CborPrimitive.Break);
             }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteArray<TC>(ICborArrayWriter<TC> arrayWriter, ref TC context)
-        {
-            int size = arrayWriter.GetArraySize(ref context);
-            WriteBeginArray(size);
-            while(arrayWriter.WriteArrayItem(ref this, ref context));
-            WriteEndArray(size);
         }
 
         private void WriteSize(CborMajorType majorType, int size)

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
@@ -5,8 +5,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 {
     public abstract class AbstractCollectionConverter<TC, TI> :
         CborConverterBase<TC>,
-        ICborArrayReader<AbstractCollectionConverter<TC, TI>.ReaderContext>,
-        ICborArrayWriter<AbstractCollectionConverter<TC, TI>.WriterContext>
+        ICborArrayReader<AbstractCollectionConverter<TC, TI>.ReaderContext>
         where TC : IEnumerable<TI>
     {
         public struct ReaderContext
@@ -62,7 +61,10 @@ namespace Dahomey.Cbor.Serialization.Converters
                     ? lengthMode : _options.ArrayLengthMode
             };
 
-            writer.WriteArray(this, ref context);
+            int size = GetArraySize(ref context);
+            writer.WriteBeginArray(size);
+            while (WriteArrayItem(ref writer, ref context)) ;
+            writer.WriteEndArray(size);
         }
 
         public void ReadBeginArray(int size, ref ReaderContext context)

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
@@ -4,8 +4,7 @@ using System.Linq;
 namespace Dahomey.Cbor.Serialization.Converters
 {
     public abstract class AbstractCollectionConverter<TC, TI> :
-        CborConverterBase<TC>,
-        ICborArrayReader<AbstractCollectionConverter<TC, TI>.ReaderContext>
+        CborConverterBase<TC>
         where TC : IEnumerable<TI>
     {
         public struct ReaderContext
@@ -40,7 +39,20 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
 
             ReaderContext context = new ReaderContext();
-            reader.ReadArray(this, ref context);
+
+            reader.ReadBeginArray();
+
+            int size = reader.ReadSize();
+
+            ReadBeginArray(size, ref context);
+
+            while (size > 0 || size < 0 && reader.GetCurrentDataItemType() != CborDataItemType.Break)
+            {
+                ReadArrayItem(ref reader, ref context);
+                size--;
+            }
+
+            reader.ReadEndArray();
 
             return InstantiateCollection(context.collection);
         }

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -4,8 +4,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 {
     public abstract class AbstractDictionaryConverter<TC, TK, TV> :
         CborConverterBase<TC>, 
-        ICborMapReader<AbstractDictionaryConverter<TC, TK, TV>.ReaderContext>,
-        ICborMapWriter<AbstractDictionaryConverter<TC, TK, TV>.WriterContext>
+        ICborMapReader<AbstractDictionaryConverter<TC, TK, TV>.ReaderContext>
         where TC : notnull, IDictionary<TK, TV>
         where TK : notnull
     {
@@ -63,7 +62,10 @@ namespace Dahomey.Cbor.Serialization.Converters
                     ? lengthMode : _options.MapLengthMode
             };
 
-            writer.WriteMap(this, ref context);
+            int size = GetMapSize(ref context);
+            writer.WriteBeginMap(size);
+            while (WriteMapItem(ref writer, ref context)) ;
+            writer.WriteEndMap(size);
         }
 
         public void ReadBeginMap(int size, ref ReaderContext context)

--- a/src/Dahomey.Cbor/Serialization/Converters/ArrayConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ArrayConverter.cs
@@ -4,8 +4,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 {
     public class ArrayConverter<TI> :
         CborConverterBase<TI[]?>, 
-        ICborArrayReader<ArrayConverter<TI>.ReaderContext>,
-        ICborArrayWriter<ArrayConverter<TI>.WriterContext>
+        ICborArrayReader<ArrayConverter<TI>.ReaderContext>
     {
         public struct ReaderContext
         {
@@ -65,7 +64,10 @@ namespace Dahomey.Cbor.Serialization.Converters
                     ? lengthMode : _options.ArrayLengthMode
             };
 
-            writer.WriteArray(this, ref context);
+            int size = GetArraySize(ref context);
+            writer.WriteBeginArray(size);
+            while (WriteArrayItem(ref writer, ref context)) ;
+            writer.WriteEndArray(size);
         }
 
         public void ReadBeginArray(int size, ref ReaderContext context)

--- a/src/Dahomey.Cbor/Serialization/Converters/ArrayConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ArrayConverter.cs
@@ -3,8 +3,7 @@
 namespace Dahomey.Cbor.Serialization.Converters
 {
     public class ArrayConverter<TI> :
-        CborConverterBase<TI[]?>, 
-        ICborArrayReader<ArrayConverter<TI>.ReaderContext>
+        CborConverterBase<TI[]?>
     {
         public struct ReaderContext
         {
@@ -37,7 +36,20 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
 
             ReaderContext context = new ReaderContext();
-            reader.ReadArray(this, ref context);
+
+            reader.ReadBeginArray();
+
+            int size = reader.ReadSize();
+
+            ReadBeginArray(size, ref context);
+
+            while (size > 0 || size < 0 && reader.GetCurrentDataItemType() != CborDataItemType.Break)
+            {
+                ReadArrayItem(ref reader, ref context);
+                size--;
+            }
+
+            reader.ReadEndArray();
 
             if (context.array != null)
             {

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -35,7 +35,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             public Dictionary<RawString, object>? creatorValues;
             public Dictionary<RawString, object>? regularValues;
             public HashSet<IMemberConverter>? readMembers;
-            public int RemainingItemCount;
+            public int remainingItemCount;
         }
 
         public struct MapWriterContext
@@ -138,11 +138,9 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             reader.ReadBeginMap();
 
-            context.RemainingItemCount = reader.ReadSize();
+            context.remainingItemCount = reader.ReadSize();
 
-            ReadBeginMap(ref context);
-
-            while (MoveNextMapItem(ref reader, ref context.RemainingItemCount))
+            while (MoveNextMapItem(ref reader, ref context.remainingItemCount))
             {
                 ReadMapItem(ref reader, ref context);
             }
@@ -277,10 +275,6 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
         }
 
-        public void ReadBeginMap(ref MapReaderContext context)
-        {
-        }
-
         public void ReadMapItem(ref CborReader reader, ref MapReaderContext context)
         {
             if (context.obj == null || context.converter == null)
@@ -290,9 +284,9 @@ namespace Dahomey.Cbor.Serialization.Converters
                     if (_discriminatorConvention != null)
                     {
                         CborReaderBookmark bookmark = reader.GetBookmark();
-                        var previousremainingItemCount = context.RemainingItemCount;
+                        var previousremainingItemCount = context.remainingItemCount;
 
-                        if (FindItem(ref reader, _discriminatorConvention.MemberName, ref context.RemainingItemCount))
+                        if (FindItem(ref reader, _discriminatorConvention.MemberName, ref context.remainingItemCount))
                         {
                             // discriminator value
                             Type actualType = _discriminatorConvention.ReadDiscriminator(ref reader);
@@ -303,7 +297,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                             context.converter = this;
                         }
 
-                        context.RemainingItemCount = previousremainingItemCount;
+                        context.remainingItemCount = previousremainingItemCount;
                         reader.ReturnToBookmark(bookmark);
                     }
                     else

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -27,8 +27,7 @@ namespace Dahomey.Cbor.Serialization.Converters
     public class ObjectConverter<T> :
         CborConverterBase<T>,
         IObjectConverter<T>,
-        ICborMapReader<ObjectConverter<T>.MapReaderContext>,
-        ICborMapWriter<ObjectConverter<T>.MapWriterContext>
+        ICborMapReader<ObjectConverter<T>.MapReaderContext>
     {
         public struct MapReaderContext
         {
@@ -256,7 +255,10 @@ namespace Dahomey.Cbor.Serialization.Converters
                 context.objectConverter = this;
             }
 
-            writer.WriteMap(this, ref context);
+            int size = GetMapSize(ref context);
+            writer.WriteBeginMap(size);
+            while (WriteMapItem(ref writer, ref context)) ;
+            writer.WriteEndMap(size);
 
             if (_objectMapping.OnSerializedMethod != null)
             {


### PR DESCRIPTION
Moved the Array and Map handling out of CborReader and CborWriter.

This reduces the complexity of the reader and writer.
Also it reduces the coupling between converter and reader/writer.
Together that should help with maintainability of this wonderful library.

The converters will become simpler too (after a refactoring).

I hope to get feedback on this change, even if the change is not accepted.