### PR TITLE
CborDataItemScanner: non-throwing data item length scanning (#139, #134)

### DIFF
--- a/src/Dahomey.Cbor.Tests/CborDataItemScannerTests.cs
+++ b/src/Dahomey.Cbor.Tests/CborDataItemScannerTests.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// Covers <see cref="CborDataItemScanner"/>: determining a data item's length without decoding it
+    /// and without throwing on truncated input — the primitive needed for CBOR sequences (RFC 8742,
+    /// issue #139) and for streaming (issue #134).
+    /// </summary>
+    public class CborDataItemScannerTests
+    {
+        private static CborDataItemStatus Scan(string hexBuffer, out int length)
+        {
+            return CborDataItemScanner.Scan(hexBuffer.HexToBytes(), out length);
+        }
+
+        [Theory]
+        // scalars
+        [InlineData("00", 1)]                       // 0
+        [InlineData("17", 1)]                       // 23
+        [InlineData("1818", 2)]                     // 24
+        [InlineData("190100", 3)]                   // 256
+        [InlineData("1A000F4240", 5)]               // 1000000
+        [InlineData("1B0000000100000000", 9)]       // 4294967296
+        [InlineData("20", 1)]                       // -1
+        [InlineData("3903E7", 3)]                   // -1000
+        [InlineData("F4", 1)]                       // false
+        [InlineData("F5", 1)]                       // true
+        [InlineData("F6", 1)]                       // null
+        [InlineData("F7", 1)]                       // undefined
+        [InlineData("F90001", 3)]                   // half 5.960464477539063e-8
+        [InlineData("FA47C35000", 5)]               // float 100000.0
+        [InlineData("FB3FD5555555555555", 9)]       // double 1/3
+        [InlineData("F820", 2)]                     // simple(32)
+        // strings
+        [InlineData("40", 1)]                       // h''
+        [InlineData("4401020304", 5)]               // h'01020304'
+        [InlineData("60", 1)]                       // ""
+        [InlineData("6449455446", 5)]               // "IETF"
+        // arrays and maps
+        [InlineData("80", 1)]                       // []
+        [InlineData("83010203", 4)]                 // [1, 2, 3]
+        [InlineData("8301820203820405", 8)]         // [1, [2, 3], [4, 5]]
+        [InlineData("A0", 1)]                       // {}
+        [InlineData("A201020304", 5)]               // {1: 2, 3: 4}
+        [InlineData("A26161016162820203", 9)]       // {"a": 1, "b": [2, 3]}
+        // tags
+        [InlineData("C074323031332D30332D32315432303A30343A30305A", 22)] // 0("2013-03-21T20:04:00Z")
+        [InlineData("D82763666F6F", 6)]             // 39("foo")
+        // indefinite lengths
+        [InlineData("5F42010243030405FF", 9)]       // (_ h'0102', h'030405')
+        [InlineData("7F657374726561646D696E67FF", 13)] // (_ "strea", "ming")
+        [InlineData("9FFF", 2)]                     // [_ ]
+        [InlineData("9F018202039F0203FFFF", 10)]    // [_ 1, [2, 3], [_ 2, 3]]
+        [InlineData("BF61610161629F0203FFFF", 11)]  // {_ "a": 1, "b": [_ 2, 3]}
+        public void CompleteItems(string hexBuffer, int expectedLength)
+        {
+            Assert.Equal(CborDataItemStatus.Complete, Scan(hexBuffer, out int length));
+            Assert.Equal(expectedLength, length);
+        }
+
+        /// <summary>
+        /// Every strict prefix of a complete item must report Incomplete — never Malformed and never
+        /// a bogus Complete. This is the property that makes the scanner usable on a stream, so it is
+        /// checked exhaustively rather than by example.
+        /// </summary>
+        [Theory]
+        [InlineData("1818")]
+        [InlineData("1B0000000100000000")]
+        [InlineData("4401020304")]
+        [InlineData("6449455446")]
+        [InlineData("83010203")]
+        [InlineData("A26161016162820203")]
+        [InlineData("C074323031332D30332D32315432303A30343A30305A")]
+        [InlineData("D82763666F6F")]
+        [InlineData("5F42010243030405FF")]
+        [InlineData("7F657374726561646D696E67FF")]
+        [InlineData("9F018202039F0203FFFF")]
+        [InlineData("BF61610161629F0203FFFF")]
+        [InlineData("FB3FD5555555555555")]
+        public void EveryStrictPrefixIsIncomplete(string hexBuffer)
+        {
+            byte[] complete = hexBuffer.HexToBytes();
+
+            for (int prefixLength = 0; prefixLength < complete.Length; prefixLength++)
+            {
+                CborDataItemStatus status = CborDataItemScanner.Scan(
+                    complete.AsSpan(0, prefixLength), out _);
+
+                Assert.Equal(CborDataItemStatus.Incomplete, status);
+            }
+
+            Assert.Equal(CborDataItemStatus.Complete, CborDataItemScanner.Scan(complete, out int length));
+            Assert.Equal(complete.Length, length);
+        }
+
+        [Fact]
+        public void EmptyBufferIsIncomplete()
+        {
+            Assert.Equal(CborDataItemStatus.Incomplete, CborDataItemScanner.Scan(default, out int length));
+            Assert.Equal(0, length);
+        }
+
+        [Theory]
+        [InlineData("1C")]   // additional info 28, reserved
+        [InlineData("1D")]   // 29, reserved
+        [InlineData("1E")]   // 30, reserved
+        [InlineData("FF")]   // stray break where an item was expected
+        [InlineData("1F")]   // indefinite length on major type 0
+        [InlineData("3F")]   // indefinite length on major type 1
+        [InlineData("DF")]   // indefinite length on major type 6 (tag)
+        [InlineData("5F00FF")]     // indefinite byte string with a non-string chunk
+        [InlineData("5F6161FF")]   // indefinite byte string with a *text* chunk
+        [InlineData("7F4101FF")]   // indefinite text string with a *byte* chunk
+        [InlineData("5F5F41014102FFFF")] // nested indefinite chunk
+        [InlineData("BF6161FF")]   // indefinite map ending between key and value
+        public void MalformedItems(string hexBuffer)
+        {
+            Assert.Equal(CborDataItemStatus.Malformed, Scan(hexBuffer, out _));
+        }
+
+        /// <summary>
+        /// A hostile buffer can describe unbounded nesting in as many bytes as it has: each 0x9F
+        /// opens an indefinite array. Without a depth limit this is a stack overflow, so it must be
+        /// refused — and refused distinguishably from malformed input.
+        /// </summary>
+        [Fact]
+        public void ExcessiveNestingIsRefusedRatherThanOverflowingTheStack()
+        {
+            byte[] deeplyNested = new byte[100_000];
+            for (int i = 0; i < deeplyNested.Length; i++)
+            {
+                deeplyNested[i] = 0x9F; // start of indefinite-length array
+            }
+
+            Assert.Equal(CborDataItemStatus.TooDeep, CborDataItemScanner.Scan(deeplyNested, out _));
+        }
+
+        [Fact]
+        public void NestingUpToTheLimitIsAccepted()
+        {
+            // maxDepth counts the outermost item as depth 1, so `depth` nested arrays need maxDepth
+            // of exactly `depth`.
+            const int depth = 10;
+            List<byte> bytes = new List<byte>();
+            for (int i = 0; i < depth - 1; i++)
+            {
+                bytes.Add(0x81); // array(1)
+            }
+            bytes.Add(0x00); // innermost: 0
+
+            Assert.Equal(
+                CborDataItemStatus.Complete,
+                CborDataItemScanner.Scan(bytes.ToArray(), depth, out int length));
+            Assert.Equal(depth, length);
+
+            Assert.Equal(
+                CborDataItemStatus.TooDeep,
+                CborDataItemScanner.Scan(bytes.ToArray(), depth - 1, out _));
+        }
+
+        [Fact]
+        public void NonPositiveMaxDepthIsRejected()
+        {
+            byte[] buffer = "00".HexToBytes();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => CborDataItemScanner.Scan(buffer, 0, out _));
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => CborDataItemScanner.Scan(buffer, -1, out _));
+        }
+
+        /// <summary>
+        /// A length that cannot possibly be satisfied reports Incomplete, not Malformed: the scanner
+        /// cannot know the stream will not eventually supply the bytes, and must not allocate or
+        /// overflow while deciding.
+        /// </summary>
+        [Fact]
+        public void AbsurdlyLargeStringLengthIsIncompleteNotFatal()
+        {
+            // bytes(0xFFFFFFFFFFFFFFFF) with no payload
+            Assert.Equal(
+                CborDataItemStatus.Incomplete,
+                Scan("5BFFFFFFFFFFFFFFFF", out _));
+
+            // array with a huge declared item count
+            Assert.Equal(
+                CborDataItemStatus.Incomplete,
+                Scan("9BFFFFFFFFFFFFFFFF", out _));
+        }
+
+        // ---- sequence reading (RFC 8742) ----
+
+        [Fact]
+        public void TryReadDataItemWalksASequence()
+        {
+            // 1, "two", [3, 4] concatenated with no framing — a CBOR sequence
+            ReadOnlySpan<byte> remaining = "016374776F820304".HexToBytes();
+            List<string> items = new List<string>();
+
+            while (CborDataItemScanner.TryReadDataItem(ref remaining, out ReadOnlySpan<byte> item))
+            {
+                items.Add(item.BytesToHex().ToUpperInvariant());
+            }
+
+            Assert.Equal(new[] { "01", "6374776F", "820304" }, items);
+            Assert.True(remaining.IsEmpty);
+        }
+
+        [Fact]
+        public void TryReadDataItemLeavesTheIncompleteTailInPlace()
+        {
+            // 1, then a truncated text string header promising 3 bytes but supplying 1
+            byte[] buffer = "01637400".HexToBytes();
+            ReadOnlySpan<byte> remaining = buffer;
+
+            Assert.True(CborDataItemScanner.TryReadDataItem(ref remaining, out ReadOnlySpan<byte> first));
+            Assert.Equal("01", first.BytesToHex().ToUpperInvariant());
+
+            // The tail is not consumed, so the caller can prepend it to the next read.
+            Assert.False(CborDataItemScanner.TryReadDataItem(ref remaining, out _));
+            Assert.Equal(3, remaining.Length);
+            Assert.Equal("637400", remaining.BytesToHex().ToUpperInvariant());
+        }
+
+        [Fact]
+        public void ScanSequenceCountsCompleteItems()
+        {
+            Assert.Equal(
+                CborDataItemStatus.Complete,
+                CborDataItemScanner.ScanSequence("016374776F820304".HexToBytes(), out int consumed, out int count));
+            Assert.Equal(8, consumed);
+            Assert.Equal(3, count);
+        }
+
+        [Fact]
+        public void ScanSequenceReportsATruncatedTail()
+        {
+            // 1, "two", then a truncated array(2) missing its second item
+            Assert.Equal(
+                CborDataItemStatus.Incomplete,
+                CborDataItemScanner.ScanSequence("016374776F8203".HexToBytes(), out int consumed, out int count));
+
+            Assert.Equal(5, consumed); // "01" + "6374776F"
+            Assert.Equal(2, count);
+        }
+
+        [Fact]
+        public void ScanSequenceReportsMalformedRemainder()
+        {
+            Assert.Equal(
+                CborDataItemStatus.Malformed,
+                CborDataItemScanner.ScanSequence("011C".HexToBytes(), out int consumed, out int count));
+
+            Assert.Equal(1, consumed);
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void EmptySequenceIsComplete()
+        {
+            Assert.Equal(
+                CborDataItemStatus.Complete,
+                CborDataItemScanner.ScanSequence(default, out int consumed, out int count));
+            Assert.Equal(0, consumed);
+            Assert.Equal(0, count);
+        }
+
+        /// <summary>
+        /// The scanner's lengths must agree with what the decoder actually consumes, otherwise a
+        /// sequence walk would drift. Cross-checked against real serializer output.
+        /// </summary>
+        [Fact]
+        public void ScannedLengthAgreesWithSerializerOutput()
+        {
+            string[] hexBuffers =
+            {
+                Helper.Write(42),
+                Helper.Write("hello"),
+                Helper.Write(new[] { 1, 2, 3 }),
+                Helper.Write(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }),
+                Helper.Write(1.0 / 3.0),
+            };
+
+            foreach (string hexBuffer in hexBuffers)
+            {
+                byte[] bytes = hexBuffer.HexToBytes();
+
+                Assert.Equal(CborDataItemStatus.Complete, CborDataItemScanner.Scan(bytes, out int length));
+                Assert.Equal(bytes.Length, length);
+            }
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/CborDataItemScannerTests.cs
+++ b/src/Dahomey.Cbor.Tests/CborDataItemScannerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using Dahomey.Cbor.Serialization;
 using Dahomey.Cbor.Tests.Extensions;
@@ -13,9 +14,38 @@ namespace Dahomey.Cbor.Tests
     /// </summary>
     public class CborDataItemScannerTests
     {
+        /// <summary>
+        /// Scans the same bytes three ways — as a span, as a single-segment sequence, and as a
+        /// sequence carrying one byte per segment — and asserts all three agree on both status and
+        /// length. The contiguous and segmented walkers are separate implementations, so every case
+        /// in this file doubles as a check that they have not drifted apart, and the one-byte
+        /// segments mean every case also exercises reading a header, an argument and a payload across
+        /// a segment boundary.
+        /// </summary>
+        private static CborDataItemStatus ScanAllShapes(ReadOnlySpan<byte> buffer, out int length)
+        {
+            return ScanAllShapes(buffer, CborScanLimits.Default, out length);
+        }
+
+        private static CborDataItemStatus ScanAllShapes(
+            ReadOnlySpan<byte> buffer, CborScanLimits limits, out int length)
+        {
+            CborDataItemStatus status = CborDataItemScanner.Scan(buffer, limits, out length);
+
+            ReadOnlySequence<byte> contiguous = new ReadOnlySequence<byte>(buffer.ToArray());
+            Assert.Equal(status, CborDataItemScanner.Scan(contiguous, limits, out long contiguousLength));
+            Assert.Equal(length, contiguousLength);
+
+            ReadOnlySequence<byte> fragmented = Helper.Fragmentize(buffer);
+            Assert.Equal(status, CborDataItemScanner.Scan(fragmented, limits, out long fragmentedLength));
+            Assert.Equal(length, fragmentedLength);
+
+            return status;
+        }
+
         private static CborDataItemStatus Scan(string hexBuffer, out int length)
         {
-            return CborDataItemScanner.Scan(hexBuffer.HexToBytes(), out length);
+            return ScanAllShapes(hexBuffer.HexToBytes(), out length);
         }
 
         [Theory]
@@ -36,6 +66,7 @@ namespace Dahomey.Cbor.Tests
         [InlineData("FA47C35000", 5)]               // float 100000.0
         [InlineData("FB3FD5555555555555", 9)]       // double 1/3
         [InlineData("F820", 2)]                     // simple(32)
+        [InlineData("F8FF", 2)]                     // simple(255)
         // strings
         [InlineData("40", 1)]                       // h''
         [InlineData("4401020304", 5)]               // h'01020304'
@@ -88,20 +119,19 @@ namespace Dahomey.Cbor.Tests
 
             for (int prefixLength = 0; prefixLength < complete.Length; prefixLength++)
             {
-                CborDataItemStatus status = CborDataItemScanner.Scan(
-                    complete.AsSpan(0, prefixLength), out _);
+                CborDataItemStatus status = ScanAllShapes(complete.AsSpan(0, prefixLength), out _);
 
                 Assert.Equal(CborDataItemStatus.Incomplete, status);
             }
 
-            Assert.Equal(CborDataItemStatus.Complete, CborDataItemScanner.Scan(complete, out int length));
+            Assert.Equal(CborDataItemStatus.Complete, ScanAllShapes(complete, out int length));
             Assert.Equal(complete.Length, length);
         }
 
         [Fact]
         public void EmptyBufferIsIncomplete()
         {
-            Assert.Equal(CborDataItemStatus.Incomplete, CborDataItemScanner.Scan(default, out int length));
+            Assert.Equal(CborDataItemStatus.Incomplete, ScanAllShapes(default, out int length));
             Assert.Equal(0, length);
         }
 
@@ -124,6 +154,22 @@ namespace Dahomey.Cbor.Tests
         }
 
         /// <summary>
