### PR TITLE
Add regression tests for #133 and #149 (both already fixed)

### DIFF
--- a/src/Dahomey.Cbor.Tests/Issues/Issue0133.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0133.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #133 — "Collection Expression Serialization": a single-element C# collection expression
+    /// failed to serialize with
+    /// "GenericArguments[0], '&lt;&gt;z__ReadOnlySingleElementList`1[...]' ... violates the constraint
+    /// of type 'TC'", while <c>new[] { 42 }</c> worked.
+    /// </summary>
+    /// <remarks>
+    /// The compiler lowers a single-element collection expression to a synthesized
+    /// <c>&lt;&gt;z__ReadOnlySingleElementList&lt;T&gt;</c>, which has no public parameterless
+    /// constructor and so cannot satisfy <c>CollectionConverter&lt;TC, TI&gt;</c>'s
+    /// <c>where TC : class, ICollection&lt;TI&gt;, new()</c>.
+    ///
+    /// Already fixed by #141, which routes types with a null namespace (the synthesized ones live in
+    /// the global namespace) to <c>InterfaceCollectionConverter</c> with <c>List&lt;T&gt;</c> as the
+    /// concrete collection instead. These tests pin that behaviour, including the multi-element
+    /// synthesized types, which lower to different classes.
+    /// </remarks>
+    public class Issue0133
+    {
+        public class Model
+        {
+            public int X { get; set; }
+        }
+
+        [Fact]
+        public void SingleElementCollectionExpressionMatchesArraySyntax()
+        {
+            int[] viaArraySyntax = new[] { 42 };
+            IReadOnlyList<int> viaCollectionExpression = [42];
+
+            // The synthesized type is the whole point of the issue; assert we really are on that path.
+            Assert.StartsWith("<>z__ReadOnlySingleElementList", viaCollectionExpression.GetType().Name);
+
+            const string hexBuffer = "81182A"; // [42]
+            Assert.Equal(hexBuffer, Helper.Write(viaArraySyntax));
+            Assert.Equal(hexBuffer, Helper.Write(viaCollectionExpression));
+        }
+
+        [Fact]
+        public void SingleElementCollectionExpressionOfObjects()
+        {
+            IEnumerable<Model> models = [new Model { X = 1 }];
+
+            Assert.StartsWith("<>z__ReadOnlySingleElementList", models.GetType().Name);
+
+            Assert.Equal("81A1615801", Helper.Write(models)); // [{"X": 1}]
+        }
+
+        /// <summary>
+        /// Two or more elements lower to a different synthesized type again
+        /// (<c>&lt;&gt;z__ReadOnlyArray</c>), so cover it separately.
+        /// </summary>
+        [Fact]
+        public void MultiElementCollectionExpression()
+        {
+            IReadOnlyList<int> values = [1, 2, 3];
+
+            Assert.Equal("83010203", Helper.Write(values)); // [1, 2, 3]
+        }
+
+        [Fact]
+        public void EmptyCollectionExpression()
+        {
+            IReadOnlyList<int> values = [];
+
+            Assert.Equal("80", Helper.Write(values)); // []
+        }
+
+        [Fact]
+        public void CollectionExpressionAsMemberValue()
+        {
+            ModelHolder holder = new ModelHolder { Values = [7] };
+
+            Assert.Equal("A16656616C7565738107", Helper.Write(holder)); // {"Values": [7]}
+        }
+
+        public class ModelHolder
+        {
+            public IReadOnlyList<int> Values { get; set; }
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0149.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0149.cs
@@ -1,0 +1,72 @@
+#nullable enable
+using System.Buffers;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #149 — "Stack Overflow": serializing a class with a nullable property whose type is the
+    /// class itself overflowed the stack.
+    /// </summary>
+    /// <remarks>
+    /// Already fixed by the recursion work in #147 (reuse the converter under construction when a
+    /// member's type matches it) and #151 (lazy converter resolution). These tests pin the behaviour
+    /// so it cannot silently regress — a regression here is a stack overflow, which kills the test
+    /// host rather than failing a test, so it is worth keeping cheap and explicit.
+    /// </remarks>
+    public class Issue0149
+    {
+        public class TestObject
+        {
+            public TestObject? TestProperty { get; set; } = null;
+        }
+
+        [Fact]
+        public void SerializeSelfReferentialNullablePropertyThatIsNull()
+        {
+            ArrayBufferWriter<byte> buffer = new ArrayBufferWriter<byte>();
+            Cbor.Serialize(new TestObject(), buffer);
+
+            // {"TestProperty": null}
+            Assert.Equal("A16C5465737450726F7065727479F6", Helper.Write(new TestObject()));
+        }
+
+        [Fact]
+        public void SerializeSelfReferentialNullablePropertyThatIsSet()
+        {
+            TestObject obj = new TestObject { TestProperty = new TestObject() };
+
+            // {"TestProperty": {"TestProperty": null}}
+            Assert.Equal(
+                "A16C5465737450726F7065727479A16C5465737450726F7065727479F6",
+                Helper.Write(obj));
+        }
+
+        [Fact]
+        public void RoundTripSelfReferentialChain()
+        {
+            TestObject obj = new TestObject
+            {
+                TestProperty = new TestObject
+                {
+                    TestProperty = new TestObject(),
+                },
+            };
+
+            string hexBuffer = Helper.Write(obj);
+            TestObject rehydrated = Cbor.Deserialize<TestObject>(
+                Extensions.StringExtensions.HexToBytes(hexBuffer));
+
+            Assert.NotNull(rehydrated.TestProperty);
+            Assert.NotNull(rehydrated.TestProperty!.TestProperty);
+            Assert.Null(rehydrated.TestProperty!.TestProperty!.TestProperty);
+        }
+
+        // NOTE: a genuine reference cycle (obj.TestProperty = obj) is deliberately NOT tested here.
+        // CBOR has no back-references, and the writer has no depth limit, so it recurses until the
+        // stack is exhausted. A StackOverflowException cannot be caught, so such a test aborts the
+        // whole test host rather than failing. Bounding recursion depth is tracked separately; see
+        // the workspace AOT-PLAN/CLAUDE notes.
+
+    }
+}


### PR DESCRIPTION
Both issues reproduce as **fixed** on current `master`, but neither has a test pinning the behaviour. This adds those tests so the fixes cannot silently regress — no product code changes at all.

### #149 — nullable self-referential property caused a stack overflow

Fixed by the recursion work in #147 and #151. Worth an explicit test because a regression manifests as a `StackOverflowException`, which aborts the test host rather than failing a test.

```csharp
class TestObject { public TestObject? TestProperty { get; set; } = null; }
Cbor.Serialize(new TestObject(), buffer);   // used to overflow; now {"TestProperty": null}
```

Covers the null case, the nested case, and a 3-deep round trip.

### #133 — single-element collection expression failed to serialize

Fixed by #141. `var array = [42]` lowers to a synthesized `<>z__ReadOnlySingleElementList<T>`, which has no public parameterless constructor and so cannot satisfy `CollectionConverter<TC, TI>`'s `where TC : class, ICollection<TI>, new()`.

The tests assert the synthesized type really is on the path (otherwise they'd pass vacuously), and also cover the empty, multi-element and member-valued forms, which the compiler lowers to *different* synthesized types.

### Deliberately not covered

A genuine reference **cycle** (`obj.Property = obj`). CBOR has no back-references and the writer has no depth limit, so it recurses until the stack is exhausted and the failure cannot be asserted. Bounding depth is a separate change.

---

835 tests pass on net10.0 (827 before). All four TFMs build. If you agree, #133 and #149 can be closed.