### PR TITLE
Added default name convention type at CborSettings

### DIFF
--- a/src/Dahomey.Cbor.Tests/NamingConventionTests.cs
+++ b/src/Dahomey.Cbor.Tests/NamingConventionTests.cs
@@ -34,5 +34,33 @@ namespace Dahomey.Cbor.Tests
             string actualName = new SnakeCaseNamingConvention().GetPropertyName(srcName);
             Assert.Equal(expectedName, actualName);
         }
+
+        [Theory]
+        [InlineData("FooBar", "foobar")]
+        [InlineData("fooBar", "foobar")]
+        [InlineData("FooBAR", "foobar")]
+        [InlineData("FooBARFoo", "foobarfoo")]
+        [InlineData("Foo", "foo")]
+        [InlineData("foo", "foo")]
+        [InlineData("", "")]
+        public void LowerCase(string srcName, string expectedName)
+        {
+            string actualName = new LowerCaseNamingConvention().GetPropertyName(srcName);
+            Assert.Equal(expectedName, actualName);
+        }
+
+        [Theory]
+        [InlineData("FooBar", "FOOBAR")]
+        [InlineData("fooBar", "FOOBAR")]
+        [InlineData("FooBAR", "FOOBAR")]
+        [InlineData("FooBARFoo", "FOOBARFOO")]
+        [InlineData("Foo", "FOO")]
+        [InlineData("foo", "FOO")]
+        [InlineData("", "")]
+        public void UpperCase(string srcName, string expectedName)
+        {
+            string actualName = new UpperCaseNamingConvention().GetPropertyName(srcName);
+            Assert.Equal(expectedName, actualName);
+        }
     }
 }

--- a/src/Dahomey.Cbor.Tests/ObjectMappingTests.cs
+++ b/src/Dahomey.Cbor.Tests/ObjectMappingTests.cs
@@ -263,5 +263,98 @@ namespace Dahomey.Cbor.Tests
             const string hexBuffer2 = "A1644E616D6563666F6F";
             Helper.TestWrite(obj2, hexBuffer2, null, options);
         }
+
+        public class OptInObject3
+        {
+
+            [CborProperty]
+            public int OptInId { get; set; }
+
+            [CborProperty]
+            public string OptInName { get; set; }
+        }
+
+        [Fact]
+        public void WriteOptInWithDefaultNamingConvention()
+        {
+            CborOptions options = new CborOptions()
+            {
+                DefaultNamingConventionType = typeof(LowerCaseNamingConvention)
+            };
+
+            options.Registry.ObjectMappingConventionRegistry.RegisterProvider(
+                new OptInObjectMappingConventionProvider()
+            );
+
+            var obj3 = new OptInObject3 { OptInId = 12, OptInName = "foo" };
+            const string hexBuffer1 = "A2676F7074696E69640C696F7074696E6E616D6563666F6F";
+            Helper.TestWrite(obj3, hexBuffer1, null, options);
+        }
+
+        [Fact]
+        public void ReadOptInWithDefaultNamingConvention()
+        {
+            CborOptions options = new CborOptions()
+            {
+                DefaultNamingConventionType = typeof(LowerCaseNamingConvention)
+            };
+
+            options.Registry.ObjectMappingConventionRegistry.RegisterProvider(
+                new OptInObjectMappingConventionProvider()
+            );
+
+            var expectedObj = new OptInObject3 { OptInId = 12, OptInName = "foo" };
+            var actualObj = Helper.Read<OptInObject3>("A2676F7074696E69640C696F7074696E6E616D6563666F6F", options);
+
+            Assert.Equal(expectedObj.OptInId, actualObj.OptInId);
+            Assert.Equal(expectedObj.OptInName, actualObj.OptInName);
+        }
+
+        [CborNamingConvention(typeof(SnakeCaseNamingConvention))]
+        public class OptInObject4
+        {
+
+            [CborProperty]
+            public int OptInId { get; set; }
+
+            [CborProperty]
+            public string OptInName { get; set; }
+        }
+
+        [Fact]
+        public void WriteOptInWithDefaultNamingConventionAndCborNamingAttribute()
+        {
+            CborOptions options = new CborOptions()
+            {
+                DefaultNamingConventionType = typeof(LowerCaseNamingConvention)
+            };
+
+            options.Registry.ObjectMappingConventionRegistry.RegisterProvider(
+                new OptInObjectMappingConventionProvider()
+            );
+
+            var obj4 = new OptInObject4 { OptInId = 12, OptInName = "foo" };
+            const string hexBuffer1 = "A2696F70745F696E5F69640C6B6F70745F696E5F6E616D6563666F6F";
+            Helper.TestWrite(obj4, hexBuffer1, null, options);
+        }
+
+        [Fact]
+        public void ReadOptInWithDefaultNamingConventionAndCborNamingAttribute()
+        {
+            CborOptions options = new CborOptions()
+            {
+                DefaultNamingConventionType = typeof(LowerCaseNamingConvention)
+            };
+
+            options.Registry.ObjectMappingConventionRegistry.RegisterProvider(
+                new OptInObjectMappingConventionProvider()
+            );
+
+            var expectedObj = new OptInObject4 { OptInId = 12, OptInName = "foo" };
+            var actualObj = Helper.Read<OptInObject4>("A2696F70745F696E5F69640C6B6F70745F696E5F6E616D6563666F6F", options);
+
+            Assert.Equal(expectedObj.OptInId, actualObj.OptInId);
+            Assert.Equal(expectedObj.OptInName, actualObj.OptInName);
+        }
     }
 }

