### PR TITLE
Add ReadOnlySequence<byte> buffer support to CborReader

### DIFF
--- a/src/Dahomey.Cbor.Tests/CallbackTests.cs
+++ b/src/Dahomey.Cbor.Tests/CallbackTests.cs
@@ -1,4 +1,6 @@
 ﻿using Dahomey.Cbor.Attributes;
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using Xunit;
 
@@ -6,7 +8,7 @@ namespace Dahomey.Cbor.Tests
 {
     public class CallbackTests
     {
-        private class ObjectWithCallbacks
+        private class ObjectWithCallbacks : IEquatable<ObjectWithCallbacks>
         {
             public int Id { get; set; }
 
@@ -32,7 +34,7 @@ namespace Dahomey.Cbor.Tests
                 OnDeserializedCalled = true;
             }
 
-            [OnDeserializing]
+            [OnSerializing]
             public void OnSerializing()
             {
                 Assert.False(OnSerializingCalled);
@@ -40,12 +42,21 @@ namespace Dahomey.Cbor.Tests
                 OnSerializingCalled = true;
             }
 
-            [OnDeserialized]
+            [OnSerialized]
             public void OnSerialized()
             {
                 Assert.True(OnSerializingCalled);
                 Assert.False(OnSerializedCalled);
                 OnSerializedCalled = true;
+            }
+
+            public bool Equals([AllowNull] ObjectWithCallbacks other)
+            {
+                return Id == other.Id &&
+                    OnDeserializingCalled == other.OnDeserializingCalled &&
+                    OnDeserializedCalled == other.OnDeserializedCalled &&
+                    OnSerializingCalled == other.OnSerializingCalled &&
+                    OnSerializedCalled == other.OnSerializedCalled;
             }
         }
 

--- a/src/Dahomey.Cbor.Tests/Dahomey.Cbor.Tests.csproj
+++ b/src/Dahomey.Cbor.Tests/Dahomey.Cbor.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.8.65" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Dahomey.Cbor.Tests/Helper.cs
+++ b/src/Dahomey.Cbor.Tests/Helper.cs
@@ -185,6 +185,11 @@ namespace Dahomey.Cbor.Tests
                 Assert.Equal(expected, ((ReadOnlySequence<byte>)(object)sequenceValue).ToArray());
                 Assert.Equal(expected, ((ReadOnlySequence<byte>)(object)fragmentizedSequenceValue).ToArray());
             }
+            else if (value is Half half && Half.IsNaN(half))
+            {
+                Assert.True(Half.IsNaN((Half)(object)sequenceValue));
+                Assert.True(Half.IsNaN((Half)(object)fragmentizedSequenceValue));
+            }
             else
             {
                 Assert.Equal(value, sequenceValue);

--- a/src/Dahomey.Cbor.Tests/Helper.cs
+++ b/src/Dahomey.Cbor.Tests/Helper.cs
@@ -1,14 +1,15 @@
 ﻿using Dahomey.Cbor.Serialization;
 using Dahomey.Cbor.Serialization.Converters;
 using Dahomey.Cbor.Util;
-using Xunit;
+using Nerdbank.Streams;
+using Newtonsoft.Json;
 using System;
+using System.Buffers;
 using System.Collections;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Buffers;
-using Nerdbank.Streams;
+using Xunit;
 
 namespace Dahomey.Cbor.Tests
 {
@@ -35,10 +36,20 @@ namespace Dahomey.Cbor.Tests
                 Assert.Equal(expected, ((ReadOnlySequence<byte>)(object)sequenceValue).ToArray());
                 Assert.Equal(expected, ((ReadOnlySequence<byte>)(object)fragmentizedSequenceValue).ToArray());
             }
-            else
+            else if (value is ICollection collection)
+            {
+                Assert.Equal(collection, (ICollection)sequenceValue);
+                Assert.Equal(collection, (ICollection)fragmentizedSequenceValue);
+            }
+            else if (value is IEquatable<T> equatable)
             {
                 Assert.Equal(value, sequenceValue);
                 Assert.Equal(value, fragmentizedSequenceValue);
+            }
+            else
+            {
+                Assert.Equal(JsonConvert.SerializeObject(value), JsonConvert.SerializeObject(sequenceValue));
+                Assert.Equal(JsonConvert.SerializeObject(value), JsonConvert.SerializeObject(fragmentizedSequenceValue));
             }
 
             return value;

--- a/src/Dahomey.Cbor/Dahomey.Cbor.csproj
+++ b/src/Dahomey.Cbor/Dahomey.Cbor.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+	<PackageReference Include="Nerdbank.Streams" Version="2.9.87-alpha" />
     <PackageReference Include="Nullable" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -33,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-      <PackageReference Include="System.IO.Pipelines" Version="6.0.1" />
+      <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -334,6 +334,8 @@ namespace Dahomey.Cbor.Serialization
         public ReadOnlySequence<byte> ReadByteStringSequence()
         {
             SkipSemanticTag();
+            Expect(CborMajorType.ByteString);
+            return ReadSizeAndSequence();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -772,6 +774,8 @@ namespace Dahomey.Cbor.Serialization
         private CborMajorType GetCurrentMajorType()
         {
             ExpectLength(1);
+            byte headerByte = GetBytes(1)[0];
+            CborMajorType majorType = (CborMajorType)((headerByte >> 5) & 0x07);
 
             if (majorType > CborMajorType.Max)
             {
@@ -806,7 +810,7 @@ namespace Dahomey.Cbor.Serialization
 
                 case CborMajorType.ByteString:
                 case CborMajorType.TextString:
-                    ReadSizeAndBytes();
+                    SkipSizeAndBytes();
                     break;
 
                 case CborMajorType.Array:

--- a/src/Dahomey.Cbor/Util/ReadOnlySequenceExtensions.cs
+++ b/src/Dahomey.Cbor/Util/ReadOnlySequenceExtensions.cs
@@ -7,6 +7,7 @@ namespace Dahomey.Cbor.Util
 {
     public static class ReadOnlySequenceExtensions
     {
+        [Obsolete]
         public static ReadOnlySpan<T> GetSpan<T>(this ReadOnlySequence<T> sequence)
         {
             if (sequence.IsSingleSegment)


### PR DESCRIPTION
This fixes #99.

The implementation should be fairly straight forward. Let me know if there are any questions and feel free to make any suggestions, comments and/or edits.

Note when sequence is used as buffer, then ReadByteString() may allocate a buffer if the current span within the sequence does not contain the entire byte string. This is the reason why the ReadByteStringSequence() is added.

Using this overload is much more memory efficient than the current use of `ReadOnlySequenceExtensions.GetSpan()` which allocates a large array to include the entire cbor buffer if the sequence has more than one segment (which it basically almost always has).