### PR TITLE
Fix conversion of type casting from object

### DIFF
--- a/src/Dahomey.Cbor.Tests/CborWriterTests.cs
+++ b/src/Dahomey.Cbor.Tests/CborWriterTests.cs
@@ -315,5 +315,14 @@ namespace Dahomey.Cbor.Tests
                 Assert.Equal(hexBuffer, BitConverter.ToString(buffer.WrittenSpan.ToArray()).Replace("-", ""));
             }
         }
+
+        [Theory]
+        [InlineData(42, "182A")]
+        [InlineData("Hello world", "6B48656C6C6F20776F726C64")]
+        [InlineData(false, "F4")]
+        public void WriteDataTypeCastAsObject(object value, string hexBuffer)
+        {
+            Helper.TestWrite(value, hexBuffer);
+        }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -377,7 +377,21 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             if (_objectMapping.CreatorMapping == null && actualType != declaredType)
             {
-                context.objectConverter = (IObjectConverter)_registry.ConverterRegistry.Lookup(value.GetType());
+                var converter = _registry.ConverterRegistry.Lookup(actualType);
+
+                if (converter is IObjectConverter objectConverter)
+                {
+                    context.objectConverter = objectConverter;
+                }
+                else if (converter is not null)
+                {
+                    converter.Write(ref writer, value);
+                    return;
+                }
+                else
+                {
+                    throw new CborException($"No converter found for type {actualType.Name}");
+                }
             }
             else
             {


### PR DESCRIPTION
It can happen that sometimes we don't know the exact type but it can be implicitly typed inside the library. The `ObjectConverter` currently only support map or array but not type casting from primitives for example.

This will allow us to do the following:

````csharp
var x = CborSerializer.Deserialize<object?>(...);

// later...

var y = (int)x; // or x as int for type checking
```