--- a/src/Dahomey.Cbor/CborOptions.cs
+++ b/src/Dahomey.Cbor/CborOptions.cs
@@ -59,6 +59,15 @@ namespace Dahomey.Cbor
         /// Default value is 39 (see: https://github.com/lucas-clemente/cbor-specs/blob/master/id.md)
         public ulong DiscriminatorSemanticTag { get; set; } = 39;
 
+        /// <summary>
+        /// Default naming convention type
+        /// </summary>
+        /// <remarks>
+        /// If type is marked 'CborNamingConventionAttribute' then will use naming convention from attribute
+        /// This option is usefult when uses codegeneration. Just set up this options same on each side
+        /// </remarks>
+        public Type? DefaultNamingConventionType { get; set; }
+
     public CborOptions()
         {
             Registry = new SerializationRegistry(this);

--- a/src/Dahomey.Cbor/Serialization/Conventions/LowerCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/LowerCaseNamingConvention.cs
@@ -1,0 +1,19 @@
+﻿namespace Dahomey.Cbor.Serialization.Conventions
+{
+    /// <summary>
+    /// Convert all names to lower case when serializing
+    /// </summary>
+    /// <remarks> VariableName1 -> variablename1</remarks>
+    public sealed class LowerCaseNamingConvention : INamingConvention
+    {
+        /// <summary>
+        /// Get property name according convention
+        /// </summary>
+        /// <param name="name"> Property raw-name</param>
+        /// <returns>Property name according convention</returns>
+        public string GetPropertyName(string name)
+        {
+            return name.ToLower();
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Conventions/UpperCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/UpperCaseNamingConvention.cs
@@ -1,0 +1,19 @@
+﻿namespace Dahomey.Cbor.Serialization.Conventions
+{
+    /// <summary>
+    /// Convert all names to upper case when serializing
+    /// </summary>
+    /// <remarks> VariableName1 -> VARIABLENAME1</remarks>
+    public sealed class UpperCaseNamingConvention : INamingConvention
+    {
+        /// <summary>
+        /// Get property name according convention
+        /// </summary>
+        /// <param name="name"> Property raw-name</param>
+        /// <returns>Property name according convention</returns>
+        public string GetPropertyName(string name)
+        {
+            return name.ToUpper();
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
@@ -27,7 +27,9 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                 objectMapping.SetDiscriminatorPolicy(discriminatorAttribute.Policy);
             }
 
-            Type? namingConventionType = type.GetCustomAttribute<CborNamingConventionAttribute>()?.NamingConventionType;
+
+            Type? namingConventionType = type.GetCustomAttribute<CborNamingConventionAttribute>()?.NamingConventionType ?? registry.Options.DefaultNamingConventionType;
+
             if (namingConventionType != null)
             {
                 INamingConvention? namingConvention = (INamingConvention?)Activator.CreateInstance(namingConventionType);
@@ -38,7 +40,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                 }
 
                 objectMapping.SetNamingConvention(namingConvention);
-            }
+            } 
 
             CborLengthModeAttribute? lengthModeAttribute = type.GetCustomAttribute<CborLengthModeAttribute>();
             if (lengthModeAttribute != null)

--- a/src/Dahomey.Cbor/Serialization/SerializationRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/SerializationRegistry.cs
@@ -10,6 +10,7 @@ namespace Dahomey.Cbor.Serialization
 {
     public class SerializationRegistry
     {
+        public CborOptions Options { get; }
         public CborConverterRegistry ConverterRegistry { get; }
         public ObjectMappingRegistry ObjectMappingRegistry { get; }
         public ObjectMappingConventionRegistry ObjectMappingConventionRegistry { get; }
@@ -17,6 +18,7 @@ namespace Dahomey.Cbor.Serialization
 
         public SerializationRegistry(CborOptions options)
         {
+            Options = options;
             ConverterRegistry = new CborConverterRegistry(options);
             ObjectMappingRegistry = new ObjectMappingRegistry(this, options);
             ObjectMappingConventionRegistry = new ObjectMappingConventionRegistry();


### PR DESCRIPTION
Added default name convention type at `CborSettings`
Added two naming conventions (`LowerCaseNamingConvention`, `UpperCaseNamingConvention`) and tests for them 
Added object mapping tests for situations with default naming convention (and `CborNamingConventionAttribute`)