+        /// RFC 8949 §3.3 forbids the two-byte form of major type 7 for values below 32, which have a
+        /// one-byte form. A decoder rejects those bytes, so scanning them as Complete would break the
+        /// contract that a complete scan means a decoder will find a whole item here — the one place
+        /// where structural scanning cannot stay agnostic about encoding.
+        /// </summary>
+        [Theory]
+        [InlineData("F800")]  // simple(0), which must be encoded as E0
+        [InlineData("F813")]  // simple(19)
+        [InlineData("F817")]  // simple(23), which must be encoded as F7
+        [InlineData("F81F")]  // the last value with a one-byte form
+        public void TwoByteSimpleValuesBelowThirtyTwoAreMalformed(string hexBuffer)
+        {
+            Assert.Equal(CborDataItemStatus.Malformed, Scan(hexBuffer, out _));
+        }
+
+        /// <summary>
         /// A hostile buffer can describe unbounded nesting in as many bytes as it has: each 0x9F
         /// opens an indefinite array. Without a depth limit this is a stack overflow, so it must be
         /// refused — and refused distinguishably from malformed input.
@@ -138,6 +184,9 @@ namespace Dahomey.Cbor.Tests
             }
 
             Assert.Equal(CborDataItemStatus.TooDeep, CborDataItemScanner.Scan(deeplyNested, out _));
+            Assert.Equal(
+                CborDataItemStatus.TooDeep,
+                CborDataItemScanner.Scan(new ReadOnlySequence<byte>(deeplyNested), out long _));
         }
 
         [Fact]
@@ -155,42 +204,114 @@ namespace Dahomey.Cbor.Tests
 
             Assert.Equal(
                 CborDataItemStatus.Complete,
-                CborDataItemScanner.Scan(bytes.ToArray(), depth, out int length));
+                ScanAllShapes(bytes.ToArray(), new CborScanLimits(maxDepth: depth), out int length));
             Assert.Equal(depth, length);
 
             Assert.Equal(
                 CborDataItemStatus.TooDeep,
-                CborDataItemScanner.Scan(bytes.ToArray(), depth - 1, out _));
+                ScanAllShapes(bytes.ToArray(), new CborScanLimits(maxDepth: depth - 1), out _));
         }
 
         [Fact]
