### PR TITLE
Add ability to read dataitem without advancing

### DIFF
--- a/src/Dahomey.Cbor.Tests/CborReaderTests.cs
+++ b/src/Dahomey.Cbor.Tests/CborReaderTests.cs
@@ -1,7 +1,6 @@
 using Dahomey.Cbor.Serialization;
 using Xunit;
 using System;
-using Dahomey.Cbor.Util;
 using System.Globalization;
 using System.Buffers;
 using Dahomey.Cbor.Tests.Extensions;
@@ -335,6 +334,37 @@ namespace Dahomey.Cbor.Tests
 
             var resultValueItem = reader.ReadDataItem();
             Assert.Equal(expectedResultValue, resultValueItem.BytesToHex());
+        }
+
+        [Theory]
+        [InlineData("a262696468366534306233336266726573756c74c6f6", "683665343062333362", "c6f6")]
+        [InlineData("a262696468366534306233336266726573756c74182a", "683665343062333362", "182a")]
+        [InlineData("A262696468376235356365363566726573756C7463657965", "683762353563653635", "63657965")]
+        public void ReadDataItemButWithoutAdvance(string hexBuffer, string expectedIdValue, string expectedResultValue)
+        {
+            var reader = new CborReader(hexBuffer.HexToBytes());
+
+            reader.ReadBeginMap();
+
+            int remainingItemCount = reader.ReadSize();
+
+            reader.MoveNextMapItem(ref remainingItemCount);
+            var key1 = reader.ReadString();
+            Assert.Equal("id", key1);
+
+            var idValueItem1 = reader.ReadDataItem(false);
+            var idValueItem2 = reader.ReadDataItem();
+            Assert.Equal(expectedIdValue, idValueItem1.BytesToHex());
+            Assert.Equal(expectedIdValue, idValueItem2.BytesToHex());
+
+            reader.MoveNextMapItem(ref remainingItemCount);
+            var key2 = reader.ReadString();
+            Assert.Equal("result", key2);
+
+            var resultValueItem1 = reader.ReadDataItem(false);
+            var resultValueItem2 = reader.ReadDataItem();
+            Assert.Equal(expectedResultValue, resultValueItem1.BytesToHex());
+            Assert.Equal(expectedResultValue, resultValueItem2.BytesToHex());
         }
 
         [Theory]

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -3,7 +3,6 @@ using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Buffers.Text;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -799,14 +798,23 @@ namespace Dahomey.Cbor.Serialization
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlySpan<byte> ReadDataItem()
+        public ReadOnlySpan<byte> ReadDataItem(bool advance = true)
         {
+            int positionBefore = _currentPos;
+            var stateBefore = _state;
+            
             int headerOffset = _state == CborReaderState.Header ? 1 : 0;
             int currentDataItemPos = _currentPos - headerOffset;
 
             SkipDataItem();
 
             int size = _currentPos - currentDataItemPos;
+
+            if (!advance)
+            {
+                _currentPos = positionBefore;
+                _state = stateBefore;
+            }
 
             return _buffer.Slice(currentDataItemPos, size);
         }


### PR DESCRIPTION
I have the need to read the current DataItem without advancing. What I want to do is:

1. Read the current data item and store it in a `ReadOnlyMemory`
2. Do not advance (or go back to the previous position)
3. Re-read the current data item but this time reading the semantic tag (and the value if needed)