### PR TITLE
RFC 8746 typed arrays, opt-in per direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ High-performance [CBOR](https://cbor.io/) serialization framework for .Net (C#)
 * Support for collection interfaces: IList<>, ICollection<>, IEnumerable<>, IReadOnlyList<>, IReadOnlyCollection<>
 * Support for dynamics
 * Support for structs
+* Support for RFC 8746 typed arrays, opt-in per direction (CborOptions.TypedArrayMode)
 
 ## Installation
 ### NuGet
@@ -90,6 +91,63 @@ CborObject obj = new CborObject
 await Cbor.SerializeAsync(cborObject, stream);
 
 ```
+
+### Typed arrays (RFC 8746)
+
+A numeric array can be encoded as an [RFC 8746](https://www.rfc-editor.org/rfc/rfc8746) typed array: one
+semantic tag and one byte string holding the whole array, instead of a headered item per element.
+
+```csharp
+CborOptions options = new CborOptions { TypedArrayMode = TypedArrayMode.ReadWriteLittleEndian };
+await Cbor.SerializeAsync(new[] { 1.5f, 2.5f }, stream, options);
+// writes D8 55 48 00 00 C0 3F 00 00 20 40
+```
+
+Supported element types, with their little-endian tag: `sbyte` (72), `ushort` (69), `short` (77),
+`uint` (70), `int` (78), `ulong` (71), `long` (79), `Half` (84), `float` (85) and `double` (86).
+`byte[]` is deliberately not included: a plain CBOR byte string is shorter and is what the format
+already uses; reading tags 64 and 68 into a `byte[]` still works.
+
+On a `float[1000]` of realistic sample data this writes 4005 bytes against 4923 for the plain form, a
+saving of 918. The 5 bytes of overhead are `D8 55` (tag 85) plus `59 0F A0` (byte string, length 4000).
+
+#### Reading and writing are separate
+
+`TypedArrayMode` is a flags enum, and the default `Never` is a true no-op — upgrading to a version that
+has typed arrays changes nothing for a caller who does not ask for them.
+
+| Value | Effect |
+|---|---|
+| `Never` (default) | Neither read nor written. A tag in 64–87 is skipped like any other unrecognised tag. |
+| `Read` | Typed arrays are read, in either byte order. Nothing is written as one. |
+| `WriteLittleEndian` | Numeric arrays are written as little-endian typed arrays. |
+| `ReadWriteLittleEndian` | Both. |
+
+`Read` on its own is the interop case: accept a peer's typed arrays without changing the bytes this side
+produces.
+
+#### What reads what
+
+Writing typed arrays applies to `T[]`. Reading one fills any of the shapes that are interchangeable with
+`T[]` — `List<T>`, `IList<T>`, `ICollection<T>`, `IEnumerable<T>`, `IReadOnlyList<T>`, `HashSet<T>`,
+`ImmutableArray<T>` and the rest — so a document written from a `float[]` member is readable by a
+consumer that declares that member as a `List<float>`.
+
+A tag whose element type does not match the target is an error rather than something to ignore: reading
+tag 86 (binary64) into a `float[]` throws, which catches a mismatch that would otherwise silently
+reinterpret the bytes.
+
+#### Two things to know
+
+`ArrayLengthMode` has no effect on an array actually written as a typed array — a typed array is a single
+definite-length byte string, so there is no array header to make indefinite. It applies as usual to every
+array not written as one.
+
+The object model does not model typed arrays. A `CborValue` holding one is a `ByteString` with the tag in
+`CborValue.SemanticTag`, so DOM code sees opaque bytes rather than numbers. Note that
+`CborValueConverter` does not write `SemanticTag` back — reading a document into a `CborValue` and
+serializing it again drops the tag, turning the typed array into a plain byte string. That is true of
+every semantic tag, not just these, but typed arrays are the easiest way to meet it.
 
 ### Custom converters
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ The object model does not model typed arrays. A `CborValue` holding one is a `By
 `CborValue.SemanticTag`, so DOM code sees opaque bytes rather than numbers. Note that
 `CborValueConverter` does not write `SemanticTag` back — reading a document into a `CborValue` and
 serializing it again drops the tag, turning the typed array into a plain byte string. That is true of
-every semantic tag, not just these, but typed arrays are the easiest way to meet it.
+every semantic tag, not just these, but typed arrays are the easiest way to meet it. Tracked as
+https://github.com/dahomey-technologies/Dahomey.Cbor/issues/162.
 
 ### Custom converters
 

--- a/src/Dahomey.Cbor.Tests/CborReaderTests.cs
+++ b/src/Dahomey.Cbor.Tests/CborReaderTests.cs
@@ -260,7 +260,7 @@ namespace Dahomey.Cbor.Tests
 
         [Theory]
         [InlineData("63666F6F", "foo", null)]
-        [InlineData("7F6166616F616FFF", "foo", typeof(NotSupportedException))]
+        [InlineData("7F6166616F616FFF", "foo", typeof(CborException))]
         [InlineData("F6", null, null)]
         [InlineData("C6F6", null, null)] // semantig tag 6 + null
         [InlineData("60", "", null)]

--- a/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
+++ b/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
@@ -1,0 +1,861 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Serialization.Converters;
+using Dahomey.Cbor.Tests.Extensions;
+using Dahomey.Cbor.Util;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    public class TypedArrayTests
+    {
+        private static CborOptions TypedArrayOptions()
+        {
+            return new CborOptions { TypedArrayMode = TypedArrayMode.ReadWriteLittleEndian };
+        }
+
+        [Fact]
+        public void WriteFloatArrayAsTypedArray()
+        {
+            // D855 tag(85) 48 bytes(8) -> 1.5f, 2.5f little endian
+            Helper.TestWrite(new[] { 1.5f, 2.5f }, "D855480000C03F00002040", null, TypedArrayOptions());
+        }
+
+        [Fact]
+        public void WriteDoubleArrayAsTypedArray()
+        {
+            // D856 tag(86) 48 bytes(8) -> 1.5d little endian
+            Helper.TestWrite(new[] { 1.5d }, "D85648000000000000F83F", null, TypedArrayOptions());
+        }
+
+        [Fact]
+        public void WriteInt16ArrayAsTypedArray()
+        {
+            // D84D tag(77) 44 bytes(4) -> 1, -2 little endian
+            Helper.TestWrite(new short[] { 1, -2 }, "D84D440100FEFF", null, TypedArrayOptions());
+        }
+
+        [Fact]
+        public void WriteEmptyArrayAsTypedArray()
+        {
+            // D855 tag(85) 40 bytes(0)
+            Helper.TestWrite(new float[0], "D85540", null, TypedArrayOptions());
+        }
+
+        [Fact]
+        public void WriteNullArrayIsStillNull()
+        {
+            // F6 null
+            Helper.TestWrite<float[]>(null, "F6", null, TypedArrayOptions());
+        }
+
+        [Fact]
+        public void DefaultOptionsStillWritePlainArrays()
+        {
+            // 82 array(2) F93E00 1.5 F94100 2.5  -- unchanged from before this feature existed
+            Helper.TestWrite(new[] { 1.5f, 2.5f }, "82F93E00F94100");
+        }
+
+        [Fact]
+        public void TypedArrayRoundTrips()
+        {
+            CborOptions options = TypedArrayOptions();
+            float[] expected = new[] { 1.5f, 2.5f, float.MaxValue, float.Epsilon };
+
+            byte[] bytes;
+            using (ByteBufferWriter bufferWriter = new ByteBufferWriter())
+            {
+                Cbor.Serialize(expected, bufferWriter, options);
+                bytes = bufferWriter.WrittenSpan.ToArray();
+            }
+
+            float[] actual = Cbor.Deserialize<float[]>(bytes, options);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReadFloatArrayLittleEndian()
+        {
+            // D855 tag(85) 48 bytes(8) -> 1.5f, 2.5f little endian
+            float[] value = Helper.Read<float[]>("D855480000C03F00002040", TypedArrayOptions());
+            Assert.Equal(new[] { 1.5f, 2.5f }, value);
+        }
+
+        [Fact]
+        public void ReadDoubleArrayLittleEndian()
+        {
+            // D856 tag(86) 48 bytes(8) -> 1.5d little endian
+            double[] value = Helper.Read<double[]>("D85648000000000000F83F", TypedArrayOptions());
+            Assert.Equal(new[] { 1.5d }, value);
+        }
+
+        [Fact]
+        public void ReadInt16ArrayLittleEndian()
+        {
+            // D84D tag(77) 44 bytes(4) -> 1, -2 little endian
+            short[] value = Helper.Read<short[]>("D84D440100FEFF", TypedArrayOptions());
+            Assert.Equal(new short[] { 1, -2 }, value);
+        }
+
+        [Fact]
+        public void ReadSByteArray()
+        {
+            // D848 tag(72) 42 bytes(2) -> 1, -2
+            sbyte[] value = Helper.Read<sbyte[]>("D8484201FE", TypedArrayOptions());
+            Assert.Equal(new sbyte[] { 1, -2 }, value);
+        }
+
+        [Fact]
+        public void ReadInt64ArrayLittleEndian()
+        {
+            // D84F tag(79) 48 bytes(8) -> -2 little endian
+            long[] value = Helper.Read<long[]>("D84F48FEFFFFFFFFFFFFFF", TypedArrayOptions());
+            Assert.Equal(new long[] { -2 }, value);
+        }
+
+        [Fact]
+        public void ReadUInt16ArrayLittleEndian()
+        {
+            // D845 tag(69) 44 bytes(4) -> 1, 2 little endian
+            ushort[] value = Helper.Read<ushort[]>("D8454401000200", TypedArrayOptions());
+            Assert.Equal(new ushort[] { 1, 2 }, value);
+        }
+
+        [Fact]
+        public void ReadInt32ArrayLittleEndian()
+        {
+            // D84E tag(78) 48 bytes(8) -> 1, -2 little endian
+            int[] value = Helper.Read<int[]>("D84E4801000000FEFFFFFF", TypedArrayOptions());
+            Assert.Equal(new[] { 1, -2 }, value);
+        }
+
+        [Fact]
+        public void ReadUInt32ArrayLittleEndian()
+        {
+            // D846 tag(70) 44 bytes(4) -> 1 little endian
+            uint[] value = Helper.Read<uint[]>("D8464401000000", TypedArrayOptions());
+            Assert.Equal(new uint[] { 1 }, value);
+        }
+
+        [Fact]
+        public void ReadUInt64ArrayLittleEndian()
+        {
+            // D847 tag(71) 48 bytes(8) -> 1 little endian
+            ulong[] value = Helper.Read<ulong[]>("D847480100000000000000", TypedArrayOptions());
+            Assert.Equal(new ulong[] { 1 }, value);
+        }
+
+        [Fact]
+        public void ReadHalfArrayLittleEndian()
+        {
+            // D854 tag(84) 42 bytes(2) -> 1.5 little endian
+            Half[] value = Helper.Read<Half[]>("D85442003E", TypedArrayOptions());
+            Assert.Equal(new[] { (Half)1.5f }, value);
+        }
+
+        [Fact]
+        public void ReadEmptyTypedArray()
+        {
+            // D855 tag(85) 40 bytes(0) -> empty
+            float[] value = Helper.Read<float[]>("D85540", TypedArrayOptions());
+            Assert.Empty(value);
+        }
+
+        [Fact]
+        public void ReadPlainArrayStillWorks()
+        {
+            // 82 array(2) F93E00 1.5 F94100 2.5  -- preferred serialization shrinks both to half
+            float[] value = Helper.Read<float[]>("82F93E00F94100");
+            Assert.Equal(new[] { 1.5f, 2.5f }, value);
+        }
+
+        [Fact]
+        public void UnrecognisedTagFallsThroughToPlainArray()
+        {
+            // D827 tag(39) 82 array(2) 01 02  -- tag 39 is not a typed array tag, so it is ignored
+            int[] value = Helper.Read<int[]>("D827820102");
+            Assert.Equal(new[] { 1, 2 }, value);
+        }
+
+        [Fact]
+        public void ReadFloatArrayBigEndian()
+        {
+            // D851 tag(81) 48 bytes(8) -> 1.5f, 2.5f big endian
+            float[] value = Helper.Read<float[]>("D851483FC0000040200000", TypedArrayOptions());
+            Assert.Equal(new[] { 1.5f, 2.5f }, value);
+        }
+
+        [Fact]
+        public void ReadInt16ArrayBigEndian()
+        {
+            // D849 tag(73) 44 bytes(4) -> 1, -2 big endian
+            short[] value = Helper.Read<short[]>("D849440001FFFE", TypedArrayOptions());
+            Assert.Equal(new short[] { 1, -2 }, value);
+        }
+
+        [Fact]
+        public void ReadDoubleArrayBigEndian()
+        {
+            // D852 tag(82) 48 bytes(8) -> 1.5d big endian
+            double[] value = Helper.Read<double[]>("D852483FF8000000000000", TypedArrayOptions());
+            Assert.Equal(new[] { 1.5d }, value);
+        }
+
+        [Fact]
+        public void BigEndianAndLittleEndianDecodeIdentically()
+        {
+            Assert.Equal(
+                Helper.Read<float[]>("D855480000C03F00002040", TypedArrayOptions()),
+                Helper.Read<float[]>("D851483FC0000040200000", TypedArrayOptions()));
+        }
+
+        private static CborException AssertThrowsCborException(Action action)
+        {
+            // Converters are built through Activator.CreateInstance, so a CborException thrown while
+            // building a mapping arrives wrapped in TargetInvocationException.
+            Exception exception = Record.Exception(action);
+            Assert.NotNull(exception);
+
+            for (Exception current = exception; current != null; current = current.InnerException)
+            {
+                if (current is CborException cborException)
+                {
+                    return cborException;
+                }
+            }
+
+            Assert.Fail($"Expected a CborException, got {exception}");
+            return null;
+        }
+
+        [Fact]
+        public void PayloadLengthNotAMultipleOfElementSizeThrows()
+        {
+            // D855 tag(85) 43 bytes(3) -- 3 is not divisible by 4
+            AssertThrowsCborException(() => Helper.Read<float[]>("D85543000000", TypedArrayOptions()));
+        }
+
+        [Fact]
+        public void WrongElementTypeThrows()
+        {
+            // D856 tag(86) is binary64; reading it into float[] is corrupt data, not a conversion
+            AssertThrowsCborException(() => Helper.Read<float[]>("D85648000000000000F83F", TypedArrayOptions()));
+        }
+
+        [Fact]
+        public void ReservedTag76Throws()
+        {
+            // D84C tag(76) is reserved by RFC 8746
+            AssertThrowsCborException(() => Helper.Read<short[]>("D84C4401000200", TypedArrayOptions()));
+        }
+
+        [Fact]
+        public void Binary128TagThrows()
+        {
+            // D853 tag(83) 40 bytes(0) -- binary128, which has no .NET type
+            AssertThrowsCborException(() => Helper.Read<double[]>("D85340", TypedArrayOptions()));
+        }
+
+        [Fact]
+        public void ReadByteArrayWithUint8Tag()
+        {
+            // D840 tag(64) 42 bytes(2) -> 1, 2
+            byte[] value = Helper.Read<byte[]>("D840420102");
+            Assert.Equal(new byte[] { 1, 2 }, value);
+        }
+
+        [Fact]
+        public void ReadByteArrayWithClampedUint8Tag()
+        {
+            // D844 tag(68) 42 bytes(2) -> 1, 2
+            byte[] value = Helper.Read<byte[]>("D844420102");
+            Assert.Equal(new byte[] { 1, 2 }, value);
+        }
+
+        [Fact]
+        public void ByteArrayIsStillWrittenAsAPlainByteString()
+        {
+            // 42 bytes(2) 0102 -- never tag 64, because the plain form is shorter and idiomatic
+            Helper.TestWrite(new byte[] { 1, 2 }, "420102", null, TypedArrayOptions());
+        }
+
+        [Fact]
+        public void TypedArrayIsSubstantiallySmallerForRealisticSampleData()
+        {
+            // A thousand sensor samples, the shape this feature exists for. Values are deliberately
+            // not representable as binary16, so the plain form cannot shrink each element to 3 bytes
+            // and the comparison reflects real recorded data rather than a best case for either side.
+            float[] samples = new float[1000];
+            for (int i = 0; i < samples.Length; i++)
+            {
+                samples[i] = i * 0.37f;
+            }
+
+            int plainBytes = Helper.Write(samples).Length / 2;
+            int typedBytes = Helper.Write(samples, TypedArrayOptions()).Length / 2;
+
+            // D8 55 (tag 85, 2 bytes) + 59 0F A0 (byte-string header, 3 bytes, since the 4000-byte
+            // payload needs a 2-byte length so the header itself is 3 bytes) + 4 bytes per element.
+            Assert.Equal(2 + 3 + 4 * samples.Length, typedBytes);
+
+            // The plain form pays a per-element header. Assert a floor rather than an exact number so
+            // the test states the guarantee instead of pinning an incidental encoding detail.
+            Assert.True(plainBytes > typedBytes,
+                $"expected the typed array to be smaller; plain={plainBytes} typed={typedBytes}");
+        }
+
+        // A typed array is almost always reached as a member of an object rather than as the root
+        // value, so the tag has to survive every probe the object read path performs before the
+        // member's own converter runs. The three object formats take three different code paths.
+
+        public class SamplesHolder
+        {
+            public float[] Samples { get; set; }
+            public string Unit { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        public class SamplesHolderIntKeyMap
+        {
+            [CborProperty(1)]
+            public float[] Samples { get; set; }
+            [CborProperty(2)]
+            public string Unit { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class SamplesHolderArray
+        {
+            [CborProperty(0)]
+            public float[] Samples { get; set; }
+            [CborProperty(1)]
+            public string Unit { get; set; }
+        }
+
+        [Fact]
+        public void StringKeyMapMemberRoundTrips()
+        {
+            // A2 map(2) 6753616D706C6573 "Samples" D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            //           64556E6974 "Unit" 6156 "V"
+            const string hexBuffer = "A26753616D706C6573D855480000C03F0000204064556E69746156";
+            CborOptions options = TypedArrayOptions();
+
+            SamplesHolder value = new SamplesHolder { Samples = new[] { 1.5f, 2.5f }, Unit = "V" };
+            Helper.TestWrite(value, hexBuffer, null, options);
+
+            SamplesHolder actual = Helper.Read<SamplesHolder>(hexBuffer, options);
+            Assert.Equal(new[] { 1.5f, 2.5f }, actual.Samples);
+            Assert.Equal("V", actual.Unit);
+        }
+
+        [Fact]
+        public void IntKeyMapMemberRoundTrips()
+        {
+            // A2 map(2) 01 1 D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            //           02 2 6156 "V"
+            const string hexBuffer = "A201D855480000C03F00002040026156";
+            CborOptions options = TypedArrayOptions();
+
+            SamplesHolderIntKeyMap value = new SamplesHolderIntKeyMap { Samples = new[] { 1.5f, 2.5f }, Unit = "V" };
+            Helper.TestWrite(value, hexBuffer, null, options);
+
+            SamplesHolderIntKeyMap actual = Helper.Read<SamplesHolderIntKeyMap>(hexBuffer, options);
+            Assert.Equal(new[] { 1.5f, 2.5f }, actual.Samples);
+            Assert.Equal("V", actual.Unit);
+        }
+
+        [Fact]
+        public void ArrayFormatMemberRoundTrips()
+        {
+            // 82 array(2) D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            //             6156 "V"
+            const string hexBuffer = "82D855480000C03F000020406156";
+            CborOptions options = TypedArrayOptions();
+
+            SamplesHolderArray value = new SamplesHolderArray { Samples = new[] { 1.5f, 2.5f }, Unit = "V" };
+            Helper.TestWrite(value, hexBuffer, null, options);
+
+            SamplesHolderArray actual = Helper.Read<SamplesHolderArray>(hexBuffer, options);
+            Assert.Equal(new[] { 1.5f, 2.5f }, actual.Samples);
+            Assert.Equal("V", actual.Unit);
+        }
+
+        public struct SamplesStruct
+        {
+            public float[] Samples { get; set; }
+            public int Id { get; set; }
+        }
+
+        [Fact]
+        public void StructMemberRoundTrips()
+        {
+            // Structs go through StructMemberConverter, a separate read path from the class one.
+            // A2 map(2) 6753616D706C6573 "Samples" D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            //           624964 "Id" 0C 12
+            const string hexBuffer = "A26753616D706C6573D855480000C03F000020406249640C";
+            CborOptions options = TypedArrayOptions();
+
+            SamplesStruct value = new SamplesStruct { Samples = new[] { 1.5f, 2.5f }, Id = 12 };
+            Helper.TestWrite(value, hexBuffer, null, options);
+
+            SamplesStruct actual = Helper.Read<SamplesStruct>(hexBuffer, options);
+            Assert.Equal(new[] { 1.5f, 2.5f }, actual.Samples);
+            Assert.Equal(12, actual.Id);
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class Signal
+        {
+            [CborProperty(1)]
+            public float[] Samples { get; set; }
+        }
+
+        [CborDiscriminator("Analog")]
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class AnalogSignal : Signal
+        {
+            [CborProperty(2)]
+            public string Unit { get; set; }
+        }
+
+        private static CborOptions PolymorphicArrayOptions()
+        {
+            CborOptions options = new CborOptions
+            {
+                TypedArrayMode = TypedArrayMode.ReadWriteLittleEndian,
+                DiscriminatorPolicy = CborDiscriminatorPolicy.Always
+            };
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<AnalogSignal>();
+            return options;
+        }
+
+        [Fact]
+        public void ArrayFormatWithDiscriminatorTagRoundTripsTypedArrayMember()
+        {
+            // Two tags in one document: the discriminator tag on the object and an RFC 8746 tag on
+            // the member nested inside it.
+            // 83 array(3) D827 tag(39) 66416E616C6F67 "Analog"
+            //             D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            //             6156 "V"
+            const string hexBuffer = "83D82766416E616C6F67D855480000C03F000020406156";
+            CborOptions options = PolymorphicArrayOptions();
+
+            Signal value = new AnalogSignal { Samples = new[] { 1.5f, 2.5f }, Unit = "V" };
+            Helper.TestWrite(value, hexBuffer, null, options);
+
+            Signal actual = Helper.Read<Signal>(hexBuffer, options);
+            AnalogSignal analog = Assert.IsType<AnalogSignal>(actual);
+            Assert.Equal(new[] { 1.5f, 2.5f }, analog.Samples);
+            Assert.Equal("V", analog.Unit);
+        }
+
+        [Fact]
+        public void ArrayFormatKeepsANonDiscriminatorTagForTheFirstItem()
+        {
+            // The object expects a discriminator tag as its first item but the document carries none,
+            // so the RFC 8746 tag it finds instead belongs to the first member and must be left in
+            // place for that member's converter.
+            // 82 array(2) D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            //             6156 "V"
+            const string hexBuffer = "82D855480000C03F000020406156";
+
+            AnalogSignal actual = Helper.Read<AnalogSignal>(hexBuffer, PolymorphicArrayOptions());
+            Assert.Equal(new[] { 1.5f, 2.5f }, actual.Samples);
+            Assert.Equal("V", actual.Unit);
+        }
+
+        [Fact]
+        public void TypedArrayAsDictionaryValueRoundTrips()
+        {
+            // A1 map(1) 6161 "a" D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            const string hexBuffer = "A16161D855480000C03F00002040";
+            CborOptions options = TypedArrayOptions();
+
+            Dictionary<string, float[]> value = new Dictionary<string, float[]>
+            {
+                ["a"] = new[] { 1.5f, 2.5f }
+            };
+            Helper.TestWrite(value, hexBuffer, null, options);
+
+            // Helper.Read compares the results of three readers for equality, which a collection of
+            // arrays cannot satisfy - float[] has no value equality. Deserialize once instead.
+            Dictionary<string, float[]> actual = Cbor.Deserialize<Dictionary<string, float[]>>(
+                hexBuffer.HexToBytes(), options);
+            Assert.Equal(new[] { 1.5f, 2.5f }, actual["a"]);
+        }
+
+        [Fact]
+        public void TypedArrayInAListRoundTrips()
+        {
+            // 82 array(2) D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            //             D85548000040400000A040 tag(85) bytes(8) 3f, 5f
+            const string hexBuffer = "82D855480000C03F00002040D85548000040400000A040";
+            CborOptions options = TypedArrayOptions();
+
+            List<float[]> value = new List<float[]>
+            {
+                new[] { 1.5f, 2.5f },
+                new[] { 3f, 5f }
+            };
+            Helper.TestWrite(value, hexBuffer, null, options);
+
+            List<float[]> actual = Cbor.Deserialize<List<float[]>>(hexBuffer.HexToBytes(), options);
+            Assert.Equal(new[] { 1.5f, 2.5f }, actual[0]);
+            Assert.Equal(new[] { 3f, 5f }, actual[1]);
+        }
+
+        [Fact]
+        public void TypedArrayInAnIndefiniteLengthArrayRoundTrips()
+        {
+            // An indefinite-length container probes for the break marker before every item, and that
+            // probe must not consume the item's own tag.
+            // 9F array(*) D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            //             FF break
+            const string hexBuffer = "9FD855480000C03F00002040FF";
+
+            List<float[]> actual = Cbor.Deserialize<List<float[]>>(hexBuffer.HexToBytes(), TypedArrayOptions());
+            Assert.Single(actual);
+            Assert.Equal(new[] { 1.5f, 2.5f }, actual[0]);
+        }
+
+        [Fact]
+        public void TypedArrayInAnIndefiniteLengthMapRoundTrips()
+        {
+            // BF map(*) 6161 "a" D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            //           FF break
+            const string hexBuffer = "BF6161D855480000C03F00002040FF";
+
+            Dictionary<string, float[]> actual = Cbor.Deserialize<Dictionary<string, float[]>>(
+                hexBuffer.HexToBytes(), TypedArrayOptions());
+            Assert.Equal(new[] { 1.5f, 2.5f }, actual["a"]);
+        }
+
+        [Fact]
+        public void TypedArrayInAnIndefiniteLengthTupleRoundTrips()
+        {
+            // Tuples run their own break probe before every item, on the same terms.
+            // 9F array(*) D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            //             6156 "V" FF break
+            const string hexBuffer = "9FD855480000C03F000020406156FF";
+
+            (float[] samples, string unit) = Cbor.Deserialize<ValueTuple<float[], string>>(
+                hexBuffer.HexToBytes(), TypedArrayOptions());
+            Assert.Equal(new[] { 1.5f, 2.5f }, samples);
+            Assert.Equal("V", unit);
+        }
+
+        public class NullableSamplesHolder
+        {
+            public float[] S { get; set; }
+        }
+
+        [Fact]
+        public void NullTypedArrayMemberRoundTripsAsNull()
+        {
+            // The member probe that finds this null is the one that must not consume a tag, so the
+            // null case is worth pinning on its own.
+            // A1 map(1) 6153 "S" F6 null
+            const string hexBuffer = "A16153F6";
+            CborOptions options = TypedArrayOptions();
+
+            Helper.TestWrite(new NullableSamplesHolder { S = null }, hexBuffer, null, options);
+
+            NullableSamplesHolder actual = Helper.Read<NullableSamplesHolder>(hexBuffer, options);
+            Assert.Null(actual.S);
+        }
+
+        [Fact]
+        public void NullTypedArrayMemberStillHonoursDisallowNull()
+        {
+            CborOptions options = TypedArrayOptions();
+            options.Registry.ObjectMappingRegistry.Register<NullableSamplesHolder>(objectMapping =>
+                objectMapping
+                    .AutoMap()
+                    .ClearMemberMappings()
+                    .MapMember(o => o.S).SetRequired(RequirementPolicy.DisallowNull)
+            );
+
+            // A1 map(1) 6153 "S" F6 null
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<NullableSamplesHolder>("A16153F6".HexToBytes(), options));
+            Assert.Equal("Property 'S' cannot be null.", exception.Message);
+        }
+
+        [Fact]
+        public void DefaultOptionsNeitherReadNorWriteTypedArrays()
+        {
+            // The default is a no-op: an upgrade that brings typed arrays in must not change what a
+            // caller who never asked for them reads or writes.
+            CborOptions options = new CborOptions();
+            Assert.Equal(TypedArrayMode.Never, options.TypedArrayMode);
+
+            // D855 tag(85) 48 bytes(8) -> 1.5f, 2.5f little endian. The tag is skipped like any other
+            // unrecognised tag, leaving a byte string where an array is required.
+            AssertThrowsCborException(() => Helper.Read<float[]>("D855480000C03F00002040", options));
+
+            // 82 array(2) F93E00 1.5 F94100 2.5 -- ordinary arrays are unaffected, in both directions
+            Helper.TestWrite(new[] { 1.5f, 2.5f }, "82F93E00F94100", null, options);
+            Assert.Equal(new[] { 1.5f, 2.5f }, Helper.Read<float[]>("82F93E00F94100", options));
+        }
+
+        [Fact]
+        public void ReadingCanBeEnabledWithoutWriting()
+        {
+            // The interop case the two flags exist for: accept a peer's typed arrays without emitting
+            // any, so the wire format this side produces does not change.
+            CborOptions options = new CborOptions { TypedArrayMode = TypedArrayMode.Read };
+
+            // D855 tag(85) 48 bytes(8) -> 1.5f, 2.5f little endian
+            Assert.Equal(new[] { 1.5f, 2.5f }, Helper.Read<float[]>("D855480000C03F00002040", options));
+
+            // A2 map(2) 6753616D706C6573 "Samples" D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            //           64556E6974 "Unit" 6156 "V"
+            SamplesHolder holder = Helper.Read<SamplesHolder>(
+                "A26753616D706C6573D855480000C03F0000204064556E69746156", options);
+            Assert.Equal(new[] { 1.5f, 2.5f }, holder.Samples);
+            Assert.Equal("V", holder.Unit);
+
+            // 82 array(2) F93E00 1.5 F94100 2.5 -- writing stays plain
+            Helper.TestWrite(new[] { 1.5f, 2.5f }, "82F93E00F94100", null, options);
+        }
+
+        [Fact]
+        public void WritingCanBeEnabledWithoutReading()
+        {
+            CborOptions options = new CborOptions { TypedArrayMode = TypedArrayMode.WriteLittleEndian };
+
+            // D855 tag(85) 48 bytes(8) -> 1.5f, 2.5f little endian
+            Helper.TestWrite(new[] { 1.5f, 2.5f }, "D855480000C03F00002040", null, options);
+
+            // and, being write-only, these options cannot read back what they just wrote
+            AssertThrowsCborException(() => Helper.Read<float[]>("D855480000C03F00002040", options));
+        }
+
+        public class ListSamplesHolder
+        {
+            public List<float> Samples { get; set; }
+            public string Unit { get; set; }
+        }
+
+        [Fact]
+        public void ATypedArrayReadsIntoAnyInterchangeableCollection()
+        {
+            // float[], List<float>, IList<float>, HashSet<float> and ImmutableArray<float> are
+            // interchangeable when reading an ordinary CBOR array. A typed array is still an array, so
+            // they stay interchangeable: a document this library writes from a float[] member is
+            // readable by a consumer that declares any of them.
+            // D855 tag(85) 48 bytes(8) -> 1.5f, 2.5f little endian
+            byte[] buffer = "D855480000C03F00002040".HexToBytes();
+            CborOptions options = TypedArrayOptions();
+            float[] expected = new[] { 1.5f, 2.5f };
+
+            Assert.Equal(expected, Cbor.Deserialize<float[]>(buffer, options));
+            Assert.Equal(expected, Cbor.Deserialize<List<float>>(buffer, options));
+            Assert.Equal(expected, Cbor.Deserialize<IList<float>>(buffer, options));
+            Assert.Equal(expected, Cbor.Deserialize<ICollection<float>>(buffer, options));
+            Assert.Equal(expected, Cbor.Deserialize<IEnumerable<float>>(buffer, options));
+            Assert.Equal(expected, Cbor.Deserialize<IReadOnlyList<float>>(buffer, options));
+            Assert.Equal(expected, Cbor.Deserialize<ImmutableArray<float>>(buffer, options));
+            Assert.Equal(expected, Cbor.Deserialize<ImmutableList<float>>(buffer, options));
+            Assert.Equal(new HashSet<float>(expected), Cbor.Deserialize<HashSet<float>>(buffer, options));
+        }
+
+        [Fact]
+        public void ATypedArrayMemberReadsIntoACollectionMember()
+        {
+            // Byte for byte the document SamplesHolder writes from its float[] member, read by a
+            // consumer that declares the same member as List<float>.
+            // A2 map(2) 6753616D706C6573 "Samples" D855480000C03F00002040 tag(85) bytes(8) 1.5f, 2.5f
+            //           64556E6974 "Unit" 6156 "V"
+            byte[] buffer = "A26753616D706C6573D855480000C03F0000204064556E69746156".HexToBytes();
+
+            ListSamplesHolder holder = Cbor.Deserialize<ListSamplesHolder>(buffer, TypedArrayOptions());
+
+            Assert.Equal(new[] { 1.5f, 2.5f }, holder.Samples);
+            Assert.Equal("V", holder.Unit);
+        }
+
+        [Fact]
+        public void CollectionsWriteOrdinaryArraysAndArraysReadThemBack()
+        {
+            // Writing typed arrays is scoped to T[]. That is not an asymmetry now that every
+            // interchangeable shape can read one: whatever this library writes, any of them reads.
+            CborOptions options = TypedArrayOptions();
+
+            // 82 array(2) F93E00 1.5 F94100 2.5
+            Helper.TestWrite(new List<float> { 1.5f, 2.5f }, "82F93E00F94100", null, options);
+            Assert.Equal(new[] { 1.5f, 2.5f }, Helper.Read<float[]>("82F93E00F94100", options));
+        }
+
+        [Fact]
+        public void ATypedArrayTagIntoAnIncompatibleCollectionThrows()
+        {
+            CborOptions options = TypedArrayOptions();
+
+            // tag 86 is binary64, so it cannot fill a List<float>
+            AssertThrowsCborException(
+                () => Cbor.Deserialize<List<float>>("D85648000000000000F83F".HexToBytes(), options));
+
+            // and a List<string> has no typed array form at all
+            AssertThrowsCborException(
+                () => Cbor.Deserialize<List<string>>("D855480000C03F00002040".HexToBytes(), options));
+        }
+
+        [Fact]
+        public void CollectionsAreUnaffectedWhenTypedArrayReadingIsOff()
+        {
+            // The same no-op guarantee the array path gives: with the default mode a collection reads
+            // exactly what it read before typed arrays existed.
+            CborOptions options = new CborOptions();
+
+            AssertThrowsCborException(
+                () => Cbor.Deserialize<List<float>>("D855480000C03F00002040".HexToBytes(), options));
+            Assert.Equal(
+                new[] { 1.5f, 2.5f },
+                Cbor.Deserialize<List<float>>("82F93E00F94100".HexToBytes(), options));
+        }
+
+        [Fact]
+        public void AChunkedTypedArrayPayloadIsACborException()
+        {
+            // RFC 8746 does not forbid an indefinite-length byte string as the tag content, and a
+            // producer streaming a large array is exactly where one shows up. The reader does not
+            // support chunked strings, but it has to say so as a CborException like every other
+            // unreadable-input error, or it escapes the handler a caller has written.
+            // D855 tag(85) 5F bytes(*) 44 0000C03F 44 00002040 FF
+            CborException exception = AssertThrowsCborException(
+                () => Cbor.Deserialize<float[]>("D8555F440000C03F4400002040FF".HexToBytes(), TypedArrayOptions()));
+
+            Assert.Contains("Indefinite-length", exception.Message);
+        }
+
+        [Fact]
+        public void ATypedArrayConverterIsNoMoreLenientAboutNestedTagsThanAnArrayConverter()
+        {
+            // int[] goes through TypedArrayConverter and string[] through ArrayConverter. What matters
+            // is that they agree: reading an array skips a tag twice, once in ReadNull and once in
+            // ReadBeginArray, so two stacked tags are accepted and three are not. Consuming the tag in
+            // TypedArrayConverter.Read as well would let the typed path take a third, accepting a
+            // nesting the plain path rejects.
+            CborOptions options = TypedArrayOptions();
+
+            // D827 tag(39) C1 tag(1) 820102 [1, 2]
+            Assert.Equal(new[] { 1, 2 }, Helper.Read<int[]>("D827C1820102", options));
+            Assert.Equal(new[] { "a", "b" }, Helper.Read<string[]>("D827C18261616162", options));
+
+            // D827 tag(39) C1 tag(1) C1 tag(1) 820102 [1, 2] -- one tag too many for either
+            AssertThrowsCborException(() => Helper.Read<int[]>("D827C1C1820102", options));
+            AssertThrowsCborException(() => Helper.Read<string[]>("D827C1C18261616162", options));
+        }
+
+        [Fact]
+        public void IndefiniteArrayLengthIsIgnoredForATypedArray()
+        {
+            // A typed array is a single definite-length byte string, so there is no array header for
+            // ArrayLengthMode to make indefinite. It still applies to any array not written as one.
+            CborOptions options = new CborOptions
+            {
+                TypedArrayMode = TypedArrayMode.ReadWriteLittleEndian,
+                ArrayLengthMode = LengthMode.IndefiniteLength,
+            };
+
+            // D855 tag(85) 48 bytes(8) -> 1.5f, 2.5f little endian
+            Helper.TestWrite(new[] { 1.5f, 2.5f }, "D855480000C03F00002040", null, options);
+
+            // 9F array(*) 6161 "a" FF -- a string[] has no typed form and stays indefinite
+            Helper.TestWrite(new[] { "a" }, "9F6161FF", null, options);
+        }
+
+        [Fact]
+        public void TheObjectModelSeesATypedArrayAsAByteStringAndDropsItsTag()
+        {
+            // CborValue has no typed array node, so a typed array arrives as a byte string with the tag
+            // parked in CborValue.SemanticTag. Two consequences for a DOM consumer:
+            //
+            //   * code that inspects or compares the value sees opaque bytes, not numbers;
+            //   * CborValueConverter never writes SemanticTag back, so reading a document and writing
+            //     it out again turns the typed array into an ordinary byte string.
+            //
+            // The second is a general property of the object model rather than anything typed arrays
+            // introduce -- every semantic tag is dropped this way -- but typed arrays are what make it
+            // easy to reach. It is pinned here so that changing it is a deliberate act.
+            // D855 tag(85) 48 bytes(8) -> 1.5f, 2.5f little endian
+            CborOptions options = TypedArrayOptions();
+            CborValue value = Cbor.Deserialize<CborValue>("D855480000C03F00002040".HexToBytes(), options);
+
+            Assert.Equal(CborValueType.ByteString, value.Type);
+            Assert.Equal(85ul, value.SemanticTag);
+
+            // 48 bytes(8) -- written back without D855, so the reader no longer sees a typed array
+            Helper.TestWrite(value, "480000C03F00002040", null, options);
+        }
+
+        private static float[] ReadFloatsWith(TypedArrayConverter<float> converter, string hexBuffer)
+        {
+            byte[] buffer = hexBuffer.HexToBytes();
+            CborReader reader = new CborReader(buffer.AsSpan());
+            return converter.Read(ref reader);
+        }
+
+        private static string WriteFloatsWith(TypedArrayConverter<float> converter, float[] value)
+        {
+            ArrayBufferWriter<byte> buffer = new ArrayBufferWriter<byte>();
+            CborWriter writer = new CborWriter(buffer);
+            converter.Write(ref writer, value, LengthMode.Default);
+            return BitConverter.ToString(buffer.WrittenSpan.ToArray()).Replace("-", "");
+        }
+
+        [Fact]
+        public void TheByteSwapRunsForHardwareOfEitherOrder()
+        {
+            // The converter takes the host byte order rather than reading BitConverter.IsLittleEndian,
+            // so the swapping paths are reachable on a machine of either order. Without that, half of
+            // this code never runs on any CI machine in service.
+            CborOptions options = TypedArrayOptions();
+            TypedArrayConverter<float> littleEndianHost = new TypedArrayConverter<float>(options, hostIsLittleEndian: true);
+            TypedArrayConverter<float> bigEndianHost = new TypedArrayConverter<float>(options, hostIsLittleEndian: false);
+
+            // A swap is needed exactly when the payload's order and the host's differ, so the two
+            // matching combinations must agree and the two differing ones must agree with each other.
+            // D855 tag(85) is little endian, D851 tag(81) is big endian; the payload bytes are the same.
+            float[] matched = ReadFloatsWith(littleEndianHost, "D855480000C03F00002040");
+            Assert.Equal(matched, ReadFloatsWith(bigEndianHost, "D851480000C03F00002040"));
+
+            float[] crossed = ReadFloatsWith(littleEndianHost, "D851480000C03F00002040");
+            Assert.Equal(crossed, ReadFloatsWith(bigEndianHost, "D855480000C03F00002040"));
+
+            Assert.NotEqual(matched, crossed);
+
+            // On write the tag is always the little-endian one, so a big-endian host has to swap its
+            // in-memory image into it. 3FC00000 is 1.5f big endian, 40200000 is 2.5f big endian.
+            Assert.Equal("D855480000C03F00002040", WriteFloatsWith(littleEndianHost, new[] { 1.5f, 2.5f }));
+            Assert.Equal("D855483FC0000040200000", WriteFloatsWith(bigEndianHost, new[] { 1.5f, 2.5f }));
+        }
+
+        [Fact]
+        public void ASingleByteElementIsNeverSwapped()
+        {
+            // sbyte has one tag for both orders (72) and nothing to reorder inside an element, so the
+            // host's byte order cannot matter.
+            CborOptions options = TypedArrayOptions();
+
+            // D848 tag(72) 42 bytes(2) 01 FE -> 1, -2
+            foreach (bool hostIsLittleEndian in new[] { true, false })
+            {
+                TypedArrayConverter<sbyte> converter = new TypedArrayConverter<sbyte>(options, hostIsLittleEndian);
+
+                ArrayBufferWriter<byte> buffer = new ArrayBufferWriter<byte>();
+                CborWriter writer = new CborWriter(buffer);
+                converter.Write(ref writer, new sbyte[] { 1, -2 }, LengthMode.Default);
+
+                Assert.Equal("D8484201FE", BitConverter.ToString(buffer.WrittenSpan.ToArray()).Replace("-", ""));
+            }
+        }
+    }
+}

--- a/src/Dahomey.Cbor/CborOptions.cs
+++ b/src/Dahomey.Cbor/CborOptions.cs
@@ -34,6 +34,41 @@ namespace Dahomey.Cbor
         IndefiniteLength = 2
     }
 
+    /// <summary>
+    /// Controls whether numeric arrays are read from, and written as, RFC 8746 typed arrays (tags 64-87).
+    /// </summary>
+    /// <remarks>
+    /// Reading and writing are separate flags so that a peer's typed arrays can be accepted without
+    /// emitting any. <see cref="Never"/> is the default and is a true no-op: with it, the library reads
+    /// and writes exactly what it did before typed arrays existed.
+    /// </remarks>
+    [Flags]
+    public enum TypedArrayMode
+    {
+        /// <summary>
+        /// Typed arrays are neither read nor written. A tag in the range 64-87 is skipped like any other
+        /// unrecognised semantic tag, so its content must be an ordinary CBOR array to be readable.
+        /// </summary>
+        Never = 0,
+
+        /// <summary>
+        /// Read RFC 8746 typed arrays, in either byte order, into the matching numeric array or collection.
+        /// A tag whose element type does not match the target throws a <see cref="CborException"/>.
+        /// </summary>
+        Read = 1,
+
+        /// <summary>
+        /// Write numeric arrays as little-endian typed arrays: tags 72, 69, 77, 70, 78, 71, 79, 84, 85
+        /// and 86. The payload is a byte-for-byte image of the array on little-endian hardware.
+        /// </summary>
+        WriteLittleEndian = 2,
+
+        /// <summary>
+        /// Read typed arrays and write little-endian ones.
+        /// </summary>
+        ReadWriteLittleEndian = Read | WriteLittleEndian,
+    }
+
     public class CborOptions
     {
         public static CborOptions Default { get; } = new CborOptions()
@@ -124,6 +159,22 @@ namespace Dahomey.Cbor
                     + "indefinite lengths admit more than one encoding of the same value.");
             }
         }
+
+        /// <summary>
+        /// Whether RFC 8746 typed arrays are read and written. Default <see cref="TypedArrayMode.Never"/>,
+        /// which leaves both paths exactly as they were before typed arrays existed.
+        /// </summary>
+        /// <remarks>
+        /// A typed array is one definite-length byte string, so <see cref="ArrayLengthMode"/> has nothing
+        /// to apply to and is ignored for any array actually written as one.
+        /// <para>
+        /// Independent of <see cref="Deterministic"/> in both directions. A typed array and a plain CBOR
+        /// array are two encodings of the same value, but which one is written is fixed by this setting
+        /// rather than chosen per value, so either mode yields one encoding and §4.2.1 is satisfied
+        /// without constraining this choice.
+        /// </para>
+        /// </remarks>
+        public TypedArrayMode TypedArrayMode { get; set; } = TypedArrayMode.Never;
 
         /// <summary>
         /// Semantic Tag to check if the discriminator is present when ObjectFormat is Array

--- a/src/Dahomey.Cbor/Dahomey.Cbor.csproj
+++ b/src/Dahomey.Cbor/Dahomey.Cbor.csproj
@@ -36,10 +36,13 @@
       <PackageReference Include="System.IO.Pipelines" Version="10.0.1" />
   </ItemGroup>
 
-  <!-- CborKeyComparer is internal: its rules are exercised directly by unit tests that the encoded
-       bytes cannot reach, such as a 65536-character key or int.MinValue. A strong-named assembly may
-       only grant friend access to another strong-named assembly, which is why the test project is
+  <!-- Two internals are exercised directly by tests that the encoded bytes cannot reach:
+       CborKeyComparer, whose rules cover cases such as a 65536-character key or int.MinValue, and
+       TypedArrayConverter, whose byte-swapping paths take the host byte order as a constructor
+       argument so both orders can be exercised on little-endian CI hardware. A strong-named assembly
+       may only grant friend access to another strong-named assembly, which is why the test project is
        signed with the same key. -->
+
   <ItemGroup>
     <InternalsVisibleTo Include="Dahomey.Cbor.Tests" Key="0024000004800000940000000602000000240000525341310004000001000100a1d13d213c4ddbe57c8cfdd25d1775a32e40eeca99c937fb91e124f672b891dde0b874d5495efd49fd23fcaef1a66d82482a52b8ba3c000d299679b39d1655b54e3cdd7fb5b7e365ecbe58cea1b94ef9a60d01ae93a0ed2e932d23830f7816c321ff3e987c547ffa0994c5e169ddd8ba09440261746b708a80ba0859b5378ba9" />
   </ItemGroup>

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -283,6 +283,20 @@ namespace Dahomey.Cbor.Serialization
                 && (header.Primitive == CborPrimitive.Null || header.Primitive == CborPrimitive.Undefined);
         }
 
+        /// <summary>
+        /// Reports whether the next data item carries a semantic tag.
+        /// </summary>
+        /// <remarks>
+        /// Like <see cref="IsNull"/> and <see cref="IsBreak"/> this inspects the header and skips
+        /// nothing. It lets a converter that only sometimes wants the tag pay for a bookmark on the rare
+        /// tagged item rather than on every item.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool IsSemanticTag()
+        {
+            return GetHeader().MajorType == CborMajorType.SemanticTag;
+        }
+
         public CborReaderBookmark GetBookmark()
         {
             CborReaderBookmark bookmark;

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -903,7 +903,7 @@ namespace Dahomey.Cbor.Serialization
 
             if (size == -1)
             {
-                ThrowNotSupported();
+                ThrowIndefiniteLengthString();
             }
 
             return ReadBytes(size, allowScratchBuffer);
@@ -938,7 +938,7 @@ namespace Dahomey.Cbor.Serialization
 
             if (size == -1)
             {
-                ThrowNotSupported();
+                ThrowIndefiniteLengthString();
             }
 
             ExpectLength(size);
@@ -1088,7 +1088,7 @@ namespace Dahomey.Cbor.Serialization
 
             if (size == -1)
             {
-                ThrowNotSupported();
+                ThrowIndefiniteLengthString();
             }
 
             ExpectLength(size);
@@ -1223,9 +1223,21 @@ namespace Dahomey.Cbor.Serialization
             throw BuildException(message);
         }
 
-        private void ThrowNotSupported()
+        /// <summary>
+        /// Indefinite-length byte and text strings - RFC 8949 §3.2.3, a chunked string terminated by a
+        /// break marker - are not supported by this reader.
+        /// </summary>
+        /// <remarks>
+        /// This is a <see cref="CborException"/> rather than a <see cref="NotSupportedException"/> so
+        /// that it is caught by the same handler as every other malformed- or unreadable-input error.
+        /// A caller has no way to tell the two apart at the point of the read, and a chunked string is
+        /// a property of the document, not of the API being misused.
+        /// </remarks>
+        private void ThrowIndefiniteLengthString()
         {
-            throw new NotSupportedException();
+            throw BuildException(
+                "Indefinite-length byte and text strings are not supported. "
+                + "Re-encode the value as a single definite-length string.");
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
@@ -35,6 +35,20 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public override TC Read(ref CborReader reader)
         {
+            if ((_options.TypedArrayMode & TypedArrayMode.Read) != 0 && reader.IsSemanticTag())
+            {
+                CborReaderBookmark bookmark = reader.GetBookmark();
+
+                if (reader.TryReadSemanticTag(out ulong tag) && TypedArrayTags.IsTypedArrayTag(tag))
+                {
+                    return ReadTypedArray(ref reader, tag);
+                }
+
+                // Some other tag, which CBOR says to ignore. Hand it back so the ReadNull below skips
+                // exactly one, as it did before typed arrays existed.
+                reader.ReturnToBookmark(bookmark);
+            }
+
             if (reader.ReadNull())
             {
                 return default!;
@@ -44,6 +58,44 @@ namespace Dahomey.Cbor.Serialization.Converters
             reader.ReadArray(this, ref context);
 
             return InstantiateCollection(context.collection);
+        }
+
+        /// <summary>
+        /// Fills this collection from an RFC 8746 typed array, so that a document written from a
+        /// <c>TI[]</c> member reads back into any of the collection shapes that are interchangeable
+        /// with it - <c>List&lt;TI&gt;</c>, <c>IList&lt;TI&gt;</c>, <c>HashSet&lt;TI&gt;</c>,
+        /// <c>ImmutableArray&lt;TI&gt;</c> and the rest.
+        /// </summary>
+        /// <remarks>
+        /// The decoding itself belongs to the converter for <c>TI[]</c>: this class has no
+        /// <c>unmanaged</c> constraint on <c>TI</c> and so cannot do the <see cref="System.Runtime.InteropServices.MemoryMarshal"/>
+        /// cast, but it can ask the registry for that converter and use it through
+        /// <see cref="ITypedArrayReader{TI}"/>. The lookup happens here rather than in the constructor
+        /// so that it costs nothing until a typed array actually arrives, and so that it cannot take
+        /// part in a converter construction cycle.
+        /// </remarks>
+        private TC ReadTypedArray(ref CborReader reader, ulong tag)
+        {
+            if (_options.Registry.ConverterRegistry.Lookup<TI[]>() is not ITypedArrayReader<TI> typedArrayReader)
+            {
+                throw new CborException(
+                    $"Cannot read a typed array tagged {tag} ({TypedArrayTags.DescribeTag(tag)}) into {typeof(TC)}.");
+            }
+
+            TI[] items = typedArrayReader.ReadTypedArray(ref reader, tag);
+            ICollection<TI> collection = InstantiateTempCollection();
+
+            if (collection is List<TI> list)
+            {
+                list.Capacity = items.Length;
+            }
+
+            foreach (TI item in items)
+            {
+                collection.Add(item);
+            }
+
+            return InstantiateCollection(collection);
         }
 
         public override void Write(ref CborWriter writer, TC value, LengthMode lengthMode)

--- a/src/Dahomey.Cbor/Serialization/Converters/ArrayConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ArrayConverter.cs
@@ -21,7 +21,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             public LengthMode lengthMode;
         }
 
-        private readonly CborOptions _options;
+        protected readonly CborOptions _options;
 
         public ArrayConverter(CborOptions options)
         {

--- a/src/Dahomey.Cbor/Serialization/Converters/CborConverterRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborConverterRegistry.cs
@@ -19,6 +19,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             RegisterConverterProvider(new ObjectConverterProvider());
             RegisterConverterProvider(new TupleConverterProvider());
             RegisterConverterProvider(new CollectionConverterProvider());
+            RegisterConverterProvider(new TypedArrayConverterProvider());
             RegisterConverterProvider(new PrimitiveConverterProvider());
             RegisterConverterProvider(new ByAttributeConverterProvider());
         }

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/TypedArrayConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/TypedArrayConverterProvider.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Dahomey.Cbor.Serialization.Converters.Providers
+{
+    public class TypedArrayConverterProvider : CborConverterProviderBase
+    {
+        public override ICborConverter? GetConverter(Type type, CborOptions options)
+        {
+            if (!type.IsArray || type.GetArrayRank() != 1)
+            {
+                return null;
+            }
+
+            Type? itemType = type.GetElementType();
+
+            if (itemType == null || !TypedArrayTags.TryGetByElementType(itemType, out _))
+            {
+                return null;
+            }
+
+            return CreateGenericConverter(options, typeof(TypedArrayConverter<>), itemType);
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/TypedArrayConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TypedArrayConverter.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// Decodes an RFC 8746 typed array payload whose tag has already been consumed.
+    /// </summary>
+    /// <remarks>
+    /// This is the seam that lets a collection converter reuse the array converter's decoding.
+    /// <see cref="AbstractCollectionConverter{TC, TI}"/> has no <c>unmanaged</c> constraint on its
+    /// element type, so it cannot name <see cref="TypedArrayConverter{TI}"/>, but it can ask the
+    /// registry for the converter of <c>TI[]</c> and test for this interface.
+    /// </remarks>
+    internal interface ITypedArrayReader<TI>
+    {
+        TI[] ReadTypedArray(ref CborReader reader, ulong tag);
+    }
+
+    /// <summary>
+    /// Reads and writes RFC 8746 typed arrays (tags 64-87) for the numeric element types, falling back
+    /// to the ordinary per-element array encoding when no typed array tag is present.
+    /// </summary>
+    internal class TypedArrayConverter<TI> : ArrayConverter<TI>, ITypedArrayReader<TI> where TI : unmanaged
+    {
+        private readonly TypedArrayTagInfo _tagInfo;
+        private readonly bool _hostIsLittleEndian;
+
+        public TypedArrayConverter(CborOptions options)
+            : this(options, BitConverter.IsLittleEndian)
+        {
+        }
+
+        /// <summary>
+        /// Takes the host byte order rather than reading <see cref="BitConverter.IsLittleEndian"/>, so
+        /// that the byte-swapping paths can be exercised on hardware of either order.
+        /// </summary>
+        internal TypedArrayConverter(CborOptions options, bool hostIsLittleEndian)
+            : base(options)
+        {
+            _hostIsLittleEndian = hostIsLittleEndian;
+
+            if (!TypedArrayTags.TryGetByElementType(typeof(TI), out _tagInfo))
+            {
+                throw new CborException($"{typeof(TI)} is not a typed array element type.");
+            }
+        }
+
+        public override TI[]? Read(ref CborReader reader)
+        {
+            if ((_options.TypedArrayMode & TypedArrayMode.Read) != 0 && reader.IsSemanticTag())
+            {
+                CborReaderBookmark bookmark = reader.GetBookmark();
+
+                if (reader.TryReadSemanticTag(out ulong tag) && TypedArrayTags.IsTypedArrayTag(tag))
+                {
+                    return ReadTypedArray(ref reader, tag);
+                }
+
+                // Some other tag, which CBOR says to ignore. Hand it back rather than keeping it
+                // consumed: base.Read skips exactly one tag, so returning it here leaves this converter
+                // exactly as lenient about nesting as ArrayConverter, no more.
+                reader.ReturnToBookmark(bookmark);
+            }
+
+            return base.Read(ref reader);
+        }
+
+        public override void Write(ref CborWriter writer, TI[]? value, LengthMode lengthMode)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            if ((_options.TypedArrayMode & TypedArrayMode.WriteLittleEndian) == 0)
+            {
+                base.Write(ref writer, value, lengthMode);
+                return;
+            }
+
+            writer.WriteSemanticTag(_tagInfo.LittleEndianTag);
+
+            ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes(value.AsSpan());
+
+            if (_hostIsLittleEndian || _tagInfo.ElementSize == 1)
+            {
+                writer.WriteByteString(bytes);
+                return;
+            }
+
+            // Big-endian host writing a little-endian tag: swap into a copy so the caller's array is
+            // left alone.
+            TI[] swapped = (TI[])value.Clone();
+            ReverseElements(swapped);
+            writer.WriteByteString(MemoryMarshal.AsBytes(swapped.AsSpan()));
+        }
+
+        public TI[] ReadTypedArray(ref CborReader reader, ulong tag)
+        {
+            bool payloadIsBigEndian;
+
+            if (tag == _tagInfo.LittleEndianTag)
+            {
+                payloadIsBigEndian = false;
+            }
+            else if (tag == _tagInfo.BigEndianTag)
+            {
+                payloadIsBigEndian = true;
+            }
+            else
+            {
+                throw new CborException(
+                    $"Cannot read a typed array tagged {tag} ({TypedArrayTags.DescribeTag(tag)}) into {typeof(TI[])}.");
+            }
+
+            // ReadByteString always returns a contiguous span, copying out of a fragmented sequence
+            // when it has to, so the cast below is always valid.
+            ReadOnlySpan<byte> bytes = reader.ReadByteString();
+
+            if (bytes.Length % _tagInfo.ElementSize != 0)
+            {
+                throw new CborException(
+                    $"Typed array payload of {bytes.Length} bytes is not a multiple of the {_tagInfo.ElementSize} byte element size.");
+            }
+
+            TI[] result = new TI[bytes.Length / _tagInfo.ElementSize];
+            MemoryMarshal.Cast<byte, TI>(bytes).CopyTo(result);
+
+            if (payloadIsBigEndian == _hostIsLittleEndian && _tagInfo.ElementSize > 1)
+            {
+                ReverseElements(result);
+            }
+
+            return result;
+        }
+
+        private void ReverseElements(TI[] values)
+        {
+            Span<byte> bytes = MemoryMarshal.AsBytes(values.AsSpan());
+
+            for (int offset = 0; offset < bytes.Length; offset += _tagInfo.ElementSize)
+            {
+                bytes.Slice(offset, _tagInfo.ElementSize).Reverse();
+            }
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/TypedArrayTags.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TypedArrayTags.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// One row of the RFC 8746 typed array tag table.
+    /// </summary>
+    internal readonly struct TypedArrayTagInfo
+    {
+        public readonly int ElementSize;
+        public readonly ulong LittleEndianTag;
+        public readonly ulong BigEndianTag;
+
+        public TypedArrayTagInfo(int elementSize, ulong littleEndianTag, ulong bigEndianTag)
+        {
+            ElementSize = elementSize;
+            LittleEndianTag = littleEndianTag;
+            BigEndianTag = bigEndianTag;
+        }
+    }
+
+    /// <summary>
+    /// The RFC 8746 typed array tag table, keyed by .NET element type.
+    /// </summary>
+    /// <remarks>
+    /// byte[] is deliberately absent. Tag 64 exists for it, but a plain major-type-2 byte string is
+    /// both shorter and idiomatic, and is what <see cref="ByteArrayConverter"/> already writes.
+    /// Tag 76 is reserved by RFC 8746; tags 83 and 87 are IEEE 754 binary128, which has no .NET type.
+    /// </remarks>
+    internal static class TypedArrayTags
+    {
+        internal const ulong MinTag = 64;
+        internal const ulong MaxTag = 87;
+
+        private static readonly Dictionary<Type, TypedArrayTagInfo> _byElementType =
+            new Dictionary<Type, TypedArrayTagInfo>
+            {
+                [typeof(sbyte)] = new TypedArrayTagInfo(1, 72, 72),
+                [typeof(ushort)] = new TypedArrayTagInfo(2, 69, 65),
+                [typeof(short)] = new TypedArrayTagInfo(2, 77, 73),
+                [typeof(uint)] = new TypedArrayTagInfo(4, 70, 66),
+                [typeof(int)] = new TypedArrayTagInfo(4, 78, 74),
+                [typeof(ulong)] = new TypedArrayTagInfo(8, 71, 67),
+                [typeof(long)] = new TypedArrayTagInfo(8, 79, 75),
+                [typeof(Half)] = new TypedArrayTagInfo(2, 84, 80),
+                [typeof(float)] = new TypedArrayTagInfo(4, 85, 81),
+                [typeof(double)] = new TypedArrayTagInfo(8, 86, 82),
+            };
+
+        /// <summary>
+        /// RFC 8746 §2, indexed by tag - <see cref="MinTag"/>.
+        /// </summary>
+        private static readonly string[] _descriptionsByTag =
+        {
+            "uint8", "uint16 big endian", "uint32 big endian", "uint64 big endian",
+            "uint8 clamped", "uint16 little endian", "uint32 little endian", "uint64 little endian",
+            "sint8", "sint16 big endian", "sint32 big endian", "sint64 big endian",
+            "reserved", "sint16 little endian", "sint32 little endian", "sint64 little endian",
+            "binary16 big endian", "binary32 big endian", "binary64 big endian", "binary128 big endian",
+            "binary16 little endian", "binary32 little endian", "binary64 little endian", "binary128 little endian",
+        };
+
+        internal static bool IsTypedArrayTag(ulong tag) => tag >= MinTag && tag <= MaxTag;
+
+        internal static bool TryGetByElementType(Type elementType, out TypedArrayTagInfo info)
+            => _byElementType.TryGetValue(elementType, out info);
+
+        internal static string DescribeTag(ulong tag)
+            => IsTypedArrayTag(tag) ? _descriptionsByTag[tag - MinTag] : $"tag {tag}";
+    }
+}


### PR DESCRIPTION
Encodes a numeric array as one RFC 8746 semantic tag plus one byte string holding the whole array, instead of a headered item per element.

> **#161 has merged, and this is rebuilt on top of it.** The read-path fix it needs is now in `master`, so this diff is the feature and nothing else. Rebuilt by cherry-picking rather than rebasing: #161 was squash-merged, so its commit is in `master` by content but not by identity, and a rebase would have replayed it against itself.

```csharp
CborOptions options = new CborOptions { TypedArrayMode = TypedArrayMode.ReadWriteLittleEndian };
await Cbor.SerializeAsync(new[] { 1.5f, 2.5f }, stream, options);
// D8 55 48 00 00 C0 3F 00 00 20 40
```

On a `float[1000]` of sample data that is 4005 bytes against 4923, and the gap widens with the array. Element types and their little-endian tags: `sbyte` (72), `ushort` (69), `short` (77), `uint` (70), `int` (78), `ulong` (71), `long` (79), `Half` (84), `float` (85), `double` (86). `byte[]` is deliberately absent — a plain byte string is shorter and is what the format already uses — though reading tags 64 and 68 into one still works.

## Opt-in per direction

`TypedArrayMode` is a flags enum whose default is a true no-op: upgrading to a version that has typed arrays changes nothing for a caller who has not asked for them, neither the bytes written nor the documents accepted.

| Value | Effect |
|---|---|
| `Never` (default) | Neither read nor written. A tag in 64–87 is skipped like any other unrecognised tag. |
| `Read` | Typed arrays are read, in either byte order. Nothing is written as one. |
| `WriteLittleEndian` | Numeric arrays are written as little-endian typed arrays. |
| `ReadWriteLittleEndian` | Both. |

`Read` alone is the interop case: accept a peer's typed arrays without changing the bytes this side emits. Two bits are used, so a future `WriteBigEndian` can be added without changing the meaning of any existing value.

## What reads what

Writing applies to `T[]`. Reading fills any shape interchangeable with it — `List<T>`, `IList<T>`, `ICollection<T>`, `IEnumerable<T>`, `IReadOnlyList<T>`, `HashSet<T>`, `ImmutableArray<T>`, `ImmutableList<T>` — so a document written from a `float[]` member is readable by a consumer that declares it a `List<float>`. Whatever this library writes, all of them read.

The decoding lives in one place: `AbstractCollectionConverter` has no `unmanaged` constraint on its element type, so it reaches the `T[]` converter through an internal `ITypedArrayReader<TI>`, looked up only once a typed array actually arrives.

A tag whose element type does not match the target is an error rather than something to ignore — tag 86 into a `float[]` would otherwise reinterpret the bytes silently. Reserved tag 76 and the two binary128 tags are refused for the same reason.

## Two things worth knowing

`ArrayLengthMode` is ignored for an array actually written as a typed array: a byte string is definite-length, so there is no array header to make indefinite. It applies as usual to every array not written as one.

The object model has no typed array node. A `CborValue` holding one is a `ByteString` with the tag in `SemanticTag`, and `CborValueConverter` never writes `SemanticTag` back — so a DOM read-then-write drops the tag and turns the typed array into ordinary bytes. That is true of every semantic tag rather than anything this feature introduces, and is not changed here, but typed arrays make it easy to reach, so it is pinned by `TheObjectModelSeesATypedArrayAsAByteStringAndDropsItsTag` and stated in the README. It is now tracked as #162, which the README links; whoever fixes that will need to update that test.

## Also here

A separate first commit makes an indefinite-length byte or text string a `CborException` carrying the reader position, instead of a bare `NotSupportedException` that escapes the `catch (CborException)` a caller writes. RFC 8746 does not forbid a chunked byte string as the tag content, and a producer streaming a large array is where one would appear. One existing `[InlineData]` in `CborReaderTests.ReadString` changes with it; that is the only behavioural change outside typed arrays.

## Tests

`TypedArrayTests.cs`, 59 cases: every element type in both byte orders, all three object formats, struct and class members, nulls, empty arrays, polymorphism with a discriminator tag in front of a typed array member, dictionaries, tuples, collection interchangeability across nine shapes, the mode matrix, malformed and mismatched payloads, chunked payloads, nested-tag parity with `ArrayConverter`, and the size comparison.

The byte-swapping paths take the host byte order as a constructor argument rather than reading `BitConverter.IsLittleEndian`, so both orders are exercised on little-endian CI instead of half the code never running. That constructor is not public API, so the converter is `internal` and the test project is a signed `InternalsVisibleTo` friend, as #158 does for `CborKeyComparer`.

**1163 tests green on .NET 8, 9 and 10**, on this head, upstream — `master`'s 1104 plus 59 here:
https://github.com/dahomey-technologies/Dahomey.Cbor/actions/runs/31093022309

## One resolution worth calling out

`CborOptions` was the only real conflict, because #158 landed `Deterministic` there while this was out of tree. The two are kept **independent**: `Deterministic` does not force `TypedArrayMode`, and `TypedArrayMode` does not constrain `Deterministic`.

That is deliberate rather than the lazy resolution, and it is the §2 objection from #156 not being reintroduced. A typed array and a plain CBOR array are two encodings of the same value, but which one gets written is fixed by the setting rather than chosen per value — so either mode yields exactly one encoding and §4.2.1 is satisfied without either option constraining the other. The reasoning is on the property so the next person does not have to re-derive it.
