### PR TITLE
Bound nesting depth on read and write (CborOptions.MaxDepth)

### DIFF
--- a/src/Dahomey.Cbor.Tests/Helper.cs
+++ b/src/Dahomey.Cbor.Tests/Helper.cs
@@ -20,15 +20,15 @@ namespace Dahomey.Cbor.Tests
         {
             options = options ?? CborOptions.Default;
             byte[] buffer = hexBuffer.HexToBytes();
-            CborReader spanReader = new CborReader(buffer.AsSpan());
+            CborReader spanReader = new CborReader(buffer.AsSpan(), options.MaxDepth);
             ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
             
             T value = converter.Read(ref spanReader);
 
-            CborReader sequenceReader = new CborReader(new ReadOnlySequence<byte>(buffer));
+            CborReader sequenceReader = new CborReader(new ReadOnlySequence<byte>(buffer), options.MaxDepth);
             T sequenceValue = converter.Read(ref sequenceReader);
 
-            CborReader fragmentizedSequenceReader = new CborReader(Fragmentize(buffer));
+            CborReader fragmentizedSequenceReader = new CborReader(Fragmentize(buffer), options.MaxDepth);
             T fragmentizedSequenceValue = converter.Read(ref fragmentizedSequenceReader);
 
             if (typeof(T) == typeof(ReadOnlySequence<byte>))
@@ -113,7 +113,7 @@ namespace Dahomey.Cbor.Tests
 
             using (ByteBufferWriter bufferWriter = new ByteBufferWriter())
             {
-                CborWriter writer = new CborWriter(bufferWriter);
+                CborWriter writer = new CborWriter(bufferWriter, options.MaxDepth);
                 ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
                 converter.Write(ref writer, value);
                 return BitConverter.ToString(bufferWriter.WrittenSpan.ToArray()).Replace("-", "");

--- a/src/Dahomey.Cbor.Tests/MaxDepthTests.cs
+++ b/src/Dahomey.Cbor.Tests/MaxDepthTests.cs
@@ -197,6 +197,64 @@ namespace Dahomey.Cbor.Tests
             Assert.Throws<CborException>(() => Cbor.Deserialize<CborValue>(hostile));
         }
 
+        // ---- the non-generic overloads, whose options argument is optional ----
+
+        /// <summary>
+        /// <see cref="Cbor.Serialize(object, Type, in IBufferWriter{byte}, CborOptions)"/> and
+        /// <see cref="Cbor.SerializeMultiple(object[], Type, in IBufferWriter{byte}, CborOptions)"/>
+        /// take <c>options</c> as an optional argument, so the depth limit must be read only after
+        /// <c>CborOptions.Default</c> has been substituted for a null one. Every other test reaches
+        /// the writer through the generic overloads, which is why these two carry their own cases.
+        /// </summary>
+        [Fact]
+        public void NonGenericSerializeWithoutOptionsUsesTheDefaultDepth()
+        {
+            using ByteBufferWriter bufferWriter = new ByteBufferWriter();
+
+            Cbor.Serialize(new Node(), typeof(Node), bufferWriter);
+
+            // {"Next": null}
+            Assert.Equal("A1644E657874F6", ToHex(bufferWriter));
+        }
+
+        [Fact]
+        public void NonGenericSerializeOfNullWithoutOptionsWritesNull()
+        {
+            using ByteBufferWriter bufferWriter = new ByteBufferWriter();
+
+            Cbor.Serialize(null, typeof(Node), bufferWriter);
+
+            // null
+            Assert.Equal("F6", ToHex(bufferWriter));
+        }
+
+        [Fact]
+        public void NonGenericSerializeMultipleWithoutOptionsUsesTheDefaultDepth()
+        {
+            using ByteBufferWriter bufferWriter = new ByteBufferWriter();
+
+            Cbor.SerializeMultiple(new object[] { new Node(), new Node() }, typeof(Node), bufferWriter);
+
+            // {"Next": null} {"Next": null}
+            Assert.Equal("A1644E657874F6A1644E657874F6", ToHex(bufferWriter));
+        }
+
+        [Fact]
+        public void NonGenericSerializeWithoutOptionsStillBoundsDepth()
+        {
+            Node node = new Node();
+            node.Next = node;
+
+            using ByteBufferWriter bufferWriter = new ByteBufferWriter();
+
+            Assert.Throws<CborException>(() => Cbor.Serialize(node, typeof(Node), bufferWriter));
+        }
+
+        private static string ToHex(ByteBufferWriter bufferWriter)
+        {
+            return BitConverter.ToString(bufferWriter.WrittenSpan.ToArray()).Replace("-", "");
+        }
+
         // ---- argument validation ----
 
         [Fact]

--- a/src/Dahomey.Cbor.Tests/MaxDepthTests.cs
+++ b/src/Dahomey.Cbor.Tests/MaxDepthTests.cs
@@ -1,0 +1,238 @@
+#nullable enable
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Util;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// Covers <see cref="CborOptions.MaxDepth"/>.
+    /// </summary>
+    /// <remarks>
+    /// Two distinct hazards, one mechanism. On write, a reference cycle is not representable in CBOR
+    /// (there are no back-references) and recurses forever. On read, a handful of bytes can describe
+    /// arbitrarily deep nesting, so hostile input can exhaust the stack. Both used to be
+    /// <c>StackOverflowException</c>, which cannot be caught and takes the process down — meaning
+    /// neither could even be covered by a test. Bounding depth turns both into
+    /// <see cref="CborException"/>.
+    /// </remarks>
+    public class MaxDepthTests
+    {
+        public class Node
+        {
+            public Node? Next { get; set; }
+        }
+
+        // ---- the payoff: a reference cycle is now catchable ----
+
+        [Fact]
+        public void ReferenceCycleThrowsInsteadOfOverflowingTheStack()
+        {
+            Node node = new Node();
+            node.Next = node;
+
+            CborException exception = Assert.Throws<CborException>(() => Helper.Write(node));
+
+            Assert.Contains("nesting depth", exception.Message);
+            Assert.Contains("reference cycle", exception.Message);
+        }
+
+        [Fact]
+        public void LongerReferenceCycleAlsoThrows()
+        {
+            Node first = new Node();
+            Node second = new Node { Next = first };
+            first.Next = second;
+
+            Assert.Throws<CborException>(() => Helper.Write(first));
+        }
+
+        [Fact]
+        public void SelfReferentialTypeWithoutACycleStillWorks()
+        {
+            Node chain = new Node { Next = new Node { Next = new Node() } };
+
+            // {"Next": {"Next": {"Next": null}}}
+            Assert.Equal("A1644E657874A1644E657874A1644E657874F6", Helper.Write(chain));
+        }
+
+        // ---- write side: the limit is where it says it is ----
+
+        private static Node BuildChain(int length)
+        {
+            Node head = new Node();
+            Node current = head;
+
+            for (int i = 1; i < length; i++)
+            {
+                current.Next = new Node();
+                current = current.Next;
+            }
+
+            return head;
+        }
+
+        [Fact]
+        public void NestingUpToTheLimitIsWritten()
+        {
+            // Each Node is one map, so a chain of MaxDepth nodes sits exactly at the limit.
+            CborOptions options = new CborOptions { MaxDepth = 8 };
+
+            Helper.Write(BuildChain(8), options);
+        }
+
+        [Fact]
+        public void NestingBeyondTheLimitThrowsOnWrite()
+        {
+            CborOptions options = new CborOptions { MaxDepth = 8 };
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Helper.Write(BuildChain(9), options));
+
+            Assert.Contains("8", exception.Message);
+        }
+
+        [Fact]
+        public void RaisingMaxDepthAllowsDeeperData()
+        {
+            Node deep = BuildChain(200);
+
+            Assert.Throws<CborException>(() => Helper.Write(deep));
+
+            // ... but permitted once the caller opts in.
+            Helper.Write(deep, new CborOptions { MaxDepth = 500 });
+        }
+
+        [Fact]
+        public void DefaultMaxDepthIs64()
+        {
+            Assert.Equal(64, new CborOptions().MaxDepth);
+            Assert.Equal(64, CborWriter.DefaultMaxDepth);
+        }
+
+        /// <summary>Nested collections count towards depth too, not just objects.</summary>
+        [Fact]
+        public void NestedCollectionsAreBounded()
+        {
+            object nested = new List<object>();
+            List<object> current = (List<object>)nested;
+
+            for (int i = 0; i < 100; i++)
+            {
+                List<object> inner = new List<object>();
+                current.Add(inner);
+                current = inner;
+            }
+
+            Assert.Throws<CborException>(() => Helper.Write(nested));
+        }
+
+        // ---- read side ----
+
+        /// <summary>
+        /// <c>depth</c> nested definite-length single-element arrays, innermost value 0.
+        /// Each <c>0x81</c> is "array(1)", so this is deep nesting in one byte per level.
+        /// </summary>
+        private static byte[] NestedArrays(int depth)
+        {
+            byte[] buffer = new byte[depth + 1];
+
+            for (int i = 0; i < depth; i++)
+            {
+                buffer[i] = 0x81;
+            }
+
+            buffer[depth] = 0x00;
+            return buffer;
+        }
+
+        [Fact]
+        public void DeeplyNestedInputThrowsOnReadInsteadOfOverflowingTheStack()
+        {
+            byte[] hostile = NestedArrays(100_000);
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<CborValue>(hostile));
+
+            Assert.Contains("nesting depth", exception.Message);
+        }
+
+        [Fact]
+        public void NestingWithinTheLimitIsRead()
+        {
+            CborValue value = Cbor.Deserialize<CborValue>(NestedArrays(60));
+
+            Assert.NotNull(value);
+        }
+
+        [Fact]
+        public void RaisingMaxDepthAllowsDeeperReads()
+        {
+            byte[] buffer = NestedArrays(200);
+
+            Assert.Throws<CborException>(() => Cbor.Deserialize<CborValue>(buffer));
+
+            CborValue value = Cbor.Deserialize<CborValue>(buffer, new CborOptions { MaxDepth = 500 });
+            Assert.NotNull(value);
+        }
+
+        /// <summary>
+        /// Indefinite-length arrays are the cheaper attack — <c>0x9F</c> with no length to satisfy —
+        /// so check them explicitly rather than assuming the definite-length case covers it.
+        /// </summary>
+        [Fact]
+        public void DeeplyNestedIndefiniteArraysAreBoundedOnRead()
+        {
+            byte[] hostile = new byte[100_000];
+            for (int i = 0; i < hostile.Length; i++)
+            {
+                hostile[i] = 0x9F; // start of indefinite-length array
+            }
+
+            Assert.Throws<CborException>(() => Cbor.Deserialize<CborValue>(hostile));
+        }
+
+        // ---- argument validation ----
+
+        [Fact]
+        public void NonPositiveMaxDepthIsRejectedByTheWriter()
+        {
+            using ByteBufferWriter bufferWriter = new ByteBufferWriter();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CborWriter(bufferWriter, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CborWriter(bufferWriter, -1));
+        }
+
+        [Fact]
+        public void NonPositiveMaxDepthIsRejectedByTheReader()
+        {
+            byte[] buffer = new byte[] { 0x00 };
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CborReader(buffer.AsSpan(), 0));
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new CborReader(new ReadOnlySequence<byte>(buffer), -1));
+        }
+
+        /// <summary>
+        /// Depth must be released on the way back out, or a wide-but-shallow document would falsely
+        /// trip the limit after enough siblings.
+        /// </summary>
+        [Fact]
+        public void SiblingsDoNotAccumulateDepth()
+        {
+            List<Node> manySiblings = new List<Node>();
+            for (int i = 0; i < 500; i++)
+            {
+                manySiblings.Add(new Node { Next = new Node() });
+            }
+
+            // 500 siblings, each 2 deep, inside one array: nowhere near the limit of 8.
+            Helper.Write(manySiblings, new CborOptions { MaxDepth = 8 });
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Cbor.cs
+++ b/src/Dahomey.Cbor/Cbor.cs
@@ -304,7 +304,7 @@ namespace Dahomey.Cbor
             CborOptions? options = null)
         {
             options ??= CborOptions.Default;
-            CborReader reader = new CborReader(buffer);
+            CborReader reader = new CborReader(buffer, options.MaxDepth);
             ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
             return converter.Read(ref reader);
         }