-        public void NonPositiveMaxDepthIsRejected()
+        public void NonPositiveLimitsAreRejected()
         {
-            byte[] buffer = "00".HexToBytes();
-
-            Assert.Throws<ArgumentOutOfRangeException>(
-                () => CborDataItemScanner.Scan(buffer, 0, out _));
-            Assert.Throws<ArgumentOutOfRangeException>(
-                () => CborDataItemScanner.Scan(buffer, -1, out _));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CborScanLimits(maxDepth: 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CborScanLimits(maxDepth: -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CborScanLimits(maxItemSize: 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CborScanLimits(maxItemSize: -1));
         }
 
         /// <summary>
-        /// A length that cannot possibly be satisfied reports Incomplete, not Malformed: the scanner
-        /// cannot know the stream will not eventually supply the bytes, and must not allocate or
-        /// overflow while deciding.
+        /// An uninitialised limits value must mean the defaults, not "no nesting and no bytes".
         /// </summary>
         [Fact]
-        public void AbsurdlyLargeStringLengthIsIncompleteNotFatal()
+        public void DefaultLimitsAreTheDocumentedDefaults()
         {
-            // bytes(0xFFFFFFFFFFFFFFFF) with no payload
-            Assert.Equal(
-                CborDataItemStatus.Incomplete,
-                Scan("5BFFFFFFFFFFFFFFFF", out _));
+            Assert.Equal(CborScanLimits.DefaultMaxDepth, default(CborScanLimits).MaxDepth);
+            Assert.Equal(CborScanLimits.UnlimitedItemSize, default(CborScanLimits).MaxItemSize);
+            Assert.Equal(CborDataItemScanner.DefaultMaxDepth, CborScanLimits.Default.MaxDepth);
+        }
 
-            // array with a huge declared item count
+        // ---- item size limit ----
+
+        /// <summary>
+        /// A merely large declared length is Incomplete when no limit is set: the scanner cannot know
+        /// the stream will not eventually supply the bytes, and must not allocate or overflow while
+        /// deciding. A length that no buffer could ever hold is a different matter — a
+        /// <see cref="ReadOnlySequence{T}"/> is bounded by <see cref="long.MaxValue"/>, so the bytes
+        /// are unobtainable rather than merely absent, and saying Incomplete would send a streaming
+        /// caller off to buffer for them forever.
+        /// </summary>
+        [Fact]
+        public void AbsurdlyLargeLengthsAreRefusedEvenWhenUnbounded()
+        {
+            // bytes(2147483647): big, but a caller could legitimately be receiving it.
+            Assert.Equal(CborDataItemStatus.Incomplete, Scan("5A7FFFFFFF", out _));
+
+            // bytes(0xFFFFFFFFFFFFFFFF) — 16 exabytes, beyond any possible buffer.
+            Assert.Equal(CborDataItemStatus.TooLarge, Scan("5BFFFFFFFFFFFFFFFF", out _));
+
+            // array with the same impossible item count, and each item costs at least a byte.
+            Assert.Equal(CborDataItemStatus.TooLarge, Scan("9BFFFFFFFFFFFFFFFF", out _));
+        }
+
+        /// <summary>
+        /// With an explicit cap the refusal comes far earlier, at whatever size the caller is actually
+        /// willing to hold, and still before a single payload byte has been read.
+        /// </summary>
+        [Theory]
+        [InlineData("5BFFFFFFFFFFFFFFFF")]  // bytes(2^64-1)
+        [InlineData("7BFFFFFFFFFFFFFFFF")]  // text(2^64-1)
+        [InlineData("9BFFFFFFFFFFFFFFFF")]  // array of 2^64-1 items
+        [InlineData("BBFFFFFFFFFFFFFFFF")]  // map of 2^64-1 pairs
+        [InlineData("5A7FFFFFFF")]          // bytes(2^31-1), a length that is merely unreasonable
+        public void DeclaredLengthsBeyondTheLimitAreTooLarge(string hexBuffer)
+        {
+            Assert.Equal(
+                CborDataItemStatus.TooLarge,
+                ScanAllShapes(hexBuffer.HexToBytes(), new CborScanLimits(maxItemSize: 1024), out _));
+        }
+
+        [Fact]
+        public void ItemsWithinTheLimitAreUnaffected()
+        {
+            byte[] item = "83010203".HexToBytes(); // [1, 2, 3], four bytes
+
+            Assert.Equal(
+                CborDataItemStatus.Complete,
+                ScanAllShapes(item, new CborScanLimits(maxItemSize: 4), out int length));
+            Assert.Equal(4, length);
+
+            Assert.Equal(
+                CborDataItemStatus.TooLarge,
+                ScanAllShapes(item, new CborScanLimits(maxItemSize: 3), out _));
+        }
+
+        /// <summary>
+        /// The limit bounds the whole item, so a nested payload cannot smuggle past a cap the
+        /// outermost header satisfied.
+        /// </summary>
+        [Fact]
+        public void TheLimitCoversNestedItems()
+        {
+            // [h'', bytes(1000000) …] — the outer array is small, its second element is not.
+            byte[] item = "82405A000F4240".HexToBytes();
+
+            Assert.Equal(
+                CborDataItemStatus.TooLarge,
+                ScanAllShapes(item, new CborScanLimits(maxItemSize: 1024), out _));
+        }
+
+        /// <summary>
+        /// TooLarge must not be reported for input that is merely truncated, or a streaming caller
+        /// would drop a live sequence.
+        /// </summary>
+        [Fact]
+        public void TruncatedItemsWithinTheLimitStayIncomplete()
+        {
             Assert.Equal(
                 CborDataItemStatus.Incomplete,
-                Scan("9BFFFFFFFFFFFFFFFF", out _));
+                ScanAllShapes("6449455446".HexToBytes().AsSpan(0, 3), new CborScanLimits(maxItemSize: 1024), out _));
         }
 
         // ---- sequence reading (RFC 8742) ----
@@ -270,6 +391,101 @@ namespace Dahomey.Cbor.Tests
             Assert.Equal(0, count);
         }
 
+        // ---- ReadOnlySequence input: the shape a PipeReader hands you ----
+
+        /// <summary>
+        /// The buffer a <c>PipeReader</c> yields is routinely multi-segment, and an item straddles
+        /// segment boundaries wherever the network happened to split it. Walking it in place is the
+        /// point of the sequence overloads: flattening first would reintroduce the copy that reading
+        /// incrementally exists to avoid.
+        /// </summary>
+        [Fact]
+        public void TryReadDataItemWalksASegmentedSequence()
+        {
+            // Same sequence as above, one byte per segment, so every item spans several segments.
+            ReadOnlySequence<byte> remaining = Helper.Fragmentize("016374776F820304".HexToBytes());
+            List<string> items = new List<string>();
+
+            while (CborDataItemScanner.TryReadDataItem(ref remaining, out ReadOnlySequence<byte> item))
+            {
+                items.Add(item.ToArray().BytesToHex().ToUpperInvariant());
+            }
+
+            Assert.Equal(new[] { "01", "6374776F", "820304" }, items);
+            Assert.True(remaining.IsEmpty);
+        }
+
+        [Fact]
+        public void TryReadDataItemLeavesTheIncompleteTailOfASequenceInPlace()
+        {
+            ReadOnlySequence<byte> remaining = Helper.Fragmentize("01637400".HexToBytes());
+
+            Assert.True(CborDataItemScanner.TryReadDataItem(ref remaining, out ReadOnlySequence<byte> first));
+            Assert.Equal("01", first.ToArray().BytesToHex().ToUpperInvariant());
+
+            Assert.False(CborDataItemScanner.TryReadDataItem(ref remaining, out _));
+            Assert.Equal(3, remaining.Length);
+            Assert.Equal("637400", remaining.ToArray().BytesToHex().ToUpperInvariant());
+
+            // The remainder is positioned for PipeReader.AdvanceTo(remaining.Start, remaining.End).
+            Assert.Equal("637400", remaining.Slice(0).ToArray().BytesToHex().ToUpperInvariant());
+        }
+
+        /// <summary>
+        /// A sequence arriving segment by segment is the streaming case in miniature: nothing is
+        /// readable until the last byte of an item lands, and then exactly one item is.
+        /// </summary>
+        [Fact]
+        public void ASegmentedSequenceYieldsItemsOnlyOnceComplete()
+        {
+            byte[] bytes = "6449455446".HexToBytes(); // "IETF"
+
+            for (int available = 0; available < bytes.Length; available++)
+            {
+                ReadOnlySequence<byte> partial = Helper.Fragmentize(bytes.AsSpan(0, available));
+                Assert.False(CborDataItemScanner.TryReadDataItem(ref partial, out _));
+                Assert.Equal(available, partial.Length); // untouched, so it can be re-examined
+            }
+
+            ReadOnlySequence<byte> complete = Helper.Fragmentize(bytes);
+            Assert.True(CborDataItemScanner.TryReadDataItem(ref complete, out ReadOnlySequence<byte> item));
+            Assert.Equal(bytes.Length, item.Length);
+            Assert.True(complete.IsEmpty);
+        }
+
+        [Fact]
+        public void ScanSequenceWalksASegmentedSequence()
+        {
+            Assert.Equal(
+                CborDataItemStatus.Complete,
+                CborDataItemScanner.ScanSequence(
+                    Helper.Fragmentize("016374776F820304".HexToBytes()), out long consumed, out int count));
+            Assert.Equal(8, consumed);
+            Assert.Equal(3, count);
+
+            Assert.Equal(
+                CborDataItemStatus.Incomplete,
+                CborDataItemScanner.ScanSequence(
+                    Helper.Fragmentize("016374776F8203".HexToBytes()), out long truncatedConsumed, out int truncatedCount));
+            Assert.Equal(5, truncatedConsumed);
+            Assert.Equal(2, truncatedCount);
+        }
+
+        [Fact]
+        public void TryGetDataItemLengthWorksOnBothShapes()
+        {
+            byte[] bytes = "83010203".HexToBytes();
+
+            Assert.True(CborDataItemScanner.TryGetDataItemLength(bytes, out int spanLength));
+            Assert.Equal(4, spanLength);
+
+            Assert.True(CborDataItemScanner.TryGetDataItemLength(Helper.Fragmentize(bytes), out long sequenceLength));
+            Assert.Equal(4, sequenceLength);
+
+            Assert.False(CborDataItemScanner.TryGetDataItemLength(bytes.AsSpan(0, 2), out _));
+            Assert.False(CborDataItemScanner.TryGetDataItemLength(Helper.Fragmentize(bytes.AsSpan(0, 2)), out long _));
+        }
+
         /// <summary>
         /// The scanner's lengths must agree with what the decoder actually consumes, otherwise a
         /// sequence walk would drift. Cross-checked against real serializer output.
@@ -290,7 +506,7 @@ namespace Dahomey.Cbor.Tests
             {
                 byte[] bytes = hexBuffer.HexToBytes();
 
-                Assert.Equal(CborDataItemStatus.Complete, CborDataItemScanner.Scan(bytes, out int length));
+                Assert.Equal(CborDataItemStatus.Complete, ScanAllShapes(bytes, out int length));
                 Assert.Equal(bytes.Length, length);
             }
         }

--- a/src/Dahomey.Cbor/Serialization/CborDataItemScanner.cs
+++ b/src/Dahomey.Cbor/Serialization/CborDataItemScanner.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 
 namespace Dahomey.Cbor.Serialization
@@ -18,9 +19,9 @@ namespace Dahomey.Cbor.Serialization
 
         /// <summary>
         /// The bytes cannot start a valid data item — a reserved additional-information value, an
-        /// indefinite length on a major type that does not allow one, a stray break, or an
-        /// indefinite-length string whose chunks are not definite-length strings of the same type.
-        /// More data will not help.
+        /// indefinite length on a major type that does not allow one, a stray break, a two-byte
+        /// simple value below 32, or an indefinite-length string whose chunks are not
+        /// definite-length strings of the same type. More data will not help.
         /// </summary>
         Malformed,
 
@@ -29,6 +30,79 @@ namespace Dahomey.Cbor.Serialization
         /// <see cref="Malformed"/>: the item may be well-formed but is refused as a resource guard.
         /// </summary>
         TooDeep,
