### PR TITLE
Streamline Map handling in CborReader

### DIFF
--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -484,6 +484,17 @@ namespace Dahomey.Cbor.Serialization
             _state = CborReaderState.Start;
         }
 
+        public bool MoveNextMapItem(ref int remainingItemCount)
+        {
+            if (remainingItemCount == 0 || remainingItemCount < 0 && GetCurrentDataItemType() == CborDataItemType.Break)
+            {
+                return false;
+            }
+
+            remainingItemCount--;
+            return true;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ReadArray<TC>(ICborArrayReader<TC> arrayReader, ref TC context)
         {

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -484,17 +484,6 @@ namespace Dahomey.Cbor.Serialization
             _state = CborReaderState.Start;
         }
 
-        public bool MoveNextMapItem(ref int remainingItemCount)
-        {
-            if (remainingItemCount == 0 || remainingItemCount < 0 && GetCurrentDataItemType() == CborDataItemType.Break)
-            {
-                return false;
-            }
-
-            remainingItemCount--;
-            return true;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ReadArray<TC>(ICborArrayReader<TC> arrayReader, ref TC context)
         {

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
@@ -365,7 +365,6 @@ namespace Dahomey.Cbor.Serialization.Converters
     {
         private readonly IDiscriminatorConvention _discriminatorConvention;
         private readonly CborDiscriminatorPolicy _discriminatorPolicy;
-        private readonly ReadOnlyMemory<byte> _memberName;
 
         public DiscriminatorMemberConverter(
             IDiscriminatorConvention discriminatorConvention, 
@@ -373,14 +372,9 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             _discriminatorConvention = discriminatorConvention;
             _discriminatorPolicy = discriminatorPolicy;
-
-            if (discriminatorConvention != null)
-            {
-                _memberName = discriminatorConvention.MemberName.ToArray();
-            }
         }
 
-        public ReadOnlySpan<byte> MemberName => _memberName.Span;
+        public ReadOnlySpan<byte> MemberName => _discriminatorConvention.MemberName;
         public bool IgnoreIfDefault => false;
         public RequirementPolicy RequirementPolicy => RequirementPolicy.Never;
 

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -37,7 +37,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             public Dictionary<RawString, object>? creatorValues;
             public Dictionary<RawString, object>? regularValues;
             public HashSet<IMemberConverter>? readMembers;
-            public int remainingItemCount;
+            public int itemCount;
         }
 
         public struct MapWriterContext
@@ -267,7 +267,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public void ReadBeginMap(int size, ref MapReaderContext context)
         {
-            context.remainingItemCount = size;
+            context.itemCount = size;
         }
 
         public void ReadMapItem(ref CborReader reader, ref MapReaderContext context)
@@ -278,7 +278,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                 {
                     if (_discriminatorConvention != null)
                     {
-                        Type? actualType = ReadDiscriminator(ref reader, _discriminatorConvention, context.remainingItemCount);
+                        Type? actualType = ReadDiscriminator(ref reader, _discriminatorConvention, context.itemCount);
 
                         if (actualType != null)
                         {
@@ -336,8 +336,6 @@ namespace Dahomey.Cbor.Serialization.Converters
                     context.regularValues!.Add(new RawString(memberName), value);
                 }
             }
-
-            context.remainingItemCount--;
         }
 
         public void ReadValueForStruct(ref CborReader reader, ref T instance, ReadOnlySpan<byte> memberName, HashSet<IMemberConverter> readMembers)

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -272,45 +272,25 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public void ReadMapItem(ref CborReader reader, ref MapReaderContext context)
         {
-            if (context.obj == null || context.converter == null)
+            if (context.converter == null)
             {
-                if (context.converter == null)
+                if (_discriminatorConvention != null)
                 {
-                    if (_discriminatorConvention != null)
-                    {
-                        Type? actualType = ReadDiscriminator(ref reader, _discriminatorConvention, context.itemCount);
+                    Type? actualType = ReadDiscriminator(ref reader, _discriminatorConvention, context.itemCount);
 
-                        if (actualType != null)
-                        {
-                            context.converter = (IObjectConverter<T>)_registry.ConverterRegistry.Lookup(actualType);
-                        }
-                        else
-                        {
-                            context.converter = this;
-                        }
+                    if (actualType != null)
+                    {
+                        context.converter = (IObjectConverter<T>)_registry.ConverterRegistry.Lookup(actualType);
                     }
                     else
                     {
                         context.converter = this;
                     }
                 }
-
-                if (context.creatorValues == null)
+                else
                 {
-                    if (!_isStruct && context.obj == null)
-                    {
-                        context.obj = context.converter.CreateInstance();
-                    }
-
-                    if (_objectMapping.OnDeserializingMethod != null)
-                    {
-                        ((Action<T>)_objectMapping.OnDeserializingMethod)(context.obj);
-                    }
+                    context.converter = this;
                 }
-            }
-            else if (context.converter == null)
-            {
-                context.converter = this;
             }
 
             ReadOnlySpan<byte> memberName = reader.ReadRawString();
@@ -322,6 +302,16 @@ namespace Dahomey.Cbor.Serialization.Converters
                 }
                 else
                 {
+                    if (context.obj == null)
+                    {
+                        context.obj = context.converter.CreateInstance();
+
+                        if (_objectMapping.OnDeserializingMethod != null)
+                        {
+                            ((Action<T>)_objectMapping.OnDeserializingMethod)(context.obj);
+                        }
+                    }
+
                     context.converter.ReadValue(ref reader, context.obj!, memberName, context.readMembers!);
                 }
             }

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -272,6 +272,8 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public void ReadMapItem(ref CborReader reader, ref MapReaderContext context)
         {
+            context.remainingItemCount--;
+
             if (context.obj == null || context.converter == null)
             {
                 if (context.converter == null)
@@ -372,9 +374,8 @@ namespace Dahomey.Cbor.Serialization.Converters
                 }
 
                 reader.SkipDataItem();
-                remainingItemCount--;
             }
-            while (remainingItemCount > 0 || remainingItemCount < 0 && reader.GetCurrentDataItemType() != CborDataItemType.Break);
+            while (reader.MoveNextMapItem(ref remainingItemCount));
 
             return false;
         }

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -278,7 +278,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                 {
                     if (_discriminatorConvention != null)
                     {
-                        Type? actualType = TryReadType(ref reader, _discriminatorConvention, context.remainingItemCount);
+                        Type? actualType = ReadDiscriminator(ref reader, _discriminatorConvention, context.remainingItemCount);
 
                         if (actualType != null)
                         {
@@ -357,7 +357,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
         }
 
-        private static Type? TryReadType(ref CborReader reader, IDiscriminatorConvention discriminatorConvention, int size)
+        private static Type? ReadDiscriminator(ref CborReader reader, IDiscriminatorConvention discriminatorConvention, int size)
         {
             Type? actualType = null;
 


### PR DESCRIPTION
Alternative approach to #72 (can be closed)

**Rationale**
From perspective of `CborReader` there shall be no difference between Array and Map.
So the special handling of map size should be removed.

This time only reading of map in `CborReader` is changed:
- `ReadMap()` now looks exactly the same as `ReadArray()`
- removed `remainingItemCount` as this belongs to `ObjectConverter` only

Hope this is what you had in mind.