### PR TITLE
Add ability to set default naming convention

### DIFF
--- a/src/Dahomey.Cbor.Tests/NamingConventionTests.cs
+++ b/src/Dahomey.Cbor.Tests/NamingConventionTests.cs
@@ -1,66 +1,103 @@
 ﻿using Dahomey.Cbor.Serialization.Conventions;
 using Xunit;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
-namespace Dahomey.Cbor.Tests
+namespace Dahomey.Cbor.Tests;
+
+public class NamingConventionTests
 {
-
-    public class NamingConventionTests
+    [Theory]
+    [InlineData("FooBar", "fooBar")]
+    [InlineData("fooBar", "fooBar")]
+    [InlineData("Foo", "foo")]
+    [InlineData("foo", "foo")]
+    [InlineData("", "")]
+    public void CamelCase(string srcName, string expectedName)
     {
-        [Theory]
-        [InlineData("FooBar", "fooBar")]
-        [InlineData("fooBar", "fooBar")]
-        [InlineData("Foo", "foo")]
-        [InlineData("foo", "foo")]
-        [InlineData("", "")]
-        public void CamelCase(string srcName, string expectedName)
-        {
-            string actualName = new CamelCaseNamingConvention().GetPropertyName(srcName);
-            Assert.Equal(expectedName, actualName);
-        }
+        string actualName = new CamelCaseNamingConvention().GetPropertyName(srcName);
+        Assert.Equal(expectedName, actualName);
+    }
 
-        [Theory]
-        [InlineData("FooBar", "foo_bar")]
-        [InlineData("fooBar", "foo_bar")]
-        [InlineData("FooBAR", "foo_bar")]
-        [InlineData("FooBARFoo", "foo_bar_foo")]
-        [InlineData("Foo", "foo")]
-        [InlineData("foo", "foo")]
-        [InlineData("", "")]
-        public void SnakeCase(string srcName, string expectedName)
-        {
-            string actualName = new SnakeCaseNamingConvention().GetPropertyName(srcName);
-            Assert.Equal(expectedName, actualName);
-        }
+    [Theory]
+    [InlineData("FooBar", "foo_bar")]
+    [InlineData("fooBar", "foo_bar")]
+    [InlineData("FooBAR", "foo_bar")]
+    [InlineData("FooBARFoo", "foo_bar_foo")]
+    [InlineData("Foo", "foo")]
+    [InlineData("foo", "foo")]
+    [InlineData("", "")]
+    public void SnakeCase(string srcName, string expectedName)
+    {
+        string actualName = new SnakeCaseNamingConvention().GetPropertyName(srcName);
+        Assert.Equal(expectedName, actualName);
+    }
 
-        [Theory]
-        [InlineData("FooBar", "foobar")]
-        [InlineData("fooBar", "foobar")]
-        [InlineData("FooBAR", "foobar")]
-        [InlineData("FooBARFoo", "foobarfoo")]
-        [InlineData("Foo", "foo")]
-        [InlineData("foo", "foo")]
-        [InlineData("", "")]
-        public void LowerCase(string srcName, string expectedName)
-        {
-            string actualName = new LowerCaseNamingConvention().GetPropertyName(srcName);
-            Assert.Equal(expectedName, actualName);
-        }
+    [Theory]
+    [InlineData("FooBar", "FOO_BAR")]
+    [InlineData("fooBar", "FOO_BAR")]
+    [InlineData("FooBAR", "FOO_BAR")]
+    [InlineData("FooBARFoo", "FOO_BAR_FOO")]
+    [InlineData("Foo", "FOO")]
+    [InlineData("foo", "FOO")]
+    [InlineData("", "")]
+    public void UpperSnakeCase(string srcName, string expectedName)
+    {
+        string actualName = new UpperSnakeCaseNamingConvention().GetPropertyName(srcName);
+        Assert.Equal(expectedName, actualName);
+    }
 
-        [Theory]
-        [InlineData("FooBar", "FOOBAR")]
-        [InlineData("fooBar", "FOOBAR")]
-        [InlineData("FooBAR", "FOOBAR")]
-        [InlineData("FooBARFoo", "FOOBARFOO")]
-        [InlineData("Foo", "FOO")]
-        [InlineData("foo", "FOO")]
-        [InlineData("", "")]
-        public void UpperCase(string srcName, string expectedName)
-        {
-            string actualName = new UpperCaseNamingConvention().GetPropertyName(srcName);
-            Assert.Equal(expectedName, actualName);
-        }
+    [Theory]
+    [InlineData("FooBar", "foo-bar")]
+    [InlineData("fooBar", "foo-bar")]
+    [InlineData("FooBAR", "foo-bar")]
+    [InlineData("FooBARFoo", "foo-bar-foo")]
+    [InlineData("Foo", "foo")]
+    [InlineData("foo", "foo")]
+    [InlineData("", "")]
+    public void KebabCase(string srcName, string expectedName)
+    {
+        string actualName = new KebabCaseNamingConvention().GetPropertyName(srcName);
+        Assert.Equal(expectedName, actualName);
+    }
+
+    [Theory]
+    [InlineData("FooBar", "FOO-BAR")]
+    [InlineData("fooBar", "FOO-BAR")]
+    [InlineData("FooBAR", "FOO-BAR")]
+    [InlineData("FooBARFoo", "FOO-BAR-FOO")]
+    [InlineData("Foo", "FOO")]
+    [InlineData("foo", "FOO")]
+    [InlineData("", "")]
+    public void UpperKebabCase(string srcName, string expectedName)
+    {
+        string actualName = new UpperKebabCaseNamingConvention().GetPropertyName(srcName);
+        Assert.Equal(expectedName, actualName);
+    }
+
+    [Theory]
+    [InlineData("FooBar", "foobar")]
+    [InlineData("fooBar", "foobar")]
+    [InlineData("FooBAR", "foobar")]
+    [InlineData("FooBARFoo", "foobarfoo")]
+    [InlineData("Foo", "foo")]
+    [InlineData("foo", "foo")]
+    [InlineData("", "")]
+    public void LowerCase(string srcName, string expectedName)
+    {
+        string actualName = new LowerCaseNamingConvention().GetPropertyName(srcName);
+        Assert.Equal(expectedName, actualName);
+    }
+
+    [Theory]
+    [InlineData("FooBar", "FOOBAR")]
+    [InlineData("fooBar", "FOOBAR")]
+    [InlineData("FooBAR", "FOOBAR")]
+    [InlineData("FooBARFoo", "FOOBARFOO")]
+    [InlineData("Foo", "FOO")]
+    [InlineData("foo", "FOO")]
+    [InlineData("", "")]
+    public void UpperCase(string srcName, string expectedName)
+    {
+        string actualName = new UpperCaseNamingConvention().GetPropertyName(srcName);
+        Assert.Equal(expectedName, actualName);
     }
 }

