### PR TITLE
Turn converters in PrimitiveConverterProvider into singleton

### DIFF
--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
@@ -6,31 +6,35 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
 {
     public class PrimitiveConverterProvider : CborConverterProviderBase
     {
-        private static readonly Dictionary<Type, Type> _converterTypes = new Dictionary<Type, Type>
+        private static readonly Dictionary<Type, Lazy<ICborConverter>> _lazyConverterTypes = new()
         {
-            [typeof(bool)] = typeof(BooleanConverter),
-            [typeof(sbyte)] = typeof(SByteConverter),
-            [typeof(byte)] = typeof(ByteConverter),
-            [typeof(short)] = typeof(Int16Converter),
-            [typeof(ushort)] = typeof(UInt16Converter),
-            [typeof(int)] = typeof(Int32Converter),
-            [typeof(uint)] = typeof(UInt32Converter),
-            [typeof(long)] = typeof(Int64Converter),
-            [typeof(ulong)] = typeof(UInt64Converter),
-            [typeof(float)] = typeof(SingleConverter),
-            [typeof(double)] = typeof(DoubleConverter),
-            [typeof(decimal)] = typeof(DecimalConverter),
-            [typeof(string)] = typeof(StringConverter),
-            [typeof(DateTime)] = typeof(DateTimeConverter),
-            [typeof(ReadOnlyMemory<byte>)] = typeof(ReadOnlyMemoryConverter),
-            [typeof(byte[])] = typeof(ByteArrayConverter),
+            [typeof(bool)] = new(() => new BooleanConverter()),
+            [typeof(sbyte)] = new(() => new SByteConverter()),
+            [typeof(byte)] = new(() => new ByteConverter()),
+            [typeof(short)] = new(() => new Int16Converter()),
+            [typeof(ushort)] = new(() => new UInt16Converter()),
+            [typeof(int)] = new(() => new Int32Converter()),
+            [typeof(uint)] = new(() => new UInt32Converter()),
+            [typeof(long)] = new(() => new Int64Converter()),
+            [typeof(ulong)] = new(() => new UInt64Converter()),
+            [typeof(float)] = new(() => new SingleConverter()),
+            [typeof(double)] = new(() => new DoubleConverter()),
+            [typeof(decimal)] = new(() => new DecimalConverter()),
+            [typeof(string)] = new(() => new StringConverter()),
+            [typeof(ReadOnlyMemory<byte>)] = new(() => new ReadOnlyMemoryConverter()),
+            [typeof(byte[])] = new(() => new ByteArrayConverter()),
         };
 
         public override ICborConverter? GetConverter(Type type, CborOptions options)
         {
-            if (_converterTypes.TryGetValue(type, out Type? converterType))
+            if (_lazyConverterTypes.TryGetValue(type, out var converterType))
             {
-                return CreateConverter(options, converterType);
+                return converterType.Value;
+            }
+
+            if (type == typeof(DateTime))
+            {
+                return new DateTimeConverter(options);
             }
 
             if (type.IsEnum)


### PR DESCRIPTION
Continuing work to reduce memory allocation compared to `System.Text.Json`.

I noticed huge memory usage from converters. Managed to reduced from 50+KB to ~22KB following this:

* Using `ConverterProvider` instead of registering all converters by hand, at least for those that are never used on primary execution. This is done in my own code FYI.
* Leveraging Singleton pattern for frenquently evaluated converters, via `Lazy<T>`
* Hence updating `PrimitiveConverterProvider` so that the inner converters of this provider will pass to gen 2 at some point, avoiding memory pressure

Couple of self remarks/questions:
* What about a `FrozenDictionary` for lazy converters. `string`, `bool` and `int` are accessed so frequently, I suppose it should be protifable. Not really sure for this.
* Making a self-made singleton for the `DateTimeConverter`. It cannot be put in a `Lazy<T>` and making a singleton can be another optimization. What do you think?