+
+        /// <summary>
+        /// The item declares more bytes than <see cref="CborScanLimits.MaxItemSize"/> allows.
+        /// Like <see cref="TooDeep"/> this is a resource guard rather than a verdict on the bytes,
+        /// and unlike <see cref="Incomplete"/> it tells a streaming caller to stop buffering: the
+        /// item will not become acceptable however much more data arrives.
+        /// </summary>
+        TooLarge,
+    }
+
+    /// <summary>
+    /// Resource bounds applied while scanning. Both exist because a handful of bytes can describe an
+    /// arbitrarily large or arbitrarily deep item, so an unbounded scanner hands untrusted input a
+    /// denial-of-service lever.
+    /// </summary>
+    /// <remarks>
+    /// <c>default(CborScanLimits)</c> is <see cref="Default"/> rather than a pair of zeroes, so a
+    /// caller cannot accidentally ask for no nesting and no bytes.
+    /// </remarks>
+    public readonly struct CborScanLimits
+    {
+        /// <summary>
+        /// Default nesting limit. Matches <c>System.Formats.Cbor</c>'s conservative default and is far
+        /// above anything real data uses.
+        /// </summary>
+        public const int DefaultMaxDepth = 64;
+
+        /// <summary>Value of <see cref="MaxItemSize"/> that imposes no size limit.</summary>
+        public const long UnlimitedItemSize = long.MaxValue;
+
+        private readonly int _maxDepth;
+        private readonly long _maxItemSize;
+
+        /// <summary>Maximum nesting depth. A top-level scalar is depth 1.</summary>
+        public int MaxDepth => _maxDepth == 0 ? DefaultMaxDepth : _maxDepth;
+
+        /// <summary>
+        /// Maximum length in bytes of a single data item, including everything nested inside it.
+        /// </summary>
+        public long MaxItemSize => _maxItemSize == 0 ? UnlimitedItemSize : _maxItemSize;
+
+        /// <summary>The limits used by the overloads that do not take any.</summary>
+        public static CborScanLimits Default => default;
+
+        /// <param name="maxDepth">Maximum nesting depth. Must be positive.</param>
+        /// <param name="maxItemSize">
+        /// Maximum length in bytes of a single data item. Must be positive; defaults to no limit.
+        /// <para>
+        /// Worth setting when scanning an untrusted stream. A declared length is believed long before
+        /// its bytes arrive — <c>5B FF FF FF FF FF FF FF FF</c> is nine bytes announcing a 16-exabyte
+        /// byte string — and without a cap the scanner can only answer
+        /// <see cref="CborDataItemStatus.Incomplete"/>, leaving the caller to buffer forever for bytes
+        /// that will never come. With a cap the same input is
+        /// <see cref="CborDataItemStatus.TooLarge"/> on the first nine bytes, before anything is
+        /// allocated. The bound is checked against declared lengths and item counts, so it holds even
+        /// for an item whose payload has not been received.
+        /// </para>
+        /// </param>
+        public CborScanLimits(int maxDepth = DefaultMaxDepth, long maxItemSize = UnlimitedItemSize)
+        {
+            if (maxDepth <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxDepth), maxDepth, "maxDepth must be positive.");
+            }
+
+            if (maxItemSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxItemSize), maxItemSize, "maxItemSize must be positive.");
+            }
+
+            _maxDepth = maxDepth;
+            _maxItemSize = maxItemSize;
+        }
     }
 
     /// <summary>
@@ -42,26 +116,34 @@ namespace Dahomey.Cbor.Serialization
     /// expected condition — cost an exception; scanning first is both cheaper and clearer.
     ///
     /// <para>
-    /// Scanning is structural only: it walks headers and skips payloads. It does not validate string
-    /// contents, tag semantics, or map key uniqueness, and it accepts non-preferred integer
-    /// encodings. <see cref="CborDataItemStatus.Complete"/> therefore means "a decoder will find a
-    /// whole item here", not "this item is canonical".
+    /// Both a <see cref="ReadOnlySpan{T}"/> and a <see cref="ReadOnlySequence{T}"/> can be scanned.
+    /// The sequence overloads are the ones a streaming caller wants: <c>PipeReader.ReadAsync</c>
+    /// hands back a routinely multi-segment <see cref="ReadOnlySequence{T}"/>, and this scanner walks
+    /// it across segment boundaries rather than requiring it to be flattened into a contiguous buffer
+    /// first. The span overloads remain the fast path for data that is already contiguous, and a
+    /// single-segment sequence is dispatched to them.
     /// </para>
     /// <para>
-    /// Nesting depth is bounded (<see cref="DefaultMaxDepth"/>) so that hostile input cannot exhaust
-    /// the stack — a buffer of <c>9F</c> bytes describes unbounded nesting in as many bytes as it has.
+    /// Scanning is structural only: it walks headers and skips payloads. It does not validate UTF-8,
+    /// tag semantics, or map key uniqueness, and it accepts non-preferred integer encodings.
+    /// <see cref="CborDataItemStatus.Complete"/> therefore means "a decoder will find a whole item
+    /// here", not "this item is canonical".
+    /// </para>
+    /// <para>
+    /// Nesting depth and item size are bounded (see <see cref="CborScanLimits"/>) so that hostile
+    /// input cannot exhaust the stack or the heap — a buffer of <c>9F</c> bytes describes unbounded
+    /// nesting in as many bytes as it has.
     /// </para>
     /// </remarks>
     public static class CborDataItemScanner
     {
-        /// <summary>
-        /// Default nesting limit. Matches <c>System.Formats.Cbor</c>'s conservative default and is far
-        /// above anything real data uses.
-        /// </summary>
-        public const int DefaultMaxDepth = 64;
+        /// <inheritdoc cref="CborScanLimits.DefaultMaxDepth"/>
+        public const int DefaultMaxDepth = CborScanLimits.DefaultMaxDepth;
 
         private const byte BreakByte = 0xFF;
         private const int IndefiniteLength = 31;
+
+        // ---- span ----
 
         /// <summary>
         /// Determines the length of the data item at the start of <paramref name="buffer"/>.
@@ -73,25 +155,18 @@ namespace Dahomey.Cbor.Serialization
         /// </param>
         public static CborDataItemStatus Scan(ReadOnlySpan<byte> buffer, out int length)
         {
-            return Scan(buffer, DefaultMaxDepth, out length);
+            return Scan(buffer, CborScanLimits.Default, out length);
         }
 
         /// <summary>
-        /// Determines the length of the data item at the start of <paramref name="buffer"/>, with an
-        /// explicit nesting limit.
+        /// Determines the length of the data item at the start of <paramref name="buffer"/>, with
+        /// explicit resource bounds.
         /// </summary>
-        /// <param name="maxDepth">
-        /// Maximum nesting depth. A top-level scalar is depth 1. Must be positive.
-        /// </param>
-        public static CborDataItemStatus Scan(ReadOnlySpan<byte> buffer, int maxDepth, out int length)
+        public static CborDataItemStatus Scan(
+            ReadOnlySpan<byte> buffer, CborScanLimits limits, out int length)
         {
-            if (maxDepth <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maxDepth), maxDepth, "maxDepth must be positive.");
-            }
-
             int position = 0;
-            CborDataItemStatus status = ScanItem(buffer, ref position, maxDepth);
+            CborDataItemStatus status = ScanItem(buffer, ref position, limits.MaxDepth, limits.MaxItemSize);
             length = position;
             return status;
         }
@@ -102,7 +177,7 @@ namespace Dahomey.Cbor.Serialization
         /// <returns>true only when a complete data item is present.</returns>
         public static bool TryGetDataItemLength(ReadOnlySpan<byte> buffer, out int length)
         {
-            return Scan(buffer, DefaultMaxDepth, out length) == CborDataItemStatus.Complete;
+            return Scan(buffer, CborScanLimits.Default, out length) == CborDataItemStatus.Complete;
         }
 
         /// <summary>