--- a/src/Dahomey.Cbor.Tests/ObjectMappingTests.cs
+++ b/src/Dahomey.Cbor.Tests/ObjectMappingTests.cs
@@ -277,9 +277,9 @@ namespace Dahomey.Cbor.Tests
         [Fact]
         public void WriteOptInWithDefaultNamingConvention()
         {
-            CborOptions options = new CborOptions()
+            var options = new CborOptions()
             {
-                DefaultNamingConventionType = typeof(LowerCaseNamingConvention)
+                DefaultNamingConvention = new LowerCaseNamingConvention()
             };
 
             options.Registry.ObjectMappingConventionRegistry.RegisterProvider(
@@ -294,9 +294,9 @@ namespace Dahomey.Cbor.Tests
         [Fact]
         public void ReadOptInWithDefaultNamingConvention()
         {
-            CborOptions options = new CborOptions()
+            var options = new CborOptions()
             {
-                DefaultNamingConventionType = typeof(LowerCaseNamingConvention)
+                DefaultNamingConvention = new LowerCaseNamingConvention()
             };
 
             options.Registry.ObjectMappingConventionRegistry.RegisterProvider(
@@ -324,9 +324,9 @@ namespace Dahomey.Cbor.Tests
         [Fact]
         public void WriteOptInWithDefaultNamingConventionAndCborNamingAttribute()
         {
-            CborOptions options = new CborOptions()
+            var options = new CborOptions()
             {
-                DefaultNamingConventionType = typeof(LowerCaseNamingConvention)
+                DefaultNamingConvention = new LowerCaseNamingConvention()
             };
 
             options.Registry.ObjectMappingConventionRegistry.RegisterProvider(
@@ -341,9 +341,9 @@ namespace Dahomey.Cbor.Tests
         [Fact]
         public void ReadOptInWithDefaultNamingConventionAndCborNamingAttribute()
         {
-            CborOptions options = new CborOptions()
+            var options = new CborOptions()
             {
-                DefaultNamingConventionType = typeof(LowerCaseNamingConvention)
+                DefaultNamingConvention = new LowerCaseNamingConvention()
             };
 
             options.Registry.ObjectMappingConventionRegistry.RegisterProvider(

--- a/src/Dahomey.Cbor/CborOptions.cs
+++ b/src/Dahomey.Cbor/CborOptions.cs
@@ -60,15 +60,11 @@ namespace Dahomey.Cbor
         public ulong DiscriminatorSemanticTag { get; set; } = 39;
 
         /// <summary>
-        /// Default naming convention type
+        /// The default naming convention to use when no naming convention is specified.
         /// </summary>
-        /// <remarks>
-        /// If type is marked 'CborNamingConventionAttribute' then will use naming convention from attribute
-        /// This option is usefult when uses codegeneration. Just set up this options same on each side
-        /// </remarks>
-        public Type? DefaultNamingConventionType { get; set; }
+        public INamingConvention? DefaultNamingConvention { get; set; }
 
-    public CborOptions()
+        public CborOptions()
         {
             Registry = new SerializationRegistry(this);
         }

--- a/src/Dahomey.Cbor/Serialization/Conventions/KebabCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/KebabCaseNamingConvention.cs
@@ -1,0 +1,9 @@
+﻿namespace Dahomey.Cbor.Serialization.Conventions;
+
+public class KebabCaseNamingConvention : INamingConvention
+{
+    public string GetPropertyName(string name)
+    {
+        return NamingConventionExtensions.GetPropertyName(name, (byte)'-');
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Conventions/NamingConventionExtensions.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/NamingConventionExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Dahomey.Cbor.Serialization.Conventions;
+
+internal static class NamingConventionExtensions
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string GetPropertyName(string name, byte separator, bool toUpper = false)
+    {
+        byte[] buffer = new byte[name.Length * 2];
+        int dstIndex = 0;
+        int srcLength = name.Length;
+        bool lastIsLower = false;
+
+        for (int srcIndex = 0; srcIndex < srcLength; srcIndex++)
+        {
+            char c = name[srcIndex];
+
+            if (char.IsUpper(c))
+            {
+                if (lastIsLower || srcIndex > 0 && srcIndex < srcLength - 1 && char.IsLower(name[srcIndex + 1]))
+                {
+                    buffer[dstIndex++] = separator;
+                    lastIsLower = false;
+                }
+
+                buffer[dstIndex++] = (byte)(toUpper ? c : char.ToLowerInvariant(c));
+            }
+            else
+            {
+                lastIsLower = true;
+                buffer[dstIndex++] = (byte)(toUpper ? char.ToUpperInvariant(c) : c);
+            }
+        }
+
+        return Encoding.UTF8.GetString(buffer, 0, dstIndex);
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Conventions/SnakeCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/SnakeCaseNamingConvention.cs
@@ -1,39 +1,9 @@
-﻿using System;
-using System.Text;
+﻿namespace Dahomey.Cbor.Serialization.Conventions;
 
-namespace Dahomey.Cbor.Serialization.Conventions
+public class SnakeCaseNamingConvention : INamingConvention
 {
-    public class SnakeCaseNamingConvention : INamingConvention
+    public string GetPropertyName(string name)
     {
-        public string GetPropertyName(string name)
-        {
-            byte[] buffer = new byte[name.Length * 2];
-            int dstIndex = 0;
-            int srcLength = name.Length;
-            bool lastIsLower = false;
-
-            for (int srcIndex = 0; srcIndex < srcLength; srcIndex++)
-            {
-                char c = name[srcIndex];
-
-                if (char.IsUpper(c))
-                {
-                    if (lastIsLower || srcIndex > 0 && srcIndex < srcLength - 1 && char.IsLower(name[srcIndex + 1]))
-                    {
-                        buffer[dstIndex++] = (byte)'_';
-                        lastIsLower = false;
-                    }
-
-                    buffer[dstIndex++] = (byte)char.ToLowerInvariant(c);
-                }
-                else
-                {
-                    lastIsLower = true;
-                    buffer[dstIndex++] = (byte)c;
-                }
-            }
-
-            return Encoding.UTF8.GetString(buffer, 0, dstIndex);
-        }
+        return NamingConventionExtensions.GetPropertyName(name, (byte)'_');
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Conventions/UpperKebabCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/UpperKebabCaseNamingConvention.cs
@@ -1,0 +1,9 @@
+﻿namespace Dahomey.Cbor.Serialization.Conventions;
+
+public class UpperKebabCaseNamingConvention : INamingConvention
+{
+    public string GetPropertyName(string name)
+    {
+        return NamingConventionExtensions.GetPropertyName(name, (byte)'-', true);
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Conventions/UpperSnakeCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/UpperSnakeCaseNamingConvention.cs
@@ -1,0 +1,9 @@
+﻿namespace Dahomey.Cbor.Serialization.Conventions;
+
+public class UpperSnakeCaseNamingConvention : INamingConvention
+{
+    public string GetPropertyName(string name)
+    {
+        return NamingConventionExtensions.GetPropertyName(name, (byte)'_', true);
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
@@ -28,7 +28,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             }
 
 
-            Type? namingConventionType = type.GetCustomAttribute<CborNamingConventionAttribute>()?.NamingConventionType ?? registry.Options.DefaultNamingConventionType;
+            Type? namingConventionType = type.GetCustomAttribute<CborNamingConventionAttribute>()?.NamingConventionType;
 
             if (namingConventionType != null)
             {
@@ -40,7 +40,14 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                 }
 
                 objectMapping.SetNamingConvention(namingConvention);
-            } 
+            }
+            else
+            {
+                if (registry.Options.DefaultNamingConvention is not null)
+                {
+                    objectMapping.SetNamingConvention(registry.Options.DefaultNamingConvention);
+                }
+            }
 
             CborLengthModeAttribute? lengthModeAttribute = type.GetCustomAttribute<CborLengthModeAttribute>();
             if (lengthModeAttribute != null)

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
@@ -57,6 +57,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             _options = options;
             ObjectType = typeof(T);
             ObjectFormat = options.ObjectFormat; // default value
+            NamingConvention = options.DefaultNamingConvention;
         }
 
         void IObjectMapping.AutoMap()


### PR DESCRIPTION
Add default naming convention property so that we can simply set a default naming convention that will be apply on every field like this:

```csharp
var options = new CborOptions
{
    DefaultNamingConvention = new SnakeCaseNamingConvention(),
};
```

It will still be overriden by the use of `CborNamingConventionAttribute`.