### PR TITLE
Discriminators registered on implemented interfaces

### DIFF
--- a/src/Dahomey.Cbor.Tests/DiscriminatorTests.cs
+++ b/src/Dahomey.Cbor.Tests/DiscriminatorTests.cs
@@ -21,13 +21,30 @@ namespace Dahomey.Cbor.Tests
             CborOptions options = new CborOptions();
             options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(NameObject));
 
-            const string hexBuffer = "A16A426173654F626A656374A3625F746A4E616D654F626A656374644E616D6563666F6F62496401";
+            const string hexBuffer = "A36B49426173654F626A656374A3625F746A4E616D654F626A656374644E616D6563626172624964026A426173654F626A656374A3625F746A4E616D654F626A656374644E616D6563666F6F624964016A4E616D654F626A656374F6";
             BaseObjectHolder obj = Helper.Read<BaseObjectHolder>(hexBuffer, options);
 
             Assert.NotNull(obj);
             Assert.IsType<NameObject>(obj.BaseObject);
             Assert.Equal("foo", ((NameObject)obj.BaseObject).Name);
             Assert.Equal(1, obj.BaseObject.Id);
+            Assert.Equal("bar", ((NameObject)obj.IBaseObject).Name);
+            Assert.Equal(2, obj.IBaseObject.Id);
+        }
+
+        [Fact]
+        public void ReadInterfacePolymorphicObject()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(NameObject));
+
+            const string hexBuffer = "A3625F746A4E616D654F626A656374644E616D6563666F6F62496401";
+            IBaseInterface obj = Helper.Read<IBaseInterface>(hexBuffer, options);
+
+            Assert.NotNull(obj);
+            Assert.IsType<NameObject>(obj);
+            Assert.Equal("foo", ((NameObject)obj).Name);
+            Assert.Equal(1, obj.Id);
         }
 
         [CborDiscriminator("OtherObject")]
@@ -48,11 +65,23 @@ namespace Dahomey.Cbor.Tests
             Assert.ThrowsAny<CborException>(() => Helper.Read<BaseObjectHolder>(hexBuffer, options));
         }
 
+        [Fact]
+        public void WriteInterfacePolymorphicObject()
+        {
+            CborOptions options = new CborOptions();
+            // options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(NameObject));
+            IBaseInterface obj = new NameObject { Id = 1, Name = "foo" };
+
+            const string hexBuffer = "A3625F746A4E616D654F626A656374644E616D6563666F6F62496401";
+
+            Helper.TestWrite(obj, hexBuffer, null, options);
+        }
+
         [Theory]
-        [InlineData(CborDiscriminatorPolicy.Default, "A26A426173654F626A656374A3625F746A4E616D654F626A656374644E616D6563666F6F624964016A4E616D654F626A656374A2644E616D656362617262496402")]
-        [InlineData(CborDiscriminatorPolicy.Auto, "A26A426173654F626A656374A3625F746A4E616D654F626A656374644E616D6563666F6F624964016A4E616D654F626A656374A2644E616D656362617262496402")]
-        [InlineData(CborDiscriminatorPolicy.Never, "A26A426173654F626A656374A2644E616D6563666F6F624964016A4E616D654F626A656374A2644E616D656362617262496402")]
-        [InlineData(CborDiscriminatorPolicy.Always, "A26A426173654F626A656374A3625F746A4E616D654F626A656374644E616D6563666F6F624964016A4E616D654F626A656374A3625F746A4E616D654F626A656374644E616D656362617262496402")]
+        [InlineData(CborDiscriminatorPolicy.Default, "A36B49426173654F626A656374A3625F74714465736372697074696F6E4F626A6563746B4465736372697074696F6E6362617A624964036A426173654F626A656374A3625F746A4E616D654F626A656374644E616D6563666F6F624964016A4E616D654F626A656374A2644E616D656362617262496402")]
+        [InlineData(CborDiscriminatorPolicy.Auto, "A36B49426173654F626A656374A3625F74714465736372697074696F6E4F626A6563746B4465736372697074696F6E6362617A624964036A426173654F626A656374A3625F746A4E616D654F626A656374644E616D6563666F6F624964016A4E616D654F626A656374A2644E616D656362617262496402")]
+        [InlineData(CborDiscriminatorPolicy.Never, "A36B49426173654F626A656374A3625F74714465736372697074696F6E4F626A6563746B4465736372697074696F6E6362617A624964036A426173654F626A656374A2644E616D6563666F6F624964016A4E616D654F626A656374A2644E616D656362617262496402")]
+        [InlineData(CborDiscriminatorPolicy.Always, "A36B49426173654F626A656374A3625F74714465736372697074696F6E4F626A6563746B4465736372697074696F6E6362617A624964036A426173654F626A656374A3625F746A4E616D654F626A656374644E616D6563666F6F624964016A4E616D654F626A656374A3625F746A4E616D654F626A656374644E616D656362617262496402")]
         public void WritePolymorphicObject(CborDiscriminatorPolicy discriminatorPolicy, string hexBuffer)
         {
             CborOptions options = new CborOptions();
@@ -79,6 +108,11 @@ namespace Dahomey.Cbor.Tests
                 {
                     Id = 2,
                     Name = "bar"
+                },
+                IBaseObject = new DescriptionObject
+                {
+                    Id = 3,
+                    Description = "baz"
                 }
             };
 
@@ -151,7 +185,7 @@ namespace Dahomey.Cbor.Tests
             options.Registry.DiscriminatorConventionRegistry.RegisterConvention(new CustomDiscriminatorConvention());
             options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(NameObject));
 
-            const string hexBuffer = "A26A426173654F626A656374A364747970651A22134C83644E616D6563666F6F624964016A4E616D654F626A656374F6";
+            const string hexBuffer = "A36B49426173654F626A656374F66A426173654F626A656374A364747970651A22134C83644E616D6563666F6F624964016A4E616D654F626A656374F6";
 
             BaseObjectHolder obj = new BaseObjectHolder
             {

--- a/src/Dahomey.Cbor.Tests/SampleClasses.cs
+++ b/src/Dahomey.Cbor.Tests/SampleClasses.cs
@@ -163,11 +163,17 @@ namespace Dahomey.Cbor.Tests
 
     public class BaseObjectHolder
     {
+        public IBaseInterface IBaseObject { get; set; }
         public BaseObject BaseObject { get; set; }
         public NameObject NameObject { get; set; }
     }
 
-    public class BaseObject
+    public interface IBaseInterface
+    {
+        int Id { get; }
+    }
+
+    public class BaseObject : IBaseInterface
     {
         public int Id { get; set; }
     }

--- a/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
@@ -70,6 +70,12 @@ namespace Dahomey.Cbor.Serialization.Conventions
                 {
                     _conventionsByType.TryAdd(currentType, convention);
                 }
+
+                // setup discriminator for all interfaces
+                foreach (var @interface in type.GetInterfaces())
+                {
+                    _conventionsByType.TryAdd(@interface, convention);
+                }
             }
 
             return convention;


### PR DESCRIPTION
The IDiscriminatorConvention is now also registered on implemented interfaces, and not only base classes as before.

Regression tests has been added.