@@ -124,7 +199,14 @@ namespace Dahomey.Cbor.Serialization
         /// </returns>
         public static bool TryReadDataItem(ref ReadOnlySpan<byte> buffer, out ReadOnlySpan<byte> item)
         {
-            if (Scan(buffer, DefaultMaxDepth, out int length) != CborDataItemStatus.Complete)
+            return TryReadDataItem(ref buffer, CborScanLimits.Default, out item);
+        }
+
+        /// <inheritdoc cref="TryReadDataItem(ref ReadOnlySpan{byte}, out ReadOnlySpan{byte})"/>
+        public static bool TryReadDataItem(
+            ref ReadOnlySpan<byte> buffer, CborScanLimits limits, out ReadOnlySpan<byte> item)
+        {
+            if (Scan(buffer, limits, out int length) != CborDataItemStatus.Complete)
             {
                 item = default;
                 return false;
@@ -145,17 +227,25 @@ namespace Dahomey.Cbor.Serialization
         /// The status that stopped the scan: <see cref="CborDataItemStatus.Complete"/> when the buffer
         /// ended exactly on an item boundary, <see cref="CborDataItemStatus.Incomplete"/> when a
         /// partial item trails, or <see cref="CborDataItemStatus.Malformed"/> /
-        /// <see cref="CborDataItemStatus.TooDeep"/> when the remainder cannot be scanned.
+        /// <see cref="CborDataItemStatus.TooDeep"/> / <see cref="CborDataItemStatus.TooLarge"/> when
+        /// the remainder cannot be scanned.
         /// </returns>
         public static CborDataItemStatus ScanSequence(
             ReadOnlySpan<byte> buffer, out int consumed, out int count)
+        {
+            return ScanSequence(buffer, CborScanLimits.Default, out consumed, out count);
+        }
+
+        /// <inheritdoc cref="ScanSequence(ReadOnlySpan{byte}, out int, out int)"/>
+        public static CborDataItemStatus ScanSequence(
+            ReadOnlySpan<byte> buffer, CborScanLimits limits, out int consumed, out int count)
         {
             consumed = 0;
             count = 0;
 
             while (consumed < buffer.Length)
             {
-                CborDataItemStatus status = Scan(buffer.Slice(consumed), DefaultMaxDepth, out int length);
+                CborDataItemStatus status = Scan(buffer.Slice(consumed), limits, out int length);
 
                 if (status != CborDataItemStatus.Complete)
                 {
@@ -169,12 +259,136 @@ namespace Dahomey.Cbor.Serialization
             return CborDataItemStatus.Complete;
         }
 
+        // ---- sequence ----
+
+        /// <summary>
+        /// Determines the length of the data item at the start of <paramref name="buffer"/>, walking
+        /// segment boundaries rather than requiring a contiguous buffer.
+        /// </summary>
+        /// <remarks>
+        /// This is the shape a streaming caller has: <c>PipeReader.ReadAsync</c> yields a
+        /// <see cref="ReadOnlySequence{T}"/> that is frequently multi-segment, and flattening it
+        /// before every scan would reintroduce the copy that reading incrementally is meant to avoid.
+        /// </remarks>
+        public static CborDataItemStatus Scan(in ReadOnlySequence<byte> buffer, out long length)
+        {
+            return Scan(buffer, CborScanLimits.Default, out length);
+        }
+
+        /// <inheritdoc cref="Scan(in ReadOnlySequence{byte}, out long)"/>
+        public static CborDataItemStatus Scan(
+            in ReadOnlySequence<byte> buffer, CborScanLimits limits, out long length)
+        {
+            // A contiguous sequence is exactly the span case; take the cheaper path.
+            if (buffer.IsSingleSegment)
+            {
+                CborDataItemStatus spanStatus = Scan(buffer.First.Span, limits, out int spanLength);
+                length = spanLength;
+                return spanStatus;
+            }
+
+            SequenceReader<byte> reader = new SequenceReader<byte>(buffer);
+            CborDataItemStatus status = ScanItem(ref reader, limits.MaxDepth, limits.MaxItemSize);
+            length = reader.Consumed;
+            return status;
+        }
+
+        /// <summary>
+        /// Convenience wrapper over <see cref="Scan(in ReadOnlySequence{byte}, out long)"/>.
+        /// </summary>
+        /// <returns>true only when a complete data item is present.</returns>
+        public static bool TryGetDataItemLength(in ReadOnlySequence<byte> buffer, out long length)
+        {
+            return Scan(buffer, CborScanLimits.Default, out length) == CborDataItemStatus.Complete;
+        }
+
+        /// <summary>
+        /// Reads one complete data item off the front of <paramref name="buffer"/>, advancing it past
+        /// what was consumed. The streaming counterpart of
+        /// <see cref="TryReadDataItem(ref ReadOnlySpan{byte}, out ReadOnlySpan{byte})"/>:
+        /// <code>
+        /// ReadResult result = await pipeReader.ReadAsync(token);
+        /// ReadOnlySequence&lt;byte&gt; remaining = result.Buffer;
+        /// while (CborDataItemScanner.TryReadDataItem(ref remaining, out ReadOnlySequence&lt;byte&gt; item))
+        /// {
+        ///     Handle(Cbor.Deserialize&lt;T&gt;(item, options));
+        /// }
+        /// pipeReader.AdvanceTo(remaining.Start, remaining.End);
+        /// </code>
+        /// Because <paramref name="buffer"/> is left at the start of the incomplete tail, it can be
+        /// handed straight back to <c>PipeReader.AdvanceTo</c> as the consumed position.
+        /// </summary>
+        /// <returns>
+        /// true when an item was read; false when the buffer is empty, holds only a partial item, or
+        /// starts with bytes that cannot be scanned. <paramref name="buffer"/> is left untouched when
+        /// false.
+        /// </returns>
+        public static bool TryReadDataItem(
+            ref ReadOnlySequence<byte> buffer, out ReadOnlySequence<byte> item)
+        {
+            return TryReadDataItem(ref buffer, CborScanLimits.Default, out item);
+        }
+
+        /// <inheritdoc cref="TryReadDataItem(ref ReadOnlySequence{byte}, out ReadOnlySequence{byte})"/>
+        public static bool TryReadDataItem(
+            ref ReadOnlySequence<byte> buffer, CborScanLimits limits, out ReadOnlySequence<byte> item)
+        {
+            if (Scan(buffer, limits, out long length) != CborDataItemStatus.Complete)
+            {
+                item = default;
+                return false;
+            }
+
+            item = buffer.Slice(0, length);
+            buffer = buffer.Slice(length);
+            return true;
+        }
+
+        /// <inheritdoc cref="ScanSequence(ReadOnlySpan{byte}, out int, out int)"/>
+        public static CborDataItemStatus ScanSequence(
+            in ReadOnlySequence<byte> buffer, out long consumed, out int count)
+        {
+            return ScanSequence(buffer, CborScanLimits.Default, out consumed, out count);
+        }
+
+        /// <inheritdoc cref="ScanSequence(ReadOnlySpan{byte}, out int, out int)"/>
+        public static CborDataItemStatus ScanSequence(
+            in ReadOnlySequence<byte> buffer, CborScanLimits limits, out long consumed, out int count)
+        {
+            consumed = 0;
+            count = 0;
+
+            long total = buffer.Length;
+
+            while (consumed < total)
+            {
+                CborDataItemStatus status = Scan(buffer.Slice(consumed), limits, out long length);
+
+                if (status != CborDataItemStatus.Complete)
+                {
+                    return status;
+                }
+
+                consumed += length;
+                count++;
+            }
+
+            return CborDataItemStatus.Complete;
+        }
+
+        // ---- span implementation ----
+
         private static CborDataItemStatus ScanItem(
-            ReadOnlySpan<byte> buffer, ref int position, int remainingDepth)
+            ReadOnlySpan<byte> buffer, ref int position, int remainingDepth, long maxItemSize)
         {
             if (remainingDepth <= 0)
             {
                 return CborDataItemStatus.TooDeep;
+            }
+
+            if (position >= maxItemSize)
+            {
+                return CborDataItemStatus.TooLarge;
             }
 
             if (position >= buffer.Length)
@@ -188,7 +402,7 @@ namespace Dahomey.Cbor.Serialization
 
             if (additionalInfo == IndefiniteLength)
             {
-                return ScanIndefinite(buffer, ref position, remainingDepth, majorType);
+                return ScanIndefinite(buffer, ref position, remainingDepth, maxItemSize, majorType);
             }
 
             CborDataItemStatus argumentStatus = ReadArgument(buffer, ref position, additionalInfo, out ulong argument);
@@ -201,11 +415,18 @@ namespace Dahomey.Cbor.Serialization
             {
                 case 0: // unsigned integer
                 case 1: // negative integer
-                case 7: // floating point / simple value — the argument is the whole payload
                     return CborDataItemStatus.Complete;
+
+                case 7: // floating point / simple value — the argument is the whole payload
+                    return CheckSimpleValue(additionalInfo, argument);
 
                 case 2: // byte string
                 case 3: // text string — `argument` bytes of payload follow
+                    if (ExceedsMaxItemSize(argument, position, maxItemSize, bytesPerUnit: 1))
+                    {
+                        return CborDataItemStatus.TooLarge;
+                    }
+
                     if (argument > (ulong)(buffer.Length - position))
                     {
                         return CborDataItemStatus.Incomplete;
@@ -215,6 +436,13 @@ namespace Dahomey.Cbor.Serialization
                     return CborDataItemStatus.Complete;
 
                 case 4: // array — `argument` items follow
+                    // Every item costs at least one byte, so a count the size limit cannot afford is
+                    // refused here rather than after the caller has buffered its way towards it.
+                    if (ExceedsMaxItemSize(argument, position, maxItemSize, bytesPerUnit: 1))
+                    {
+                        return CborDataItemStatus.TooLarge;
+                    }
+
                     for (ulong i = 0; i < argument; i++)
                     {
                         // Bail out early rather than spin on a huge count we can never satisfy.
@@ -223,7 +451,7 @@ namespace Dahomey.Cbor.Serialization
                             return CborDataItemStatus.Incomplete;
                         }
 
-                        CborDataItemStatus status = ScanItem(buffer, ref position, remainingDepth - 1);
+                        CborDataItemStatus status = ScanItem(buffer, ref position, remainingDepth - 1, maxItemSize);
                         if (status != CborDataItemStatus.Complete)
                         {
                             return status;
@@ -233,6 +461,11 @@ namespace Dahomey.Cbor.Serialization
                     return CborDataItemStatus.Complete;
 
                 case 5: // map — `argument` key/value pairs follow
+                    if (ExceedsMaxItemSize(argument, position, maxItemSize, bytesPerUnit: 2))
+                    {
+                        return CborDataItemStatus.TooLarge;
+                    }
+
                     for (ulong i = 0; i < argument; i++)
                     {
                         if (position >= buffer.Length)
@@ -240,13 +473,13 @@ namespace Dahomey.Cbor.Serialization
                             return CborDataItemStatus.Incomplete;
                         }
 
-                        CborDataItemStatus keyStatus = ScanItem(buffer, ref position, remainingDepth - 1);
+                        CborDataItemStatus keyStatus = ScanItem(buffer, ref position, remainingDepth - 1, maxItemSize);
                         if (keyStatus != CborDataItemStatus.Complete)
                         {
                             return keyStatus;
                         }
 
-                        CborDataItemStatus valueStatus = ScanItem(buffer, ref position, remainingDepth - 1);
+                        CborDataItemStatus valueStatus = ScanItem(buffer, ref position, remainingDepth - 1, maxItemSize);
                         if (valueStatus != CborDataItemStatus.Complete)
                         {
                             return valueStatus;
@@ -256,7 +489,7 @@ namespace Dahomey.Cbor.Serialization
                     return CborDataItemStatus.Complete;
 
                 case 6: // semantic tag — exactly one tagged item follows
-                    return ScanItem(buffer, ref position, remainingDepth - 1);
+                    return ScanItem(buffer, ref position, remainingDepth - 1, maxItemSize);
 
                 default:
                     return CborDataItemStatus.Malformed;
@@ -264,7 +497,7 @@ namespace Dahomey.Cbor.Serialization
         }
 
         private static CborDataItemStatus ScanIndefinite(
-            ReadOnlySpan<byte> buffer, ref int position, int remainingDepth, int majorType)
+            ReadOnlySpan<byte> buffer, ref int position, int remainingDepth, long maxItemSize, int majorType)
         {
             switch (majorType)
             {
@@ -273,6 +506,11 @@ namespace Dahomey.Cbor.Serialization
                     // RFC 8949: chunks must be definite-length strings of the same major type.
                     while (true)
                     {
+                        if (position >= maxItemSize)
+                        {
+                            return CborDataItemStatus.TooLarge;
+                        }
+
                         if (position >= buffer.Length)
                         {
                             return CborDataItemStatus.Incomplete;
@@ -292,7 +530,7 @@ namespace Dahomey.Cbor.Serialization
                             return CborDataItemStatus.Malformed;
                         }
 
-                        CborDataItemStatus status = ScanItem(buffer, ref position, remainingDepth - 1);
+                        CborDataItemStatus status = ScanItem(buffer, ref position, remainingDepth - 1, maxItemSize);
                         if (status != CborDataItemStatus.Complete)
                         {
                             return status;
@@ -302,6 +540,11 @@ namespace Dahomey.Cbor.Serialization
                 case 4: // indefinite-length array
                     while (true)
                     {
+                        if (position >= maxItemSize)
+                        {
+                            return CborDataItemStatus.TooLarge;
+                        }
+
                         if (position >= buffer.Length)
                         {
                             return CborDataItemStatus.Incomplete;
@@ -313,7 +556,7 @@ namespace Dahomey.Cbor.Serialization
                             return CborDataItemStatus.Complete;
                         }
 
-                        CborDataItemStatus status = ScanItem(buffer, ref position, remainingDepth - 1);
+                        CborDataItemStatus status = ScanItem(buffer, ref position, remainingDepth - 1, maxItemSize);
                         if (status != CborDataItemStatus.Complete)
                         {
                             return status;
@@ -323,6 +566,11 @@ namespace Dahomey.Cbor.Serialization
                 case 5: // indefinite-length map
                     while (true)
                     {
+                        if (position >= maxItemSize)
+                        {
+                            return CborDataItemStatus.TooLarge;
+                        }
+
                         if (position >= buffer.Length)
                         {
                             return CborDataItemStatus.Incomplete;
@@ -334,7 +582,7 @@ namespace Dahomey.Cbor.Serialization
                             return CborDataItemStatus.Complete;
                         }
 
-                        CborDataItemStatus keyStatus = ScanItem(buffer, ref position, remainingDepth - 1);
+                        CborDataItemStatus keyStatus = ScanItem(buffer, ref position, remainingDepth - 1, maxItemSize);
                         if (keyStatus != CborDataItemStatus.Complete)
                         {
                             return keyStatus;
@@ -346,7 +594,7 @@ namespace Dahomey.Cbor.Serialization
                             return CborDataItemStatus.Malformed;
                         }
 
-                        CborDataItemStatus valueStatus = ScanItem(buffer, ref position, remainingDepth - 1);
+                        CborDataItemStatus valueStatus = ScanItem(buffer, ref position, remainingDepth - 1, maxItemSize);
                         if (valueStatus != CborDataItemStatus.Complete)
                         {
                             return valueStatus;
@@ -418,6 +666,330 @@ namespace Dahomey.Cbor.Serialization
                     // 28, 29 and 30 are reserved by RFC 8949.
                     return CborDataItemStatus.Malformed;
             }
+        }
+
+        // ---- sequence implementation ----
+        //
+        // A deliberate mirror of the span implementation above rather than a shared one: the two
+        // cursors are a `ref int` into a span and a `SequenceReader<byte>`, and a ref struct cannot be
+        // a generic type argument on netstandard2.0, so there is no way to write the walk once without
+        // pushing the contiguous case through SequenceReader and paying for it there. The tests scan
+        // every corpus entry as a span, as a single-segment sequence and as a byte-per-segment
+        // sequence, and assert all three agree — that equivalence is what keeps the two in step.
+
+        private static CborDataItemStatus ScanItem(
+            ref SequenceReader<byte> reader, int remainingDepth, long maxItemSize)
+        {
+            if (remainingDepth <= 0)
+            {
+                return CborDataItemStatus.TooDeep;
+            }
+
+            if (reader.Consumed >= maxItemSize)
+            {
+                return CborDataItemStatus.TooLarge;
+            }
+
+            if (!reader.TryRead(out byte initialByte))
+            {
+                return CborDataItemStatus.Incomplete;
+            }
+
+            int majorType = initialByte >> 5;
+            int additionalInfo = initialByte & 0x1F;
+
+            if (additionalInfo == IndefiniteLength)
+            {
+                return ScanIndefinite(ref reader, remainingDepth, maxItemSize, majorType);
+            }
+
+            CborDataItemStatus argumentStatus = ReadArgument(ref reader, additionalInfo, out ulong argument);
+            if (argumentStatus != CborDataItemStatus.Complete)
+            {
+                return argumentStatus;
+            }
+
+            switch (majorType)
+            {
+                case 0: // unsigned integer
+                case 1: // negative integer
+                    return CborDataItemStatus.Complete;
+
+                case 7: // floating point / simple value
+                    return CheckSimpleValue(additionalInfo, argument);
+
+                case 2: // byte string
+                case 3: // text string
+                    if (ExceedsMaxItemSize(argument, reader.Consumed, maxItemSize, bytesPerUnit: 1))
+                    {
+                        return CborDataItemStatus.TooLarge;
+                    }
+
+                    if (argument > (ulong)reader.Remaining)
+                    {
+                        return CborDataItemStatus.Incomplete;
+                    }
+
+                    reader.Advance((long)argument);
+                    return CborDataItemStatus.Complete;
+
+                case 4: // array
+                    if (ExceedsMaxItemSize(argument, reader.Consumed, maxItemSize, bytesPerUnit: 1))
+                    {
+                        return CborDataItemStatus.TooLarge;
+                    }
+
+                    for (ulong i = 0; i < argument; i++)
+                    {
+                        if (reader.End)
+                        {
+                            return CborDataItemStatus.Incomplete;
+                        }
+
+                        CborDataItemStatus status = ScanItem(ref reader, remainingDepth - 1, maxItemSize);
+                        if (status != CborDataItemStatus.Complete)
+                        {
+                            return status;
+                        }
+                    }
+
+                    return CborDataItemStatus.Complete;
+
+                case 5: // map
+                    if (ExceedsMaxItemSize(argument, reader.Consumed, maxItemSize, bytesPerUnit: 2))
+                    {
+                        return CborDataItemStatus.TooLarge;
+                    }
+
+                    for (ulong i = 0; i < argument; i++)
+                    {
+                        if (reader.End)
+                        {
+                            return CborDataItemStatus.Incomplete;
+                        }
+
+                        CborDataItemStatus keyStatus = ScanItem(ref reader, remainingDepth - 1, maxItemSize);
+                        if (keyStatus != CborDataItemStatus.Complete)
+                        {
+                            return keyStatus;
+                        }
+
+                        CborDataItemStatus valueStatus = ScanItem(ref reader, remainingDepth - 1, maxItemSize);
+                        if (valueStatus != CborDataItemStatus.Complete)
+                        {
+                            return valueStatus;
+                        }
+                    }
+
+                    return CborDataItemStatus.Complete;
+
+                case 6: // semantic tag
+                    return ScanItem(ref reader, remainingDepth - 1, maxItemSize);
+
+                default:
+                    return CborDataItemStatus.Malformed;
+            }
+        }
+
+        private static CborDataItemStatus ScanIndefinite(
+            ref SequenceReader<byte> reader, int remainingDepth, long maxItemSize, int majorType)
+        {
+            switch (majorType)
+            {
+                case 2: // indefinite-length byte string
+                case 3: // indefinite-length text string
+                    while (true)
+                    {
+                        if (reader.Consumed >= maxItemSize)
+                        {
+                            return CborDataItemStatus.TooLarge;
+                        }
+
+                        if (!reader.TryPeek(out byte next))
+                        {
+                            return CborDataItemStatus.Incomplete;
+                        }
+
+                        if (next == BreakByte)
+                        {
+                            reader.Advance(1);
+                            return CborDataItemStatus.Complete;
+                        }
+
+                        int chunkMajorType = next >> 5;
+                        int chunkAdditionalInfo = next & 0x1F;
+
+                        if (chunkMajorType != majorType || chunkAdditionalInfo == IndefiniteLength)
+                        {
+                            return CborDataItemStatus.Malformed;
+                        }
+
+                        CborDataItemStatus status = ScanItem(ref reader, remainingDepth - 1, maxItemSize);
+                        if (status != CborDataItemStatus.Complete)
+                        {
+                            return status;
+                        }
+                    }
+
+                case 4: // indefinite-length array
+                    while (true)
+                    {
+                        if (reader.Consumed >= maxItemSize)
+                        {
+                            return CborDataItemStatus.TooLarge;
+                        }
+
+                        if (!reader.TryPeek(out byte next))
+                        {
+                            return CborDataItemStatus.Incomplete;
+                        }
+
+                        if (next == BreakByte)
+                        {
+                            reader.Advance(1);
+                            return CborDataItemStatus.Complete;
+                        }
+
+                        CborDataItemStatus status = ScanItem(ref reader, remainingDepth - 1, maxItemSize);
+                        if (status != CborDataItemStatus.Complete)
+                        {
+                            return status;
+                        }
+                    }
+
+                case 5: // indefinite-length map
+                    while (true)
+                    {
+                        if (reader.Consumed >= maxItemSize)
+                        {
+                            return CborDataItemStatus.TooLarge;
+                        }
+
+                        if (!reader.TryPeek(out byte next))
+                        {
+                            return CborDataItemStatus.Incomplete;
+                        }
+
+                        if (next == BreakByte)
+                        {
+                            reader.Advance(1);
+                            return CborDataItemStatus.Complete;
+                        }
+
+                        CborDataItemStatus keyStatus = ScanItem(ref reader, remainingDepth - 1, maxItemSize);
+                        if (keyStatus != CborDataItemStatus.Complete)
+                        {
+                            return keyStatus;
+                        }
+
+                        // A map must not end between a key and its value.
+                        if (reader.TryPeek(out byte afterKey) && afterKey == BreakByte)
+                        {
+                            return CborDataItemStatus.Malformed;
+                        }
+
+                        CborDataItemStatus valueStatus = ScanItem(ref reader, remainingDepth - 1, maxItemSize);
+                        if (valueStatus != CborDataItemStatus.Complete)
+                        {
+                            return valueStatus;
+                        }
+                    }
+
+                default:
+                    return CborDataItemStatus.Malformed;
+            }
+        }
+
+        private static CborDataItemStatus ReadArgument(
+            ref SequenceReader<byte> reader, int additionalInfo, out ulong argument)
+        {
+            argument = 0;
+
+            if (additionalInfo <= 23)
+            {
+                argument = (ulong)additionalInfo;
+                return CborDataItemStatus.Complete;
+            }
+
+            int argumentLength;
+
+            switch (additionalInfo)
+            {
+                case 24: argumentLength = 1; break;
+                case 25: argumentLength = 2; break;
+                case 26: argumentLength = 4; break;
+                case 27: argumentLength = 8; break;
+
+                default:
+                    // 28, 29 and 30 are reserved by RFC 8949.
+                    return CborDataItemStatus.Malformed;
+            }
+
+            Span<byte> bytes = stackalloc byte[8];
+            Span<byte> argumentBytes = bytes.Slice(0, argumentLength);
+
+            if (!reader.TryCopyTo(argumentBytes))
+            {
+                return CborDataItemStatus.Incomplete;
+            }
+
+            reader.Advance(argumentLength);
+
+            switch (argumentLength)
+            {
+                case 1:
+                    argument = argumentBytes[0];
+                    break;
+
+                case 2:
+                    argument = BinaryPrimitives.ReadUInt16BigEndian(argumentBytes);
+                    break;
+
+                case 4:
+                    argument = BinaryPrimitives.ReadUInt32BigEndian(argumentBytes);
+                    break;
+
+                default:
+                    argument = BinaryPrimitives.ReadUInt64BigEndian(argumentBytes);
+                    break;
+            }
+
+            return CborDataItemStatus.Complete;
+        }
+
+        // ---- shared checks ----
+
+        /// <summary>
+        /// RFC 8949 §3.3: the two-byte form of major type 7 must not encode a value below 32, because
+        /// those simple values have a one-byte form. A decoder rejects such input, so reporting
+        /// <see cref="CborDataItemStatus.Complete"/> would break the contract that a complete scan
+        /// means a decoder will find a whole item here.
+        /// </summary>
+        private static CborDataItemStatus CheckSimpleValue(int additionalInfo, ulong argument)
+        {
+            if (additionalInfo == 24 && argument < 32)
+            {
+                return CborDataItemStatus.Malformed;
+            }
+
+            return CborDataItemStatus.Complete;
+        }
+
+        /// <summary>
+        /// Decides whether a declared count busts the size limit, given that each unit — a payload
+        /// byte, an array item, or a map key/value pair — costs at least
+        /// <paramref name="bytesPerUnit"/> bytes. Phrased as a division so that a count near
+        /// <see cref="ulong.MaxValue"/> cannot overflow into looking affordable.
+        /// </summary>
+        private static bool ExceedsMaxItemSize(ulong count, long position, long maxItemSize, int bytesPerUnit)
+        {
+            if (position >= maxItemSize)
+            {
+                return true;
+            }
+
+            ulong affordable = (ulong)(maxItemSize - position) / (ulong)bytesPerUnit;
+            return count > affordable;
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/CborDataItemScanner.cs
+++ b/src/Dahomey.Cbor/Serialization/CborDataItemScanner.cs
@@ -1,0 +1,423 @@
+using System;
+using System.Buffers.Binary;
+
+namespace Dahomey.Cbor.Serialization
+{
+    /// <summary>
+    /// Outcome of scanning a buffer for one CBOR data item.
+    /// </summary>
+    public enum CborDataItemStatus
+    {
+        /// <summary>A complete data item is present.</summary>
+        Complete,
+
+        /// <summary>
+        /// The buffer ends part-way through a data item. Not an error: read more bytes and retry.
+        /// </summary>
+        Incomplete,
+
+        /// <summary>
+        /// The bytes cannot start a valid data item — a reserved additional-information value, an
+        /// indefinite length on a major type that does not allow one, a stray break, or an
+        /// indefinite-length string whose chunks are not definite-length strings of the same type.
+        /// More data will not help.
+        /// </summary>
+        Malformed,
+
+        /// <summary>
+        /// Nesting exceeded the permitted depth. Deliberately distinct from
+        /// <see cref="Malformed"/>: the item may be well-formed but is refused as a resource guard.
+        /// </summary>
+        TooDeep,
+    }
+
+    /// <summary>
+    /// Determines the byte length of a CBOR data item without decoding it, and without throwing on
+    /// truncated input.
+    /// </summary>
+    /// <remarks>
+    /// This is the primitive needed to read CBOR sequences (RFC 8742) and to consume CBOR from a
+    /// stream, where a buffer routinely ends in the middle of an item. Asking a decoder to parse and
+    /// catching its "unexpected end of buffer" exception works but makes truncation — an ordinary,
+    /// expected condition — cost an exception; scanning first is both cheaper and clearer.
+    ///
+    /// <para>
+    /// Scanning is structural only: it walks headers and skips payloads. It does not validate string
+    /// contents, tag semantics, or map key uniqueness, and it accepts non-preferred integer
+    /// encodings. <see cref="CborDataItemStatus.Complete"/> therefore means "a decoder will find a
+    /// whole item here", not "this item is canonical".
+    /// </para>
+    /// <para>
+    /// Nesting depth is bounded (<see cref="DefaultMaxDepth"/>) so that hostile input cannot exhaust
+    /// the stack — a buffer of <c>9F</c> bytes describes unbounded nesting in as many bytes as it has.
+    /// </para>
+    /// </remarks>
+    public static class CborDataItemScanner
+    {
+        /// <summary>
+        /// Default nesting limit. Matches <c>System.Formats.Cbor</c>'s conservative default and is far
+        /// above anything real data uses.
+        /// </summary>
+        public const int DefaultMaxDepth = 64;
+
+        private const byte BreakByte = 0xFF;
+        private const int IndefiniteLength = 31;
+
+        /// <summary>
+        /// Determines the length of the data item at the start of <paramref name="buffer"/>.
+        /// </summary>
+        /// <param name="buffer">Bytes to scan. Only the leading data item is considered.</param>
+        /// <param name="length">
+        /// The item's length in bytes when the result is <see cref="CborDataItemStatus.Complete"/>;
+        /// otherwise the number of bytes consumed before scanning stopped, which is not meaningful.
+        /// </param>
+        public static CborDataItemStatus Scan(ReadOnlySpan<byte> buffer, out int length)
+        {
+            return Scan(buffer, DefaultMaxDepth, out length);
+        }
+
+        /// <summary>
+        /// Determines the length of the data item at the start of <paramref name="buffer"/>, with an
+        /// explicit nesting limit.
+        /// </summary>
+        /// <param name="maxDepth">
+        /// Maximum nesting depth. A top-level scalar is depth 1. Must be positive.
+        /// </param>
+        public static CborDataItemStatus Scan(ReadOnlySpan<byte> buffer, int maxDepth, out int length)
+        {
+            if (maxDepth <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxDepth), maxDepth, "maxDepth must be positive.");
+            }
+
+            int position = 0;
+            CborDataItemStatus status = ScanItem(buffer, ref position, maxDepth);
+            length = position;
+            return status;
+        }
+
+        /// <summary>
+        /// Convenience wrapper over <see cref="Scan(ReadOnlySpan{byte}, out int)"/>.
+        /// </summary>
+        /// <returns>true only when a complete data item is present.</returns>
+        public static bool TryGetDataItemLength(ReadOnlySpan<byte> buffer, out int length)
+        {
+            return Scan(buffer, DefaultMaxDepth, out length) == CborDataItemStatus.Complete;
+        }
+
+        /// <summary>
+        /// Reads one complete data item off the front of <paramref name="buffer"/>, advancing it past
+        /// what was consumed. Intended for iterating a CBOR sequence (RFC 8742):
+        /// <code>
+        /// ReadOnlySpan&lt;byte&gt; remaining = received;
+        /// while (CborDataItemScanner.TryReadDataItem(ref remaining, out ReadOnlySpan&lt;byte&gt; item))
+        /// {
+        ///     Handle(Cbor.Deserialize&lt;T&gt;(item, options));
+        /// }
+        /// // `remaining` now holds the incomplete tail; prepend it to the next read.
+        /// </code>
+        /// </summary>
+        /// <returns>
+        /// true when an item was read; false when the buffer is empty, holds only a partial item, or
+        /// starts with malformed bytes. <paramref name="buffer"/> is left untouched when false, so the
+        /// caller can distinguish "need more data" from "made progress".
+        /// </returns>
+        public static bool TryReadDataItem(ref ReadOnlySpan<byte> buffer, out ReadOnlySpan<byte> item)
+        {
+            if (Scan(buffer, DefaultMaxDepth, out int length) != CborDataItemStatus.Complete)
+            {
+                item = default;
+                return false;
+            }
+
+            item = buffer.Slice(0, length);
+            buffer = buffer.Slice(length);
+            return true;
+        }
+
+        /// <summary>
+        /// Counts the complete data items in <paramref name="buffer"/> and reports how many bytes they
+        /// occupy, so a caller can tell a cleanly-terminated sequence from a truncated one.
+        /// </summary>
+        /// <param name="consumed">Bytes occupied by the complete items.</param>
+        /// <param name="count">Number of complete items found.</param>
+        /// <returns>
+        /// The status that stopped the scan: <see cref="CborDataItemStatus.Complete"/> when the buffer
+        /// ended exactly on an item boundary, <see cref="CborDataItemStatus.Incomplete"/> when a
+        /// partial item trails, or <see cref="CborDataItemStatus.Malformed"/> /
+        /// <see cref="CborDataItemStatus.TooDeep"/> when the remainder cannot be scanned.
+        /// </returns>
+        public static CborDataItemStatus ScanSequence(
+            ReadOnlySpan<byte> buffer, out int consumed, out int count)
+        {
+            consumed = 0;
+            count = 0;
+
+            while (consumed < buffer.Length)
+            {
+                CborDataItemStatus status = Scan(buffer.Slice(consumed), DefaultMaxDepth, out int length);
+
+                if (status != CborDataItemStatus.Complete)
+                {
+                    return status;
+                }
+
+                consumed += length;
+                count++;
+            }
+
+            return CborDataItemStatus.Complete;
+        }
+
+        private static CborDataItemStatus ScanItem(
+            ReadOnlySpan<byte> buffer, ref int position, int remainingDepth)
+        {
+            if (remainingDepth <= 0)
+            {
+                return CborDataItemStatus.TooDeep;
+            }
+
+            if (position >= buffer.Length)
+            {
+                return CborDataItemStatus.Incomplete;
+            }
+
+            byte initialByte = buffer[position++];
+            int majorType = initialByte >> 5;
+            int additionalInfo = initialByte & 0x1F;
+
+            if (additionalInfo == IndefiniteLength)
+            {
+                return ScanIndefinite(buffer, ref position, remainingDepth, majorType);
+            }
+
+            CborDataItemStatus argumentStatus = ReadArgument(buffer, ref position, additionalInfo, out ulong argument);
+            if (argumentStatus != CborDataItemStatus.Complete)
+            {
+                return argumentStatus;
+            }
+
+            switch (majorType)
+            {
+                case 0: // unsigned integer
+                case 1: // negative integer
+                case 7: // floating point / simple value — the argument is the whole payload
+                    return CborDataItemStatus.Complete;
+
+                case 2: // byte string
+                case 3: // text string — `argument` bytes of payload follow
+                    if (argument > (ulong)(buffer.Length - position))
+                    {
+                        return CborDataItemStatus.Incomplete;
+                    }
+
+                    position += (int)argument;
+                    return CborDataItemStatus.Complete;
+
+                case 4: // array — `argument` items follow
+                    for (ulong i = 0; i < argument; i++)
+                    {
+                        // Bail out early rather than spin on a huge count we can never satisfy.
+                        if (position >= buffer.Length)
+                        {
+                            return CborDataItemStatus.Incomplete;
+                        }
+
+                        CborDataItemStatus status = ScanItem(buffer, ref position, remainingDepth - 1);
+                        if (status != CborDataItemStatus.Complete)
+                        {
+                            return status;
+                        }
+                    }
+
+                    return CborDataItemStatus.Complete;
+
+                case 5: // map — `argument` key/value pairs follow
+                    for (ulong i = 0; i < argument; i++)
+                    {
+                        if (position >= buffer.Length)
+                        {
+                            return CborDataItemStatus.Incomplete;
+                        }
+
+                        CborDataItemStatus keyStatus = ScanItem(buffer, ref position, remainingDepth - 1);
+                        if (keyStatus != CborDataItemStatus.Complete)
+                        {
+                            return keyStatus;
+                        }
+
+                        CborDataItemStatus valueStatus = ScanItem(buffer, ref position, remainingDepth - 1);
+                        if (valueStatus != CborDataItemStatus.Complete)
+                        {
+                            return valueStatus;
+                        }
+                    }
+
+                    return CborDataItemStatus.Complete;
+
+                case 6: // semantic tag — exactly one tagged item follows
+                    return ScanItem(buffer, ref position, remainingDepth - 1);
+
+                default:
+                    return CborDataItemStatus.Malformed;
+            }
+        }
+
+        private static CborDataItemStatus ScanIndefinite(
+            ReadOnlySpan<byte> buffer, ref int position, int remainingDepth, int majorType)
+        {
+            switch (majorType)
+            {
+                case 2: // indefinite-length byte string
+                case 3: // indefinite-length text string
+                    // RFC 8949: chunks must be definite-length strings of the same major type.
+                    while (true)
+                    {
+                        if (position >= buffer.Length)
+                        {
+                            return CborDataItemStatus.Incomplete;
+                        }
+
+                        if (buffer[position] == BreakByte)
+                        {
+                            position++;
+                            return CborDataItemStatus.Complete;
+                        }
+
+                        int chunkMajorType = buffer[position] >> 5;
+                        int chunkAdditionalInfo = buffer[position] & 0x1F;
+
+                        if (chunkMajorType != majorType || chunkAdditionalInfo == IndefiniteLength)
+                        {
+                            return CborDataItemStatus.Malformed;
+                        }
+
+                        CborDataItemStatus status = ScanItem(buffer, ref position, remainingDepth - 1);
+                        if (status != CborDataItemStatus.Complete)
+                        {
+                            return status;
+                        }
+                    }
+
+                case 4: // indefinite-length array
+                    while (true)
+                    {
+                        if (position >= buffer.Length)
+                        {
+                            return CborDataItemStatus.Incomplete;
+                        }
+
+                        if (buffer[position] == BreakByte)
+                        {
+                            position++;
+                            return CborDataItemStatus.Complete;
+                        }
+
+                        CborDataItemStatus status = ScanItem(buffer, ref position, remainingDepth - 1);
+                        if (status != CborDataItemStatus.Complete)
+                        {
+                            return status;
+                        }
+                    }
+
+                case 5: // indefinite-length map
+                    while (true)
+                    {
+                        if (position >= buffer.Length)
+                        {
+                            return CborDataItemStatus.Incomplete;
+                        }
+
+                        if (buffer[position] == BreakByte)
+                        {
+                            position++;
+                            return CborDataItemStatus.Complete;
+                        }
+
+                        CborDataItemStatus keyStatus = ScanItem(buffer, ref position, remainingDepth - 1);
+                        if (keyStatus != CborDataItemStatus.Complete)
+                        {
+                            return keyStatus;
+                        }
+
+                        // A map must not end between a key and its value.
+                        if (position < buffer.Length && buffer[position] == BreakByte)
+                        {
+                            return CborDataItemStatus.Malformed;
+                        }
+
+                        CborDataItemStatus valueStatus = ScanItem(buffer, ref position, remainingDepth - 1);
+                        if (valueStatus != CborDataItemStatus.Complete)
+                        {
+                            return valueStatus;
+                        }
+                    }
+
+                default:
+                    // Major types 0, 1, 6 and 7 have no indefinite form. For type 7 additional
+                    // info 31 is the break code, which is only valid inside an indefinite-length
+                    // item and is therefore malformed where an item was expected.
+                    return CborDataItemStatus.Malformed;
+            }
+        }
+
+        private static CborDataItemStatus ReadArgument(
+            ReadOnlySpan<byte> buffer, ref int position, int additionalInfo, out ulong argument)
+        {
+            argument = 0;
+
+            if (additionalInfo <= 23)
+            {
+                argument = (ulong)additionalInfo;
+                return CborDataItemStatus.Complete;
+            }
+
+            switch (additionalInfo)
+            {
+                case 24:
+                    if (position + 1 > buffer.Length)
+                    {
+                        return CborDataItemStatus.Incomplete;
+                    }
+
+                    argument = buffer[position];
+                    position += 1;
+                    return CborDataItemStatus.Complete;
+
+                case 25:
+                    if (position + 2 > buffer.Length)
+                    {
+                        return CborDataItemStatus.Incomplete;
+                    }
+
+                    argument = BinaryPrimitives.ReadUInt16BigEndian(buffer.Slice(position));
+                    position += 2;
+                    return CborDataItemStatus.Complete;
+
+                case 26:
+                    if (position + 4 > buffer.Length)
+                    {
+                        return CborDataItemStatus.Incomplete;
+                    }
+
+                    argument = BinaryPrimitives.ReadUInt32BigEndian(buffer.Slice(position));
+                    position += 4;
+                    return CborDataItemStatus.Complete;
+
+                case 27:
+                    if (position + 8 > buffer.Length)
+                    {
+                        return CborDataItemStatus.Incomplete;
+                    }
+
+                    argument = BinaryPrimitives.ReadUInt64BigEndian(buffer.Slice(position));
+                    position += 8;
+                    return CborDataItemStatus.Complete;
+
+                default:
+                    // 28, 29 and 30 are reserved by RFC 8949.
+                    return CborDataItemStatus.Malformed;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Addresses #139 (RFC 8742 CBOR sequences) and #134 (streaming). Both need the same primitive: given a buffer that may end mid-item, determine whether a complete data item is present and how many bytes it occupies — **without throwing when it isn't**.

Today the only way to answer that is to attempt a decode and catch the "Unexpected end of buffer" `CborException`. That works, but it makes truncation — an ordinary, expected condition when reading from a stream — cost an exception. That is precisely the "exception-based parsing" #139 objects to.

### API

Every entry point takes either a `ReadOnlySpan<byte>` or a `ReadOnlySequence<byte>`:

```csharp
CborDataItemScanner.Scan(buffer, out int length)                    // -> CborDataItemStatus
CborDataItemScanner.Scan(buffer, limits, out int length)
CborDataItemScanner.TryGetDataItemLength(buffer, out int length)
CborDataItemScanner.TryReadDataItem(ref buffer, out ReadOnlySpan<byte> item)
CborDataItemScanner.ScanSequence(buffer, out int consumed, out int count)

CborDataItemScanner.Scan(sequence, out long length)
CborDataItemScanner.Scan(sequence, limits, out long length)
CborDataItemScanner.TryGetDataItemLength(sequence, out long length)
CborDataItemScanner.TryReadDataItem(ref sequence, out ReadOnlySequence<byte> item)
CborDataItemScanner.ScanSequence(sequence, out long consumed, out int count)
```

The sequence overloads are the ones a streaming caller wants. `PipeReader.ReadAsync` yields a routinely multi-segment `ReadOnlySequence<byte>`, and `CborReader` is already built on sequences, so the scanner walks segment boundaries in place rather than requiring the buffer to be flattened first — which would reintroduce the copy that reading incrementally exists to avoid:

```csharp
ReadResult result = await pipeReader.ReadAsync(token);
ReadOnlySequence<byte> remaining = result.Buffer;

while (CborDataItemScanner.TryReadDataItem(ref remaining, out ReadOnlySequence<byte> item))
{
    Handle(Cbor.Deserialize<T>(item, options));
}

pipeReader.AdvanceTo(remaining.Start, remaining.End);
```

`remaining` is left at the start of the incomplete tail, so it can be handed straight back to `AdvanceTo` as the consumed position. The span overloads remain the fast path for data that is already contiguous, and a single-segment sequence is dispatched to them.

`CborDataItemStatus` separates the outcomes callers must treat differently: `Complete`, `Incomplete` (read more and retry), `Malformed` (more data will not help), `TooDeep` and `TooLarge` (resource guards).

### Bounding depth and size

`CborScanLimits` carries both bounds. `default(CborScanLimits)` is the defaults, not a pair of zeroes.

**Depth** — a buffer of `0x9F` bytes opens one indefinite-length array per byte, so an unbounded scanner is a stack-overflow vector on untrusted input. Default 64, matching `System.Formats.Cbor`.

**Item size** — a declared length is believed long before its bytes arrive. `5B FF FF FF FF FF FF FF FF` is nine bytes announcing a 16-exabyte byte string; with no bound the only available answer is `Incomplete`, which tells a streaming caller to buffer forever for bytes that will never come. `MaxItemSize` turns that into `TooLarge` on the first nine bytes, before anything is allocated. The bound is checked against declared lengths and item counts — an array costs at least one byte per item, a map two per pair — so it holds for an item whose payload has not been received. Counts are compared by division so a count near `ulong.MaxValue` cannot overflow into looking affordable. Unlimited by default, except that a length exceeding `long.MaxValue` is always refused: no `ReadOnlySequence<byte>` could hold it, so those bytes are unobtainable rather than merely absent.

### Scope

Scanning is **structural only** — it walks headers and skips payloads. It does not validate UTF-8, tag semantics or map key uniqueness, and it accepts non-preferred integer encodings. So `Complete` means "a decoder will find a whole item here", not "this item is canonical". Documented on the type.

Structural validation that *is* performed: reserved additional-information values 28–30, indefinite lengths on major types that have no indefinite form, stray break codes, indefinite-length strings whose chunks are not definite-length strings of the same major type, indefinite maps ending between a key and its value, and two-byte simple values below 32 (RFC 8949 §3.3 forbids that encoding, and a decoder rejects it, so calling it `Complete` would break the contract above).

### Tests

89 cases. Three are properties rather than examples:

* **every case is scanned three ways** — as a span, as a single-segment sequence, and as a sequence carrying one byte per segment — and all three must agree on status and length. The contiguous and segmented walks are separate implementations (a `ref struct` cannot be a generic type argument on netstandard2.0, so they cannot share one walk without pushing the contiguous case through `SequenceReader`), and this equivalence is what keeps them in step. It also means every case exercises a header, an argument and a payload split across segment boundaries.
* **every strict prefix** of a complete item reports `Incomplete` — never `Malformed`, never a bogus `Complete`. This is the property that makes the scanner safe on a stream, so it's checked exhaustively over all prefixes of 13 representative encodings rather than by sampling.
* **scanned lengths agree with what the serializer actually emits**, so a sequence walk cannot drift.

Plus the depth and size limits, absurd declared lengths that must not overflow, and sequence walking with a truncated tail in both shapes.

### Still open on top of this

The async `CborSequenceReader` over a `Stream`/`PipeReader` that #134 asks for. This is the primitive it needs, not the whole feature.

---

New types only; purely additive, no existing behaviour touched. 916 tests pass on net10.0 (827 before). All four TFMs build.
