### PR TITLE
feat: directly use `MemberInfo` for naming convention

### DIFF
--- a/src/Dahomey.Cbor.Tests/Issues/Issue0021.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0021.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using Dahomey.Cbor.Serialization;
 using Dahomey.Cbor.Serialization.Conventions;
 using Dahomey.Cbor.Serialization.Converters.Mappings;
@@ -13,9 +14,9 @@ namespace Dahomey.Cbor.Tests.Issues
     {
         public class LowerCaseNamingConvention : INamingConvention
         {
-            public string GetPropertyName(string name)
+            public string GetPropertyName(MemberInfo memberInfo)
             {
-                return name.ToLowerInvariant();
+                return memberInfo.Name.ToLowerInvariant();
             }
         }
 

--- a/src/Dahomey.Cbor.Tests/NamingConventionTests.cs
+++ b/src/Dahomey.Cbor.Tests/NamingConventionTests.cs
@@ -1,19 +1,30 @@
-﻿using Dahomey.Cbor.Serialization.Conventions;
+﻿using System.Linq;
+using Dahomey.Cbor.Serialization.Conventions;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests;
 
 public class NamingConventionTests
 {
+    private class TestObject
+    {
+        public string FooBar { get; set; }
+        public string fooBar { get; set; }
+        public string FooBAR { get; set; }
+        public string FooBARFoo { get; set; }
+        public string Foo { get; set; }
+        public string foo { get; set; }
+    }
+    
     [Theory]
     [InlineData("FooBar", "fooBar")]
     [InlineData("fooBar", "fooBar")]
     [InlineData("Foo", "foo")]
     [InlineData("foo", "foo")]
-    [InlineData("", "")]
     public void CamelCase(string srcName, string expectedName)
     {
-        string actualName = new CamelCaseNamingConvention().GetPropertyName(srcName);
+        var memberInfo = typeof(TestObject).GetMember(srcName).Single();
+        string actualName = new CamelCaseNamingConvention().GetPropertyName(memberInfo);
         Assert.Equal(expectedName, actualName);
     }
 
@@ -24,10 +35,10 @@ public class NamingConventionTests
     [InlineData("FooBARFoo", "foo_bar_foo")]
     [InlineData("Foo", "foo")]
     [InlineData("foo", "foo")]
-    [InlineData("", "")]
     public void SnakeCase(string srcName, string expectedName)
     {
-        string actualName = new SnakeCaseNamingConvention().GetPropertyName(srcName);
+        var memberInfo = typeof(TestObject).GetMember(srcName).Single();
+        string actualName = new SnakeCaseNamingConvention().GetPropertyName(memberInfo);
         Assert.Equal(expectedName, actualName);
     }
 
@@ -38,10 +49,10 @@ public class NamingConventionTests
     [InlineData("FooBARFoo", "FOO_BAR_FOO")]
     [InlineData("Foo", "FOO")]
     [InlineData("foo", "FOO")]
-    [InlineData("", "")]
     public void UpperSnakeCase(string srcName, string expectedName)
     {
-        string actualName = new UpperSnakeCaseNamingConvention().GetPropertyName(srcName);
+        var memberInfo = typeof(TestObject).GetMember(srcName).Single();
+        string actualName = new UpperSnakeCaseNamingConvention().GetPropertyName(memberInfo);
         Assert.Equal(expectedName, actualName);
     }
 
@@ -52,10 +63,10 @@ public class NamingConventionTests
     [InlineData("FooBARFoo", "foo-bar-foo")]
     [InlineData("Foo", "foo")]
     [InlineData("foo", "foo")]
-    [InlineData("", "")]
     public void KebabCase(string srcName, string expectedName)
     {
-        string actualName = new KebabCaseNamingConvention().GetPropertyName(srcName);
+        var memberInfo = typeof(TestObject).GetMember(srcName).Single();
+        string actualName = new KebabCaseNamingConvention().GetPropertyName(memberInfo);
         Assert.Equal(expectedName, actualName);
     }
 
@@ -66,10 +77,10 @@ public class NamingConventionTests
     [InlineData("FooBARFoo", "FOO-BAR-FOO")]
     [InlineData("Foo", "FOO")]
     [InlineData("foo", "FOO")]
-    [InlineData("", "")]
     public void UpperKebabCase(string srcName, string expectedName)
     {
-        string actualName = new UpperKebabCaseNamingConvention().GetPropertyName(srcName);
+        var memberInfo = typeof(TestObject).GetMember(srcName).Single();
+        string actualName = new UpperKebabCaseNamingConvention().GetPropertyName(memberInfo);
         Assert.Equal(expectedName, actualName);
     }
 
@@ -80,10 +91,10 @@ public class NamingConventionTests
     [InlineData("FooBARFoo", "foobarfoo")]
     [InlineData("Foo", "foo")]
     [InlineData("foo", "foo")]
-    [InlineData("", "")]
     public void LowerCase(string srcName, string expectedName)
     {
-        string actualName = new LowerCaseNamingConvention().GetPropertyName(srcName);
+        var memberInfo = typeof(TestObject).GetMember(srcName).Single();
+        string actualName = new LowerCaseNamingConvention().GetPropertyName(memberInfo);
         Assert.Equal(expectedName, actualName);
     }
 
@@ -94,10 +105,10 @@ public class NamingConventionTests
     [InlineData("FooBARFoo", "FOOBARFOO")]
     [InlineData("Foo", "FOO")]
     [InlineData("foo", "FOO")]
-    [InlineData("", "")]
     public void UpperCase(string srcName, string expectedName)
     {
-        string actualName = new UpperCaseNamingConvention().GetPropertyName(srcName);
+        var memberInfo = typeof(TestObject).GetMember(srcName).Single();
+        string actualName = new UpperCaseNamingConvention().GetPropertyName(memberInfo);
         Assert.Equal(expectedName, actualName);
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Conventions/CamelCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/CamelCaseNamingConvention.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Text;
+﻿using System.Reflection;
 
 namespace Dahomey.Cbor.Serialization.Conventions
 {
     public class CamelCaseNamingConvention : INamingConvention
     {
-        public string GetPropertyName(string reflectionName)
+        public string GetPropertyName(MemberInfo member)
         {
+            string reflectionName = member.Name;
             if (string.IsNullOrEmpty(reflectionName) || char.IsLower(reflectionName[0]))
             {
                 return reflectionName;

--- a/src/Dahomey.Cbor/Serialization/Conventions/INamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/INamingConvention.cs
@@ -1,7 +1,9 @@
-﻿namespace Dahomey.Cbor.Serialization.Conventions
+﻿using System.Reflection;
+
+namespace Dahomey.Cbor.Serialization.Conventions
 {
     public interface INamingConvention
     {
-        string GetPropertyName(string name);
+        string GetPropertyName(MemberInfo member);
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Conventions/KebabCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/KebabCaseNamingConvention.cs
@@ -1,9 +1,11 @@
-﻿namespace Dahomey.Cbor.Serialization.Conventions;
+﻿using System.Reflection;
+
+namespace Dahomey.Cbor.Serialization.Conventions;
 
 public class KebabCaseNamingConvention : INamingConvention
 {
-    public string GetPropertyName(string name)
+    public string GetPropertyName(MemberInfo member)
     {
-        return NamingConventionExtensions.GetPropertyName(name, (byte)'-');
+        return NamingConventionExtensions.GetPropertyName(member.Name, (byte)'-');
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Conventions/LowerCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/LowerCaseNamingConvention.cs
@@ -1,4 +1,6 @@
-﻿namespace Dahomey.Cbor.Serialization.Conventions
+﻿using System.Reflection;
+
+namespace Dahomey.Cbor.Serialization.Conventions
 {
     /// <summary>
     /// Convert all names to lower case when serializing
@@ -9,11 +11,11 @@
         /// <summary>
         /// Get property name according convention
         /// </summary>
-        /// <param name="name"> Property raw-name</param>
+        /// <param name="member">Property member info</param>
         /// <returns>Property name according convention</returns>
-        public string GetPropertyName(string name)
+        public string GetPropertyName(MemberInfo member)
         {
-            return name.ToLower();
+            return member.Name.ToLower();
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Conventions/SnakeCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/SnakeCaseNamingConvention.cs
@@ -1,9 +1,11 @@
-﻿namespace Dahomey.Cbor.Serialization.Conventions;
+﻿using System.Reflection;
+
+namespace Dahomey.Cbor.Serialization.Conventions;
 
 public class SnakeCaseNamingConvention : INamingConvention
 {
-    public string GetPropertyName(string name)
+    public string GetPropertyName(MemberInfo member)
     {
-        return NamingConventionExtensions.GetPropertyName(name, (byte)'_');
+        return NamingConventionExtensions.GetPropertyName(member.Name, (byte)'_');
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Conventions/UpperCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/UpperCaseNamingConvention.cs
@@ -1,4 +1,6 @@
-﻿namespace Dahomey.Cbor.Serialization.Conventions
+﻿using System.Reflection;
+
+namespace Dahomey.Cbor.Serialization.Conventions
 {
     /// <summary>
     /// Convert all names to upper case when serializing
@@ -9,11 +11,11 @@
         /// <summary>
         /// Get property name according convention
         /// </summary>
-        /// <param name="name"> Property raw-name</param>
+        /// <param name="member">Property member info</param>
         /// <returns>Property name according convention</returns>
-        public string GetPropertyName(string name)
+        public string GetPropertyName(MemberInfo member)
         {
-            return name.ToUpper();
+            return member.Name.ToUpper();
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Conventions/UpperKebabCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/UpperKebabCaseNamingConvention.cs
@@ -1,9 +1,11 @@
-﻿namespace Dahomey.Cbor.Serialization.Conventions;
+﻿using System.Reflection;
+
+namespace Dahomey.Cbor.Serialization.Conventions;
 
 public class UpperKebabCaseNamingConvention : INamingConvention
 {
-    public string GetPropertyName(string name)
+    public string GetPropertyName(MemberInfo member)
     {
-        return NamingConventionExtensions.GetPropertyName(name, (byte)'-', true);
+        return NamingConventionExtensions.GetPropertyName(member.Name, (byte)'-', true);
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Conventions/UpperSnakeCaseNamingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/UpperSnakeCaseNamingConvention.cs
@@ -1,9 +1,11 @@
-﻿namespace Dahomey.Cbor.Serialization.Conventions;
+﻿using System.Reflection;
+
+namespace Dahomey.Cbor.Serialization.Conventions;
 
 public class UpperSnakeCaseNamingConvention : INamingConvention
 {
-    public string GetPropertyName(string name)
+    public string GetPropertyName(MemberInfo member)
     {
-        return NamingConventionExtensions.GetPropertyName(name, (byte)'_', true);
+        return NamingConventionExtensions.GetPropertyName(member.Name, (byte)'_', true);
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
@@ -188,7 +188,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                 }
                 else if (_objectMapping.NamingConvention != null)
                 {
-                    _memberName = _objectMapping.NamingConvention.GetPropertyName(MemberInfo.Name);
+                    _memberName = _objectMapping.NamingConvention.GetPropertyName(MemberInfo);
                 }
                 else
                 {


### PR DESCRIPTION
Like said, I am in need of the `MemberInfo` for custom naming convention.

Can you also release a new version once this PR is merged?

Thank you.