### PR TITLE
Never invoke MapCreator for abstract types

### DIFF
--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
@@ -101,25 +101,28 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
             objectMapping.AddMemberMappings(memberMappings);
 
-            ConstructorInfo[] constructorInfos = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
-
-            ConstructorInfo? constructorInfo = constructorInfos
-                .FirstOrDefault(c => c.IsDefined(typeof(CborConstructorAttribute)));
-
-            if (constructorInfo != null)
+            if (!type.IsAbstract)
             {
-                CborConstructorAttribute? constructorAttribute = constructorInfo.GetCustomAttribute<CborConstructorAttribute>();
-                CreatorMapping creatorMapping = objectMapping.MapCreator(constructorInfo);
-                if (constructorAttribute != null && constructorAttribute.MemberNames != null)
+                ConstructorInfo[] constructorInfos = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+
+                ConstructorInfo? constructorInfo = constructorInfos
+                    .FirstOrDefault(c => c.IsDefined(typeof(CborConstructorAttribute)));
+
+                if (constructorInfo != null)
                 {
-                    creatorMapping.SetMemberNames(constructorAttribute.MemberNames);
+                    CborConstructorAttribute? constructorAttribute = constructorInfo.GetCustomAttribute<CborConstructorAttribute>();
+                    CreatorMapping creatorMapping = objectMapping.MapCreator(constructorInfo);
+                    if (constructorAttribute != null && constructorAttribute.MemberNames != null)
+                    {
+                        creatorMapping.SetMemberNames(constructorAttribute.MemberNames);
+                    }
                 }
-            }
-            // if no default constructor, pick up first one
-            else if (constructorInfos.Length > 0 && !constructorInfos.Any(c => c.GetParameters().Length == 0))
-            {
-                constructorInfo = constructorInfos[0];
-                objectMapping.MapCreator(constructorInfo);
+                // if no default constructor, pick up first one
+                else if (constructorInfos.Length > 0 && !constructorInfos.Any(c => c.GetParameters().Length == 0))
+                {
+                    constructorInfo = constructorInfos[0];
+                    objectMapping.MapCreator(constructorInfo);
+                }
             }
 
             MethodInfo? methodInfo = type.GetMethods()


### PR DESCRIPTION
This disables constructor mapping for abstract types as it fails if an abstract base class has multiple constructors.