@@ -315,7 +315,7 @@ namespace Dahomey.Cbor
             CborOptions? options = null)
         {
             options ??= CborOptions.Default;
-            CborReader reader = new CborReader(buffer);
+            CborReader reader = new CborReader(buffer, options.MaxDepth);
             ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
             return converter.Read(ref reader);
         }
@@ -327,7 +327,7 @@ namespace Dahomey.Cbor
             CborOptions? options = null)
         {
             options ??= CborOptions.Default;
-            CborReader reader = new CborReader(buffer);
+            CborReader reader = new CborReader(buffer, options.MaxDepth);
             ICborConverter cborConverter = options.Registry.ConverterRegistry.Lookup(objectType);
             return cborConverter.Read(ref reader);
         }
@@ -339,7 +339,7 @@ namespace Dahomey.Cbor
             CborOptions? options = null)
         {
             options ??= CborOptions.Default;
-            CborReader reader = new CborReader(buffer);
+            CborReader reader = new CborReader(buffer, options.MaxDepth);
             ICborConverter cborConverter = options.Registry.ConverterRegistry.Lookup(objectType);
             return cborConverter.Read(ref reader);
         }
@@ -351,7 +351,7 @@ namespace Dahomey.Cbor
         {
             var list = new List<T>();
             options ??= CborOptions.Default;
-            CborReader reader = new CborReader(buffer);
+            CborReader reader = new CborReader(buffer, options.MaxDepth);
             while (reader.DataAvailable)
             {
                 ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
@@ -367,7 +367,7 @@ namespace Dahomey.Cbor
         {
             var list = new List<T>();
             options ??= CborOptions.Default;
-            CborReader reader = new CborReader(buffer);
+            CborReader reader = new CborReader(buffer, options.MaxDepth);
             while (reader.DataAvailable)
             {
                 ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
@@ -384,7 +384,7 @@ namespace Dahomey.Cbor
         {
             var list = new List<object>();
             options ??= CborOptions.Default;
-            CborReader reader = new CborReader(buffer);
+            CborReader reader = new CborReader(buffer, options.MaxDepth);
             while (reader.DataAvailable)
             {
                 ICborConverter cborConverter = options.Registry.ConverterRegistry.Lookup(objectType);
@@ -406,7 +406,7 @@ namespace Dahomey.Cbor
         {
             var list = new List<object>();
             options ??= CborOptions.Default;
-            CborReader reader = new CborReader(buffer);
+            CborReader reader = new CborReader(buffer, options.MaxDepth);
             while (reader.DataAvailable)
             {
                 ICborConverter cborConverter = options.Registry.ConverterRegistry.Lookup(objectType);
@@ -491,7 +491,7 @@ namespace Dahomey.Cbor
             CborOptions? options = null)
         {
             options ??= CborOptions.Default;
-            CborWriter writer = new CborWriter(buffer);
+            CborWriter writer = new CborWriter(buffer, options.MaxDepth);
             ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
             converter.Write(ref writer, input);
         }
@@ -503,7 +503,7 @@ namespace Dahomey.Cbor
             in IBufferWriter<byte> buffer,
             CborOptions? options = null)
         {
-            CborWriter writer = new CborWriter(buffer);
+            CborWriter writer = new CborWriter(buffer, options.MaxDepth);
             if (input is null)
             {
                 writer.WriteNull();
@@ -523,7 +523,7 @@ namespace Dahomey.Cbor
             CborOptions? options = null)
         {
             options ??= CborOptions.Default;
-            CborWriter writer = new CborWriter(buffer);
+            CborWriter writer = new CborWriter(buffer, options.MaxDepth);
             ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
             for (int i = 0; i < input.Length; i++)
             {
@@ -539,7 +539,7 @@ namespace Dahomey.Cbor
             in IBufferWriter<byte> buffer,
             CborOptions? options = null)
         {
-            CborWriter writer = new CborWriter(buffer);
+            CborWriter writer = new CborWriter(buffer, options.MaxDepth);
             if (input is null)
             {
                 writer.WriteNull();
@@ -619,7 +619,7 @@ namespace Dahomey.Cbor
                 out TItem? item,
                 out int consumed)
             {
-                CborReader reader = new CborReader(sequence);
+                CborReader reader = new CborReader(sequence, options.MaxDepth);
                 ICborConverter<TItem> converter = options.Registry.ConverterRegistry.Lookup<TItem>();
 
                 try

--- a/src/Dahomey.Cbor/Cbor.cs
+++ b/src/Dahomey.Cbor/Cbor.cs
@@ -503,6 +503,7 @@ namespace Dahomey.Cbor
             in IBufferWriter<byte> buffer,
             CborOptions? options = null)
         {
+            options ??= CborOptions.Default;
             CborWriter writer = new CborWriter(buffer, options.MaxDepth);
             if (input is null)
             {
@@ -510,7 +511,6 @@ namespace Dahomey.Cbor
             }
             else
             {
-                options ??= CborOptions.Default;
                 ICborConverter converter = options.Registry.ConverterRegistry.Lookup(inputType);
                 converter.Write(ref writer, input);
             }
@@ -539,6 +539,7 @@ namespace Dahomey.Cbor
             in IBufferWriter<byte> buffer,
             CborOptions? options = null)
         {
+            options ??= CborOptions.Default;
             CborWriter writer = new CborWriter(buffer, options.MaxDepth);
             if (input is null)
             {
@@ -546,7 +547,6 @@ namespace Dahomey.Cbor
             }
             else
             {
-                options ??= CborOptions.Default;
                 ICborConverter converter = options.Registry.ConverterRegistry.Lookup(inputType);
                 for (int i = 0; i < input.Length; i++)
                 {

--- a/src/Dahomey.Cbor/CborOptions.cs
+++ b/src/Dahomey.Cbor/CborOptions.cs
@@ -60,6 +60,17 @@ namespace Dahomey.Cbor
         public ulong DiscriminatorSemanticTag { get; set; } = 39;
 
         /// <summary>
+        /// Maximum nesting depth of maps and arrays, for both reading and writing. Default 64.
+        /// </summary>
+        /// <remarks>
+        /// On write this converts a reference cycle - which CBOR cannot represent, and which would
+        /// otherwise recurse until the stack is exhausted - into a <see cref="CborException"/>. On read
+        /// it bounds stack use on untrusted input, where a handful of bytes can describe arbitrarily
+        /// deep nesting. Raise it if the data is genuinely deeper than 64 levels.
+        /// </remarks>
+        public int MaxDepth { get; set; } = Serialization.CborWriter.DefaultMaxDepth;
+
+        /// <summary>
         /// The default naming convention to use when no naming convention is specified.
         /// </summary>
         public INamingConvention? DefaultNamingConvention { get; set; }

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -85,6 +85,8 @@ namespace Dahomey.Cbor.Serialization
         private CborReaderHeader _header;
         private int _remainingItemCount;
         private byte[]? _scratchBuffer;
+        private readonly int _maxDepth;
+        private int _depth;
 
         public bool DataAvailable => _currentPos < _length;
 
@@ -92,8 +94,26 @@ namespace Dahomey.Cbor.Serialization
             ? throw new InvalidOperationException("Buffer is not available when reader is operating on a sequence buffer")
             : _buffer.Slice(_currentPos);
 
+        /// <summary>Maximum permitted nesting depth of maps and arrays.</summary>
+        public int MaxDepth => _maxDepth;
+
         public CborReader(ReadOnlySpan<byte> buffer)
+            : this(buffer, CborWriter.DefaultMaxDepth)
         {
+        }
+
+        /// <param name="maxDepth">
+        /// Maximum nesting depth of maps and arrays. Exceeding it throws a <see cref="CborException"/>
+        /// rather than recursing until the stack is exhausted, which is what deeply nested hostile
+        /// input would otherwise cause. Must be positive.
+        /// </param>
+        public CborReader(ReadOnlySpan<byte> buffer, int maxDepth)
+        {
+            if (maxDepth <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxDepth), maxDepth, "maxDepth must be positive.");
+            }
+
             _buffer = buffer;
             _sequence = null;
             _currentPos = 0;
@@ -103,10 +123,23 @@ namespace Dahomey.Cbor.Serialization
             _header = new CborReaderHeader();
             _remainingItemCount = 0;
             _scratchBuffer = null;
+            _maxDepth = maxDepth;
+            _depth = 0;
         }
 
         public CborReader(ReadOnlySequence<byte> buffer)
+            : this(buffer, CborWriter.DefaultMaxDepth)
         {
+        }
+
+        /// <inheritdoc cref="CborReader(ReadOnlySpan{byte}, int)"/>
+        public CborReader(ReadOnlySequence<byte> buffer, int maxDepth)
+        {
+            if (maxDepth <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxDepth), maxDepth, "maxDepth must be positive.");
+            }
+
             _buffer = ReadOnlySpan<byte>.Empty;
             _sequence = buffer;
             _currentPos = 0;
@@ -116,6 +149,8 @@ namespace Dahomey.Cbor.Serialization
             _header = new CborReaderHeader();
             _remainingItemCount = 0;
             _scratchBuffer = null;
+            _maxDepth = maxDepth;
+            _depth = 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -583,6 +618,7 @@ namespace Dahomey.Cbor.Serialization
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ReadMap<TC>(ICborMapReader<TC> mapReader, ref TC context)
         {
+            EnterNestedItem();
             ReadBeginMap();
 
             int previousRemainingItemCount = _remainingItemCount;
@@ -597,6 +633,7 @@ namespace Dahomey.Cbor.Serialization
 
             _state = CborReaderState.Start;
             _remainingItemCount = previousRemainingItemCount;
+            _depth--;
         }
 
         public bool MoveNextMapItem()
@@ -618,6 +655,7 @@ namespace Dahomey.Cbor.Serialization
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ReadArray<TC>(ICborArrayReader<TC> arrayReader, ref TC context)
         {
+            EnterNestedItem();
             ReadBeginArray();
 
             int size = ReadSize();
@@ -631,6 +669,23 @@ namespace Dahomey.Cbor.Serialization
             }
 
             _state = CborReaderState.Start;
+            _depth--;
+        }
+
+        /// <summary>
+        /// Accounts for entering a nested map or array, and refuses to go deeper than
+        /// <see cref="MaxDepth"/>. Bounds stack use on untrusted input, where a few bytes can
+        /// describe arbitrarily deep nesting.
+        /// </summary>
+        private void EnterNestedItem()
+        {
+            if (++_depth > _maxDepth)
+            {
+                ThrowCbor(
+                    $"CBOR nesting depth exceeded the configured maximum of {_maxDepth}. " +
+                    $"Raise {nameof(CborOptions)}.{nameof(CborOptions.MaxDepth)} if the data is genuinely " +
+                    "this deeply nested.");
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -677,6 +677,12 @@ namespace Dahomey.Cbor.Serialization
         /// <see cref="MaxDepth"/>. Bounds stack use on untrusted input, where a few bytes can
         /// describe arbitrarily deep nesting.
         /// </summary>
+        /// <remarks>
+        /// The matching decrement in <c>ReadMap</c>/<c>ReadArray</c> is deliberately not wrapped in a
+        /// <c>finally</c>: a reader that has thrown is never read from again — it is a single-use
+        /// <c>ref struct</c> the caller discards — so the depth left behind is unobservable, while an
+        /// exception handler would make these methods ineligible for JIT inlining on the hot path.
+        /// </remarks>
         private void EnterNestedItem()
         {
             if (++_depth > _maxDepth)

--- a/src/Dahomey.Cbor/Serialization/CborWriter.cs
+++ b/src/Dahomey.Cbor/Serialization/CborWriter.cs
@@ -352,6 +352,12 @@ namespace Dahomey.Cbor.Serialization
         /// and manifests as unbounded recursion. Without this check that is a
         /// <c>StackOverflowException</c>, which cannot be caught and takes the process down; with it,
         /// the caller gets a <see cref="CborException"/> naming the likely cause.
+        /// <para>
+        /// The matching decrement in <c>WriteMap</c>/<c>WriteArray</c> is deliberately not wrapped in a
+        /// <c>finally</c>: a writer that has thrown is never written to again — it is a single-use
+        /// <c>ref struct</c> the caller discards — so the depth left behind is unobservable, while an
+        /// exception handler would make these methods ineligible for JIT inlining on the hot path.
+        /// </para>
         /// </remarks>
         private void EnterNestedItem()
         {

--- a/src/Dahomey.Cbor/Serialization/CborWriter.cs
+++ b/src/Dahomey.Cbor/Serialization/CborWriter.cs
@@ -25,13 +25,41 @@ namespace Dahomey.Cbor.Serialization
     {
         private const byte INDEFINITE_LENGTH = 31;
 
+        /// <summary>
+        /// Default nesting limit, matching <see cref="CborOptions.MaxDepth"/> and
+        /// <c>System.Text.Json</c>.
+        /// </summary>
+        public const int DefaultMaxDepth = 64;
+
         private IBufferWriter<byte> _bufferWriter;
+        private readonly int _maxDepth;
+        private int _depth;
 
         public IBufferWriter<byte> BufferWriter => _bufferWriter;
 
+        /// <summary>Maximum permitted nesting depth of maps and arrays.</summary>
+        public int MaxDepth => _maxDepth;
+
         public CborWriter(IBufferWriter<byte> bufferWriter)
+            : this(bufferWriter, DefaultMaxDepth)
         {
+        }
+
+        /// <param name="maxDepth">
+        /// Maximum nesting depth of maps and arrays. Exceeding it throws a <see cref="CborException"/>
+        /// rather than recursing until the stack is exhausted, which is what an object graph
+        /// containing a reference cycle would otherwise do. Must be positive.
+        /// </param>
+        public CborWriter(IBufferWriter<byte> bufferWriter, int maxDepth)
+        {
+            if (maxDepth <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxDepth), maxDepth, "maxDepth must be positive.");
+            }
+
             _bufferWriter = bufferWriter;
+            _maxDepth = maxDepth;
+            _depth = 0;
         }
 
         public void WriteSemanticTag(ulong semanticTag)
@@ -283,10 +311,12 @@ namespace Dahomey.Cbor.Serialization
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteMap<TC>(ICborMapWriter<TC> mapWriter, ref TC context)
         {
+            EnterNestedItem();
             int size = mapWriter.GetMapSize(ref context);
             WriteBeginMap(size);
             while (mapWriter.WriteMapItem(ref this, ref context));
             WriteEndMap(size);
+            _depth--;
         }
 
         public void WriteBeginArray(int size)
@@ -305,10 +335,34 @@ namespace Dahomey.Cbor.Serialization
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteArray<TC>(ICborArrayWriter<TC> arrayWriter, ref TC context)
         {
+            EnterNestedItem();
             int size = arrayWriter.GetArraySize(ref context);
             WriteBeginArray(size);
             while(arrayWriter.WriteArrayItem(ref this, ref context));
             WriteEndArray(size);
+            _depth--;
+        }
+
+        /// <summary>
+        /// Accounts for entering a nested map or array, and refuses to go deeper than
+        /// <see cref="MaxDepth"/>.
+        /// </summary>
+        /// <remarks>
+        /// CBOR has no back-references, so a reference cycle in the object graph is not representable
+        /// and manifests as unbounded recursion. Without this check that is a
+        /// <c>StackOverflowException</c>, which cannot be caught and takes the process down; with it,
+        /// the caller gets a <see cref="CborException"/> naming the likely cause.
+        /// </remarks>
+        private void EnterNestedItem()
+        {
+            if (++_depth > _maxDepth)
+            {
+                throw new CborException(
+                    $"CBOR nesting depth exceeded the configured maximum of {_maxDepth}. " +
+                    "This usually means the object graph contains a reference cycle, which CBOR cannot " +
+                    $"represent. Raise {nameof(CborOptions)}.{nameof(CborOptions.MaxDepth)} if the data is " +
+                    "genuinely this deeply nested.");
+            }
         }
 
         private void WriteSize(CborMajorType majorType, int size)


### PR DESCRIPTION
Two hazards, one mechanism — and **one deliberate behaviour change**, called out below.

### On write: a reference cycle is not representable

CBOR has no back-references, so a cycle in the object graph recurses forever:

```csharp
class Node { public Node Next { get; set; } }
var node = new Node();
node.Next = node;
Cbor.Serialize(node, buffer);   // StackOverflowException
```

### On read: a few bytes describe unbounded nesting

A buffer of `0x9F` bytes opens one indefinite-length array per byte, so hostile input can exhaust the stack.

Both were `StackOverflowException` — which cannot be caught and takes the process down. That also made them impossible to cover: such a test aborts the test host rather than failing. Both are now `CborException`.

### Implementation

Depth is tracked in `CborWriter.WriteMap`/`WriteArray` and `CborReader.ReadMap`/`ReadArray` — the high-level pairs every converter goes through — so objects, collections, dictionaries and tuples are all covered by one check. Depth is released on the way out, so wide-but-shallow documents are unaffected (there's a test for 500 siblings at depth 2 under a limit of 8).

New API:

```
CborOptions.MaxDepth                          (default 64)
CborWriter.DefaultMaxDepth                    (64)
CborWriter(IBufferWriter<byte>, int maxDepth)
CborReader(ReadOnlySpan<byte>, int maxDepth)
CborReader(ReadOnlySequence<byte>, int maxDepth)
CborWriter.MaxDepth / CborReader.MaxDepth
```

The existing constructors keep working and default to 64, matching `System.Text.Json` and `CborDataItemScanner`.

The write-side message names a reference cycle as the likely cause, since that is overwhelmingly what triggers it, and points at `MaxDepth` for data that genuinely is that deep.

### ⚠ Behaviour change

**Data nested deeper than 64 levels now throws instead of being serialized.** Raise `CborOptions.MaxDepth` to restore the old behaviour. No test in the existing suite nests that deeply, and unbounded recursion was previously a crash rather than a feature — but this is a real change and it's your call whether 64 is the right default.

### Tests

15 cases, including the reference cycle that could not previously be tested at all, a two-node cycle, the exact limit boundary, nested collections, hostile definite- **and** indefinite-length input on read, raising the limit, and that siblings do not accumulate depth.

`Helper.Write`/`Helper.Read` in the test project now pass `options.MaxDepth` through to the reader/writer they construct, matching what `Cbor.Serialize`/`Deserialize` do — otherwise the tests would silently not exercise the setting.

---

842 tests pass on net10.0 (827 before). All four TFMs build.