### PR TITLE
Deterministic encoding: CborOptions.Deterministic (RFC 8949 §4.2.1), closes #148

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,22 +227,45 @@ sorts before ``"aa"``. Keys of different CBOR major types order by major type fi
 integer, then negative integer, then byte string, then text string — which is why negative integer
 keys sort after all non-negative ones.
 
-Supported dictionary key types are ``string``, ``char``, ``byte[]``/``ReadOnlyMemory<byte>``, every
-integral type (``byte``, ``sbyte``, ``short``, ``ushort``, ``int``, ``uint``, ``long``, ``ulong``)
-and enums — each ordered as its own converter writes it. For an enum that means: with
-``EnumFormat.WriteToString`` a value that *has* a name is written and ordered as that name, and a
-value that has none (a combination of flags, or a cast from an unlisted number) falls back to the
-integer form in both. ``CborObject`` keys may be text strings, byte strings and integers, mixed
-freely within one map, which is what lets a document read off the wire be re-encoded
-deterministically. Any other key type throws a ``CborException`` rather than silently emitting
-unsorted output.
+Any key type whose converter can write it can be ordered, because each key is ordered on the bytes
+that converter produces — strings, chars, byte strings, every integral type, enums, floating point,
+booleans and ``DateTime`` alike. A custom key converter needs nothing added here to participate. The
+same holds for ``CborObject``, whose keys may be of any kind and may mix kinds freely within one map,
+including nulls, arrays and nested maps; that is what lets a document read off the wire be re-encoded
+deterministically whatever it contains.
 
 **An enum key whose underlying type is wider than 32 bits is written truncated to 32 bits**, and is
-therefore ordered that way too — the ordering follows the bytes actually emitted. Two enum values
-that differ only above bit 31 collide into the same map key, producing a map with duplicate keys that
-is neither deterministic nor valid to hash. This is how enums are written with or without
-``Deterministic``; if your enum is backed by ``long``/``ulong`` and its values exceed 32 bits, key
-the map by the underlying integer instead.
+therefore ordered that way too. Two enum values that differ only above bit 31 collide into the same
+map key, producing a map with duplicate keys that is neither deterministic nor valid to hash. This is
+how ``EnumConverter`` writes enums with or without ``Deterministic``; if your enum is backed by
+``long``/``ulong`` and its values exceed 32 bits, key the map by the underlying integer instead.
+
+#### The discriminator is no longer the first key
+
+Without ``Deterministic`` the discriminator is written first, at index 0. Sorted bytewise it takes
+whatever position its encoded key earns like any other: ``"_t"`` encodes to ``0x62 0x5F 0x74``, which
+places it after every one-character member name and after every two-character name starting below
+``0x5F`` — on a PascalCase model, somewhere in the middle of the map.
+
+This is what §4.2.1 requires; it grants a discriminator no exemption. Two consequences are worth
+knowing:
+
+* **Reads of polymorphic types get slower.** Deserialization bookmarks the reader, scans the map for
+  the discriminator, then rewinds and re-reads. Previously it hit on the first item; now it may scan
+  the whole map first. Correctness is unaffected — Dahomey.Cbor does not care where the discriminator
+  sits — but the cost is real.
+* **Strict readers elsewhere may reject the document.** Several polymorphic deserializers in other
+  ecosystems require the type tag in first position. A document this library round-trips happily may
+  not be readable by one of those once sorted.
+
+Both are avoidable without giving up compliance, and both are free:
+
+* ``CborObjectFormat.IntKeyMap`` — the discriminator's index is 0, encoding to the single byte
+  ``0x00``. That is the smallest encoding in the lowest major type, so nothing can sort before it.
+  This is the recommendation.
+* ``StringKeyMap`` with a one-character discriminator name, which
+  ``DefaultDiscriminatorConvention`` takes as a constructor argument. A one-character name encodes in
+  two bytes and so beats every name of two characters or more.
 
 ``Deterministic`` may be set at any point in an options object's life, including on the long-lived
 ``CborOptions.Default`` — but not while a write using those options is in flight. It is read when a
@@ -250,9 +273,13 @@ write starts, not when converters are built, so it takes effect on the very next
 *during* a write (from a property getter, a custom converter, or another thread) is picked up by the
 write after it, and the write in progress finishes on the ordering it started with.
 
-Deterministic mode also rejects any setting that would admit more than one encoding of the same
-value: setting ``ArrayLengthMode`` or ``MapLengthMode`` to ``LengthMode.IndefiniteLength`` while
-``Deterministic`` is enabled throws a ``CborException``.
+Deterministic mode also refuses any setting that would admit more than one encoding of the same
+value. An indefinite-length map or array throws a ``CborException`` at the point the header would be
+written, whichever of the three sources asked for it: ``CborOptions.ArrayLengthMode``,
+``CborOptions.MapLengthMode``, or a ``CborLengthMode`` attribute on a type or member — the last of
+which takes priority over both options, and is therefore the case most likely to surprise. The
+refusal is at the writer rather than at the property setters so that no combination can slip past by
+being configured in the wrong order.
 
 **When verifying an integrity hash, hash the bytes you received, never a re-serialization.** If
 ``UnhandledNameMode.Silent`` is in effect, decoding a document written by a newer version silently

--- a/README.md
+++ b/README.md
@@ -229,15 +229,26 @@ keys sort after all non-negative ones.
 
 Supported dictionary key types are ``string``, ``char``, ``byte[]``/``ReadOnlyMemory<byte>``, every
 integral type (``byte``, ``sbyte``, ``short``, ``ushort``, ``int``, ``uint``, ``long``, ``ulong``)
-and enums — each ordered as its own converter writes it, so an enum is ordered as text when
-``EnumFormat`` is ``WriteToString``. ``CborObject`` keys may be text strings, byte strings and
-integers, mixed freely within one map, which is what lets a document read off the wire be re-encoded
+and enums — each ordered as its own converter writes it. For an enum that means: with
+``EnumFormat.WriteToString`` a value that *has* a name is written and ordered as that name, and a
+value that has none (a combination of flags, or a cast from an unlisted number) falls back to the
+integer form in both. ``CborObject`` keys may be text strings, byte strings and integers, mixed
+freely within one map, which is what lets a document read off the wire be re-encoded
 deterministically. Any other key type throws a ``CborException`` rather than silently emitting
 unsorted output.
 
+**An enum key whose underlying type is wider than 32 bits is written truncated to 32 bits**, and is
+therefore ordered that way too — the ordering follows the bytes actually emitted. Two enum values
+that differ only above bit 31 collide into the same map key, producing a map with duplicate keys that
+is neither deterministic nor valid to hash. This is how enums are written with or without
+``Deterministic``; if your enum is backed by ``long``/``ulong`` and its values exceed 32 bits, key
+the map by the underlying integer instead.
+
 ``Deterministic`` may be set at any point in an options object's life, including on the long-lived
-``CborOptions.Default``: it is read when a value is written, not when converters are built, so it
-takes effect on the very next write.
+``CborOptions.Default`` — but not while a write using those options is in flight. It is read when a
+write starts, not when converters are built, so it takes effect on the very next write; a change made
+*during* a write (from a property getter, a custom converter, or another thread) is picked up by the
+write after it, and the write in progress finishes on the ordering it started with.
 
 Deterministic mode also rejects any setting that would admit more than one encoding of the same
 value: setting ``ArrayLengthMode`` or ``MapLengthMode`` to ``LengthMode.IndefiniteLength`` while

--- a/README.md
+++ b/README.md
@@ -219,12 +219,25 @@ deduplication meaningful. This is the §4.2.1 ordering rule, not the deprecated 
 from §4.2.3, which is not implemented.
 
 Key ordering applies to ``StringKeyMap`` and ``IntKeyMap`` objects, ``Dictionary<K,V>``, and
-``CborObject``/``CborValue`` maps; ``CborObjectFormat.Array`` has no map keys and is therefore
-already deterministic. Because ordering is on the *encoded* key, a shorter key always sorts before a
-longer one, so ``"z"`` sorts before ``"aa"``, and negative integer keys sort after all non-negative
-ones, because a negative integer is a different CBOR major type. Supported dictionary key types are
-``string``, ``int``, ``long`` and ``ulong``; any other key type throws a ``CborException`` rather
-than silently emitting unsorted output.
+``CborObject``/``CborValue`` maps. ``CborObjectFormat.Array`` writes its members positionally and has
+no map keys at all, so its bytes are identical with and without ``Deterministic``.
+
+Because ordering is on the *encoded* key, a shorter key always sorts before a longer one, so ``"z"``
+sorts before ``"aa"``. Keys of different CBOR major types order by major type first — unsigned
+integer, then negative integer, then byte string, then text string — which is why negative integer
+keys sort after all non-negative ones.
+
+Supported dictionary key types are ``string``, ``char``, ``byte[]``/``ReadOnlyMemory<byte>``, every
+integral type (``byte``, ``sbyte``, ``short``, ``ushort``, ``int``, ``uint``, ``long``, ``ulong``)
+and enums — each ordered as its own converter writes it, so an enum is ordered as text when
+``EnumFormat`` is ``WriteToString``. ``CborObject`` keys may be text strings, byte strings and
+integers, mixed freely within one map, which is what lets a document read off the wire be re-encoded
+deterministically. Any other key type throws a ``CborException`` rather than silently emitting
+unsorted output.
+
+``Deterministic`` may be set at any point in an options object's life, including on the long-lived
+``CborOptions.Default``: it is read when a value is written, not when converters are built, so it
+takes effect on the very next write.
 
 Deterministic mode also rejects any setting that would admit more than one encoding of the same
 value: setting ``ArrayLengthMode`` or ``MapLengthMode`` to ``LengthMode.IndefiniteLength`` while

--- a/README.md
+++ b/README.md
@@ -205,4 +205,33 @@ and register it the same way.
 > **Note:** the registry caches one convention per declared type, so a single hierarchy cannot mix
 > string- and int-keyed discriminators. Independent hierarchies may each use their own kind within the
 > same `CborOptions`.
+### Deterministic encoding (RFC 8949 §4.2)
+
+```csharp
+CborOptions options = new CborOptions { Deterministic = true };
+await Cbor.SerializeAsync(customObject, stream, options);
+```
+
+Guarantees the four core requirements of RFC 8949 §4.2.1: shortest-form arguments for integers,
+lengths and tags; preferred float serialization; definite lengths; and map keys sorted bytewise on
+their encoded form. The same value always produces the same bytes, which is what makes hashing and
+deduplication meaningful. This is the §4.2.1 ordering rule, not the deprecated length-first variant
+from §4.2.3, which is not implemented.
+
+Key ordering applies to ``StringKeyMap`` and ``IntKeyMap`` objects, ``Dictionary<K,V>``, and
+``CborObject``/``CborValue`` maps; ``CborObjectFormat.Array`` has no map keys and is therefore
+already deterministic. Because ordering is on the *encoded* key, a shorter key always sorts before a
+longer one, so ``"z"`` sorts before ``"aa"``, and negative integer keys sort after all non-negative
+ones, because a negative integer is a different CBOR major type. Supported dictionary key types are
+``string``, ``int``, ``long`` and ``ulong``; any other key type throws a ``CborException`` rather
+than silently emitting unsorted output.
+
+Deterministic mode also rejects any setting that would admit more than one encoding of the same
+value: setting ``ArrayLengthMode`` or ``MapLengthMode`` to ``LengthMode.IndefiniteLength`` while
+``Deterministic`` is enabled throws a ``CborException``.
+
+**When verifying an integrity hash, hash the bytes you received, never a re-serialization.** If
+``UnhandledNameMode.Silent`` is in effect, decoding a document written by a newer version silently
+drops members this version doesn't know about, and re-encoding then produces different — and
+differently hashing — bytes than what was received. Hash the wire bytes directly.
 

--- a/src/Dahomey.Cbor.Tests/Dahomey.Cbor.Tests.csproj
+++ b/src/Dahomey.Cbor.Tests/Dahomey.Cbor.Tests.csproj
@@ -4,6 +4,10 @@
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+    <!-- Signed with the library's own key so it can be an InternalsVisibleTo friend of it; a
+         strong-named assembly cannot grant friend access to an unsigned one. -->
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>../Dahomey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dahomey.Cbor.Tests/DeterministicByteCompatibilityTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicByteCompatibilityTests.cs
@@ -1,0 +1,218 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.ObjectModel;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// Every value the deterministic key work passes through, written with default options, pinned to
+    /// the bytes the library produced before that work existed.
+    /// </summary>
+    /// <remarks>
+    /// The ordering feature is opt-in, so the load-bearing claim is not only that
+    /// <c>Deterministic = true</c> sorts correctly but that <c>Deterministic = false</c> — every
+    /// existing caller — writes exactly what it wrote before. The key path encodes each key through
+    /// its own converter, which touches map writing for objects, dictionaries and
+    /// <see cref="CborObject"/> alike; a per-feature test cannot show that the untouched setting is
+    /// untouched, and reading a diff cannot either.
+    /// <para>
+    /// The expected bytes are not hand-written. They were captured by running <see cref="Corpus"/>
+    /// unchanged on the base commit and recording what came out, so a disagreement here means this
+    /// branch moved the default output rather than that someone predicted it wrongly. To regenerate
+    /// after adding a case, run the corpus on the base commit and print each entry.
+    /// </para>
+    /// </remarks>
+    public class DeterministicByteCompatibilityTests
+    {
+        private class StringKeyed
+        {
+            public int Zebra { get; set; }
+            public int Apple { get; set; }
+            public int Mango { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        private class IntKeyed
+        {
+            [CborProperty(-1)]
+            public int Negative { get; set; }
+            [CborProperty(0)]
+            public int Zero { get; set; }
+            [CborProperty(7)]
+            public int Seven { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        private class ArrayFormatted
+        {
+            [CborProperty(0)]
+            public int Zebra { get; set; }
+            [CborProperty(1)]
+            public int Apple { get; set; }
+        }
+
+        private class Nesting
+        {
+            public int Yak { get; set; }
+            public StringKeyed Inner { get; set; }
+            public int Ant { get; set; }
+        }
+
+        private enum Aliased
+        {
+            First = 1,
+            AlsoFirst = 1,
+            Second = 2,
+        }
+
+        [Flags]
+        private enum Flagged
+        {
+            None = 0,
+            A = 1,
+            B = 2,
+        }
+
+        [CborDiscriminator("base")]
+        private class Base
+        {
+            public int Common { get; set; }
+        }
+
+        [CborDiscriminator("derived")]
+        private class Derived : Base
+        {
+            public int Extra { get; set; }
+        }
+
+        /// <summary>
+        /// Name → a write of that value under default options. Each entry serializes at its own static
+        /// type, which is what selects the converter under test.
+        /// </summary>
+        private static Dictionary<string, Func<string>> Corpus()
+        {
+            return new Dictionary<string, Func<string>>
+            {
+                ["object.stringKeyMap"] = () => Helper.Write(new StringKeyed { Zebra = 1, Apple = 2, Mango = 3 }),
+                ["object.intKeyMap"] = () => Helper.Write(new IntKeyed { Negative = 1, Zero = 2, Seven = 3 }),
+                ["object.arrayFormat"] = () => Helper.Write(new ArrayFormatted { Zebra = 1, Apple = 2 }),
+                ["object.nested"] = () => Helper.Write(new Nesting
+                {
+                    Yak = 1,
+                    Inner = new StringKeyed { Zebra = 4, Apple = 5, Mango = 6 },
+                    Ant = 2,
+                }),
+                ["object.polymorphic"] = () => Helper.Write<Base>(new Derived { Common = 1, Extra = 2 }),
+
+                ["dictionary.string"] = () => Helper.Write(new Dictionary<string, int>
+                {
+                    ["zebra"] = 1,
+                    ["apple"] = 2,
+                    ["z"] = 3,
+                    ["aa"] = 4,
+                }),
+                ["dictionary.int"] = () => Helper.Write(new Dictionary<int, string>
+                {
+                    [10] = "a",
+                    [-1] = "b",
+                    [0] = "c",
+                    [65536] = "d",
+                }),
+                ["dictionary.long"] = () => Helper.Write(new Dictionary<long, string>
+                {
+                    [4294967301L] = "a",
+                    [10L] = "b",
+                }),
+                ["dictionary.char"] = () => Helper.Write(new Dictionary<char, int>
+                {
+                    ['z'] = 1,
+                    ['a'] = 2,
+                }),
+                ["dictionary.enum.aliased"] = () => Helper.Write(new Dictionary<Aliased, int>
+                {
+                    [Aliased.Second] = 1,
+                    [Aliased.First] = 2,
+                }),
+                ["dictionary.enum.flags"] = () => Helper.Write(new Dictionary<Flagged, int>
+                {
+                    [Flagged.A | Flagged.B] = 1,
+                    [Flagged.None] = 2,
+                }),
+                ["dictionary.double"] = () => Helper.Write(new Dictionary<double, int>
+                {
+                    [2.5] = 1,
+                    [-1.5] = 2,
+                }),
+                ["dictionary.bool"] = () => Helper.Write(new Dictionary<bool, int>
+                {
+                    [true] = 1,
+                    [false] = 2,
+                }),
+                ["dictionary.byteArray"] = () => Helper.Write(new Dictionary<byte[], int>
+                {
+                    [new byte[] { 0x02 }] = 1,
+                    [new byte[] { 0x01 }] = 2,
+                }),
+                ["dictionary.nested"] = () => Helper.Write(new Dictionary<string, Dictionary<string, int>>
+                {
+                    ["outer"] = new Dictionary<string, int> { ["z"] = 1, ["a"] = 2 },
+                }),
+
+                ["cborObject.mixedKeys"] = () => Helper.Write(new CborObject
+                {
+                    ["zebra"] = 1,
+                    [(ulong)10] = 2,
+                    [(ulong)4294967301] = 3,
+                    ["a"] = 4,
+                }),
+                ["cborObject.nested"] = () => Helper.Write(new CborObject
+                {
+                    ["outer"] = new CborObject { ["z"] = 1, ["a"] = 2 },
+                }),
+            };
+        }
+
+        /// <summary>
+        /// Name → the bytes the base commit writes for that value under default options.
+        /// </summary>
+        private static readonly Dictionary<string, string> Expected = new Dictionary<string, string>
+        {
+            ["object.stringKeyMap"] = "A3655A6562726101654170706C6502654D616E676F03",
+            ["object.intKeyMap"] = "A3200100020703",
+            ["object.arrayFormat"] = "820102",
+            ["object.nested"] = "A36359616B0165496E6E6572A3655A6562726104654170706C6505654D616E676F0663416E7402",
+            ["object.polymorphic"] = "A3625F7467646572697665646545787472610266436F6D6D6F6E01",
+            ["dictionary.string"] = "A4657A6562726101656170706C6502617A0362616104",
+            ["dictionary.int"] = "A40A61612061620061631A000100006164",
+            ["dictionary.long"] = "A21B000000010000000561610A6162",
+            ["dictionary.char"] = "A2617A01616102",
+            ["dictionary.enum.aliased"] = "A202010102",
+            ["dictionary.enum.flags"] = "A203010002",
+            ["dictionary.double"] = "A2F9410001F9BE0002",
+            ["dictionary.bool"] = "A2F501F402",
+            ["dictionary.byteArray"] = "A2410201410102",
+            ["dictionary.nested"] = "A1656F75746572A2617A01616102",
+            ["cborObject.mixedKeys"] = "A4657A65627261010A021B000000010000000503616104",
+            ["cborObject.nested"] = "A1656F75746572A2617A01616102",
+        };
+
+        public static IEnumerable<object[]> CorpusNames()
+        {
+            foreach (string name in Corpus().Keys)
+            {
+                yield return new object[] { name };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CorpusNames))]
+        public void DefaultOptionsWriteTheSameBytesAsTheBaseCommit(string name)
+        {
+            Assert.True(Expected.ContainsKey(name), $"No pinned bytes for corpus entry '{name}'.");
+            Assert.Equal(Expected[name], Corpus()[name]());
+        }
+
+    }
+}

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Dahomey.Cbor.Attributes;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests
@@ -191,6 +192,93 @@ namespace Dahomey.Cbor.Tests
             //   654170706C65 "Apple"  02
             //   654D616E676F "Mango"  03
             Helper.TestWrite(value, "A3655A6562726101654170706C6502654D616E676F03");
+        }
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        private class IntKeyMapWithNegativeIndex
+        {
+            [CborProperty(-1)]
+            public int Negative { get; set; }
+            [CborProperty(0)]
+            public int Zero { get; set; }
+            [CborProperty(1)]
+            public int One { get; set; }
+        }
+
+        // ObjectMapping.ValidateMemberNamesAndindexes unconditionally pre-sorts IntKeyMap members by
+        // plain ascending int? (ObjectMapping.cs ~line 369), regardless of Deterministic. Ascending
+        // int treats -1 as less than 0, so a negative index sorts FIRST here -- this is the pre-existing,
+        // non-deterministic behaviour, and it is the control for the next test.
+        [Fact]
+        public void IntKeyMapNegativeIndexSortsFirstWhenNotDeterministic()
+        {
+            IntKeyMapWithNegativeIndex value = new IntKeyMapWithNegativeIndex { Negative = 7, Zero = 8, One = 9 };
+
+            // A3 map(3)
+            //   20 -1   07
+            //   00  0   08
+            //   01  1   09
+            Helper.TestWrite(value, "A3200700080109");
+        }
+
+        // RFC 8949 4.2.1: a negative key is CBOR major type 1, whose leading byte (0x20-0x3B) always
+        // exceeds a major type 0 leading byte (0x00-0x1B), so canonical order puts every negative key
+        // AFTER every non-negative one -- the opposite of plain ascending int order. CborKeyComparer.
+        // CompareIntKeys gets this right; the ascending pre-sort above does not. With Deterministic
+        // = true, ObjectConverter's own sort runs after that pre-sort and corrects it: -1 (encoded
+        // 0x20) moves from first to last, behind 0 (0x00) and 1 (0x01).
+        [Fact]
+        public void IntKeyMapNegativeIndexSortsLastWhenDeterministic()
+        {
+            IntKeyMapWithNegativeIndex value = new IntKeyMapWithNegativeIndex { Negative = 7, Zero = 8, One = 9 };
+
+            // A3 map(3)
+            //   00  0   08
+            //   01  1   09
+            //   20 -1   07
+            Helper.TestWrite(value,
+                "A3000801092007",
+                null,
+                new CborOptions { Deterministic = true });
+        }
+
+        [CborDiscriminator("Disc")]
+        private class DiscriminatedObject
+        {
+            public int Zebra { get; set; }
+            public int Apple { get; set; }
+        }
+
+        // DiscriminatorMemberConverter.MemberIndex is hardcoded to 0 in every format (MemberConverter.cs
+        // ~line 400), so in a StringKeyMap type carrying a discriminator, the discriminator's
+        // IMemberConverter has BOTH a MemberIndex (0) and a MemberName ("_t"). CompareMembersForDeterministicOrder's
+        // two-sided `x.MemberIndex.HasValue && y.MemberIndex.HasValue` guard still routes this correctly:
+        // ordinary StringKeyMap members have MemberIndex == null, so comparing any of them against the
+        // discriminator entry falls through to CompareTextKeys on both MemberNames. "_t" (2 UTF-8 bytes,
+        // header 0x62) is shorter-encoded than "Apple"/"Zebra" (5 bytes, header 0x65), and CompareTextKeys
+        // orders by encoded length before content, so the discriminator sorts first regardless of its
+        // own text, followed by Apple/Zebra alphabetically.
+        [Fact]
+        public void StringKeyMapWithDiscriminatorIsSortedWhenDeterministic()
+        {
+            CborOptions options = new CborOptions { Deterministic = true };
+            options.Registry.DiscriminatorConventionRegistry.RegisterType(typeof(DiscriminatedObject));
+            options.Registry.ObjectMappingRegistry.Register<DiscriminatedObject>(om =>
+            {
+                om.AutoMap();
+                om.SetDiscriminatorPolicy(Dahomey.Cbor.Attributes.CborDiscriminatorPolicy.Always);
+            });
+
+            DiscriminatedObject value = new DiscriminatedObject { Zebra = 1, Apple = 2 };
+
+            // A3 map(3)
+            //   625F74 "_t"          6444697363 "Disc"
+            //   654170706C65 "Apple" 02
+            //   655A65627261 "Zebra" 01
+            Helper.TestWrite(value,
+                "A3625F746444697363654170706C6502655A6562726101",
+                null,
+                options);
         }
     }
 }

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    public class DeterministicEncodingTests
+    {
+        [Fact]
+        public void DeterministicIsOffByDefault()
+        {
+            Assert.False(new CborOptions().Deterministic);
+        }
+
+        [Fact]
+        public void DeterministicRejectsIndefiniteArrayLength()
+        {
+            CborOptions options = new CborOptions { ArrayLengthMode = LengthMode.IndefiniteLength };
+            Assert.Throws<CborException>(() => options.Deterministic = true);
+        }
+
+        [Fact]
+        public void DeterministicRejectsIndefiniteMapLength()
+        {
+            CborOptions options = new CborOptions { MapLengthMode = LengthMode.IndefiniteLength };
+            Assert.Throws<CborException>(() => options.Deterministic = true);
+        }
+
+        [Fact]
+        public void IndefiniteLengthIsRejectedOnceDeterministic()
+        {
+            CborOptions options = new CborOptions { Deterministic = true };
+            Assert.Throws<CborException>(() => options.ArrayLengthMode = LengthMode.IndefiniteLength);
+            Assert.Throws<CborException>(() => options.MapLengthMode = LengthMode.IndefiniteLength);
+        }
+
+        [Fact]
+        public void DefiniteLengthIsStillAllowedWhenDeterministic()
+        {
+            CborOptions options = new CborOptions { Deterministic = true };
+            options.ArrayLengthMode = LengthMode.DefiniteLength;
+            options.MapLengthMode = LengthMode.DefiniteLength;
+            Assert.True(options.Deterministic);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -51,14 +51,39 @@ namespace Dahomey.Cbor.Tests
         }
 
         [Theory]
-        [InlineData("a", "b", -1)]     // same length, bytewise
+        [InlineData("a", "b", -1)]     // same length (1 vs 1), same header size tier: falls through to content bytewise
         [InlineData("b", "a", 1)]
         [InlineData("a", "a", 0)]
-        [InlineData("z", "aa", -1)]    // shorter encoded key sorts first
+        [InlineData("z", "aa", -1)]    // length 1 vs 2, both single-byte headers (same size TIER): header length VALUE decides, content never compared
         [InlineData("aa", "z", 1)]
         [InlineData("", "a", -1)]      // empty key is the smallest
         public void TextKeysSortBytewiseOnTheEncodedForm(string a, string b, int expected)
         {
+            Assert.Equal(expected, CompareNames(a, b));
+        }
+
+        // These cross an actual header-size TIER boundary (1-byte header <-> 2-byte header <-> 3-byte
+        // header), not just a length value within one tier. The content is deliberately chosen so that
+        // raw content comparison disagrees with the correct answer: a naive CompareTextKeys that skipped
+        // the header-size step and just called SequenceCompareTo on the raw name bytes would get these
+        // backwards, which is exactly the bug this test exists to catch.
+        //
+        // len 23 'z' (0x7A) encodes as header 0x77 + 23 content bytes = 24 bytes total: [77 7A*23].
+        // len 24 'a' (0x61) encodes as header 78 18 + 24 content bytes = 26 bytes total: [78 18 61*24].
+        // First byte 0x77 < 0x78, so the 23-char key sorts first even though 'z' > 'a' by content.
+        //
+        // len 255 'z' encodes as header 78 FF + 255 content bytes = 257 bytes: [78 FF 7A*255].
+        // len 256 'a' encodes as header 79 01 00 + 256 content bytes = 259 bytes: [79 01 00 61*256].
+        // First byte 0x78 < 0x79, so the 255-char key sorts first even though 'z' > 'a' by content.
+        [Theory]
+        [InlineData(23, 'z', 24, 'a', -1)]
+        [InlineData(24, 'a', 23, 'z', 1)]
+        [InlineData(255, 'z', 256, 'a', -1)]
+        [InlineData(256, 'a', 255, 'z', 1)]
+        public void TextKeysCrossHeaderSizeTiersEvenWhenContentDisagrees(int lengthA, char charA, int lengthB, char charB, int expected)
+        {
+            string a = new string(charA, lengthA);
+            string b = new string(charB, lengthB);
             Assert.Equal(expected, CompareNames(a, b));
         }
 
@@ -69,8 +94,55 @@ namespace Dahomey.Cbor.Tests
         [InlineData(1, 1, 0)]
         [InlineData(0, -1, -1)]        // negative keys are major type 1, so they sort last
         [InlineData(-1, 0, 1)]
-        [InlineData(-1, -2, -1)]
+        [InlineData(-1, -2, -1)]       // -1 = 0x20, -2 = 0x21: ascending bytewise, so -1 sorts before -2
         public void IntKeysSortBytewiseOnTheEncodedForm(int a, int b, int expected)
+        {
+            Assert.Equal(expected, Math.Sign(Dahomey.Cbor.Serialization.CborKeyComparer.CompareIntKeys(a, b)));
+        }
+
+        // Cross an argument-size TIER boundary (1-byte arg <-> 2-byte arg <-> 4-byte arg -- CBOR has no
+        // 3-byte argument form, so the 65535/65536 pair jumps two tiers at once). The non-negative pair
+        // exercises the same shortcut as the table above; the negative pairs are the only cases that
+        // reach CborKeyComparer's private CompareArgumentEncoding ladder at all, since CompareIntKeys
+        // only calls it from the a<0 && b<0 branch.
+        //
+        // -24  -> argument 23  -> 0x37 (1 byte).
+        // -25  -> argument 24  -> 0x38 0x18 (2 bytes). 0x37 < 0x38, so -24 sorts before -25.
+        //
+        // -256  -> argument 255  -> 0x38 0xFF (2 bytes).
+        // -257  -> argument 256  -> 0x39 0x01 0x00 (3 bytes). 0x38 < 0x39, so -256 sorts before -257.
+        //
+        // -65536  -> argument 65535 -> 0x39 0xFF 0xFF (3 bytes).
+        // -65537  -> argument 65536 -> 0x3A 0x00 0x01 0x00 0x00 (5 bytes). 0x39 < 0x3A, so -65536 sorts
+        // before -65537.
+        [Theory]
+        [InlineData(65535, 65536, -1)]
+        [InlineData(65536, 65535, 1)]
+        [InlineData(-24, -25, -1)]
+        [InlineData(-25, -24, 1)]
+        [InlineData(-256, -257, -1)]
+        [InlineData(-257, -256, 1)]
+        [InlineData(-65536, -65537, -1)]
+        [InlineData(-65537, -65536, 1)]
+        public void IntKeysCrossArgumentSizeTiers(int a, int b, int expected)
+        {
+            Assert.Equal(expected, Math.Sign(Dahomey.Cbor.Serialization.CborKeyComparer.CompareIntKeys(a, b)));
+        }
+
+        // int.MinValue is the brief's named overflow trap: -1 - int.MinValue overflows a 32-bit
+        // computation (int.MinValue has no positive counterpart in Int32). CompareIntKeys computes
+        // -1L - a in `long`, where int.MinValue promotes to -2147483648L and -1L - (-2147483648L) =
+        // 2147483647L, which fits comfortably in both long and the target ulong. These cases pin that:
+        // if the subtraction were ever narrowed back to `int`, this is the value that would misbehave.
+        //
+        // int.MinValue -> argument 2147483647 (5-byte form, header 0x3A) vs -1 -> argument 0 (1-byte
+        // form, header 0x20): 0x20 < 0x3A, so -1 sorts before int.MinValue.
+        [Theory]
+        [InlineData(int.MinValue, -1, 1)]
+        [InlineData(-1, int.MinValue, -1)]
+        [InlineData(int.MinValue, 0, 1)]
+        [InlineData(0, int.MinValue, -1)]
+        public void IntKeysHandleMinValueWithoutOverflow(int a, int b, int expected)
         {
             Assert.Equal(expected, Math.Sign(Dahomey.Cbor.Serialization.CborKeyComparer.CompareIntKeys(a, b)));
         }

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -75,11 +75,23 @@ namespace Dahomey.Cbor.Tests
         // len 255 'z' encodes as header 78 FF + 255 content bytes = 257 bytes: [78 FF 7A*255].
         // len 256 'a' encodes as header 79 01 00 + 256 content bytes = 259 bytes: [79 01 00 61*256].
         // First byte 0x78 < 0x79, so the 255-char key sorts first even though 'z' > 'a' by content.
+        //
+        // len 65535 'z' encodes as header 79 FF FF (additional-info 25: a 2-byte length field, and
+        // 65535 == 0xFFFF fits exactly) + 65535 content bytes = 65538 bytes: [79 FF FF 7A*65535].
+        // len 65536 'a' exceeds the 2-byte length field's range, so it needs additional-info 26 (a
+        // 4-byte length field): header 7A 00 01 00 00 (65536 == 0x00010000) + 65536 content bytes =
+        // 65541 bytes: [7A 00 01 00 00 61*65536].
+        // First byte 0x79 < 0x7A, so the 65535-char key sorts first even though 'z' > 'a' by content.
+        // This is CompareTextKeys's only 2-byte-length-field <-> 4-byte-length-field crossing; unlike
+        // the int side, CompareTextKeys has no non-negative shortcut, so this tier boundary is always
+        // on the comparison path and was previously unexercised.
         [Theory]
         [InlineData(23, 'z', 24, 'a', -1)]
         [InlineData(24, 'a', 23, 'z', 1)]
         [InlineData(255, 'z', 256, 'a', -1)]
         [InlineData(256, 'a', 255, 'z', 1)]
+        [InlineData(65535, 'z', 65536, 'a', -1)]
+        [InlineData(65536, 'a', 65535, 'z', 1)]
         public void TextKeysCrossHeaderSizeTiersEvenWhenContentDisagrees(int lengthA, char charA, int lengthB, char charB, int expected)
         {
             string a = new string(charA, lengthA);

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -42,5 +42,37 @@ namespace Dahomey.Cbor.Tests
             options.MapLengthMode = LengthMode.DefiniteLength;
             Assert.True(options.Deterministic);
         }
+
+        private static int CompareNames(string a, string b)
+        {
+            return Math.Sign(Dahomey.Cbor.Serialization.CborKeyComparer.CompareTextKeys(
+                System.Text.Encoding.UTF8.GetBytes(a),
+                System.Text.Encoding.UTF8.GetBytes(b)));
+        }
+
+        [Theory]
+        [InlineData("a", "b", -1)]     // same length, bytewise
+        [InlineData("b", "a", 1)]
+        [InlineData("a", "a", 0)]
+        [InlineData("z", "aa", -1)]    // shorter encoded key sorts first
+        [InlineData("aa", "z", 1)]
+        [InlineData("", "a", -1)]      // empty key is the smallest
+        public void TextKeysSortBytewiseOnTheEncodedForm(string a, string b, int expected)
+        {
+            Assert.Equal(expected, CompareNames(a, b));
+        }
+
+        [Theory]
+        [InlineData(0, 1, -1)]
+        [InlineData(23, 24, -1)]       // 0x17 then 0x18 0x18 -- still ascending
+        [InlineData(255, 256, -1)]     // 0x18 FF then 0x19 01 00 -- still ascending
+        [InlineData(1, 1, 0)]
+        [InlineData(0, -1, -1)]        // negative keys are major type 1, so they sort last
+        [InlineData(-1, 0, 1)]
+        [InlineData(-1, -2, -1)]
+        public void IntKeysSortBytewiseOnTheEncodedForm(int a, int b, int expected)
+        {
+            Assert.Equal(expected, Math.Sign(Dahomey.Cbor.Serialization.CborKeyComparer.CompareIntKeys(a, b)));
+        }
     }
 }

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.ObjectModel;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests
@@ -341,6 +342,71 @@ namespace Dahomey.Cbor.Tests
             {
                 [1.5] = 1,
                 [2.5] = 2,
+            };
+
+            CborOptions options = new CborOptions { Deterministic = true };
+            Assert.Throws<CborException>(() => Helper.Write(value, options));
+        }
+
+        [Fact]
+        public void CborObjectStringKeysAreSortedWhenDeterministic()
+        {
+            CborObject value = new CborObject
+            {
+                ["zebra"] = 1,
+                ["apple"] = 2,
+            };
+
+            // A2 map(2)
+            //   656170706C65 "apple" 02
+            //   657A65627261 "zebra" 01
+            Helper.TestWrite(value,
+                "A2656170706C6502657A6562726101",
+                null,
+                new CborOptions { Deterministic = true });
+
+            // Insertion order is zebra, apple, so the non-deterministic encoding disagrees with the
+            // sorted one above -- pinning that this is actually the sort taking effect, not a
+            // coincidence of Dictionary's default enumeration order.
+            Assert.NotEqual(Helper.Write(value), Helper.Write(value, new CborOptions { Deterministic = true }));
+        }
+
+        [Fact]
+        public void CborObjectIntegerKeysSortMajorTypeZeroBeforeMajorTypeOneWhenDeterministic()
+        {
+            CborObject value = new CborObject
+            {
+                [1] = "one",
+                [-1] = "minus one",
+                [0] = "zero",
+            };
+
+            // Same rule as IntKeyedDictionaryKeysAreSortedWhenDeterministic above: CborPositive (major
+            // type 0) always sorts before CborNegative (major type 1), so 0 and 1 both precede -1
+            // despite -1 > ... being false in plain numeric order.
+            //
+            // A3 map(3)
+            //   00  0   64 7A65726F           "zero"
+            //   01  1   63 6F6E65              "one"
+            //   20 -1   69 6D696E7573206F6E65  "minus one"
+            Helper.TestWrite(value,
+                "A300647A65726F01636F6E6520696D696E7573206F6E65",
+                null,
+                new CborOptions { Deterministic = true });
+        }
+
+        [Fact]
+        public void CborObjectWithUnsupportedKeyTypeThrowsUnwrappedWhenDeterministic()
+        {
+            // A boolean key is neither CborValueType.String nor CborValueType.Positive/Negative, so it
+            // must throw CborException -- and, per the List<T>.Sort wrapping bug fixed for
+            // NonStringNonIntDictionaryKeysThrowWhenDeterministic, it must arrive as a CborException,
+            // not wrapped in InvalidOperationException. Assert.Throws<CborException> already fails on a
+            // mismatched exception type, so this pins the unwrap without any extra assertion.
+            CborObject value = new CborObject
+            {
+                [true] = 1,
+                ["ok"] = 2,
             };
 
             CborOptions options = new CborOptions { Deterministic = true };

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Tests.Extensions;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests
@@ -335,6 +336,161 @@ namespace Dahomey.Cbor.Tests
                 new CborOptions { Deterministic = true });
         }
 
+        // Every integral CLR type is a working dictionary key without Deterministic, so turning the flag
+        // on must not take any of them away: an opt-in guarantee that breaks working code is a poor
+        // trade. Each is decorated as the major type its own key converter emits, so the order computed
+        // is the order of the bytes actually written -- which is why these expectations are the
+        // converters' own encodings, not a normalisation of them.
+        [Fact]
+        public void ByteKeyedDictionaryKeysAreSortedWhenDeterministic()
+        {
+            Dictionary<byte, int> value = new Dictionary<byte, int>
+            {
+                [200] = 1,
+                [1] = 2,
+            };
+
+            // A2 map(2)
+            //   01     1    02
+            //   18C8 200    01
+            Helper.TestWrite(value, "A2010218C801", null, new CborOptions { Deterministic = true });
+        }
+
+        [Fact]
+        public void SByteKeyedDictionaryKeysAreSortedWhenDeterministic()
+        {
+            Dictionary<sbyte, int> value = new Dictionary<sbyte, int>
+            {
+                [-1] = 1,
+                [2] = 2,
+            };
+
+            // A2 map(2)
+            //   02   2   02
+            //   20  -1   01      -- major type 1 sorts after every major type 0 key
+            Helper.TestWrite(value, "A202022001", null, new CborOptions { Deterministic = true });
+        }
+
+        [Fact]
+        public void ShortKeyedDictionaryKeysAreSortedWhenDeterministic()
+        {
+            Dictionary<short, int> value = new Dictionary<short, int>
+            {
+                [-2] = 1,
+                [3] = 2,
+            };
+
+            // A2 map(2)
+            //   03   3   02
+            //   21  -2   01
+            Helper.TestWrite(value, "A203022101", null, new CborOptions { Deterministic = true });
+        }
+
+        [Fact]
+        public void UShortKeyedDictionaryKeysAreSortedWhenDeterministic()
+        {
+            Dictionary<ushort, int> value = new Dictionary<ushort, int>
+            {
+                [65535] = 1,
+                [7] = 2,
+            };
+
+            // A2 map(2)
+            //   07          7   02
+            //   19FFFF  65535   01
+            Helper.TestWrite(value, "A2070219FFFF01", null, new CborOptions { Deterministic = true });
+        }
+
+        [Fact]
+        public void UIntKeyedDictionaryKeysAreSortedWhenDeterministic()
+        {
+            Dictionary<uint, string> value = new Dictionary<uint, string>
+            {
+                [4294967295] = "big",
+                [1] = "small",
+            };
+
+            // A2 map(2)
+            //   01                    1   65736D616C6C  "small"
+            //   1AFFFFFFFF   4294967295   63626967      "big"
+            Helper.TestWrite(value,
+                "A20165736D616C6C1AFFFFFFFF63626967",
+                null,
+                new CborOptions { Deterministic = true });
+        }
+
+        private enum Signal
+        {
+            Stop = -1,
+            Go = 0,
+            Wait = 1,
+        }
+
+        [Fact]
+        public void EnumKeyedDictionaryKeysAreSortedWhenDeterministic()
+        {
+            Dictionary<Signal, int> value = new Dictionary<Signal, int>
+            {
+                [Signal.Stop] = 1,
+                [Signal.Go] = 2,
+                [Signal.Wait] = 3,
+            };
+
+            // With the default EnumFormat (WriteToInt) the keys are plain integers, so Stop (-1) is
+            // major type 1 and sorts last.
+            //
+            // A3 map(3)
+            //   00   Go    0   02
+            //   01   Wait  1   03
+            //   20   Stop -1   01
+            Helper.TestWrite(value, "A3000201032001", null, new CborOptions { Deterministic = true });
+        }
+
+        // A boxed enum is not an `int` -- unboxing is exact-type, so `key is int` is false for
+        // Signal.Go however int-like its underlying type is. That is what made enum keys throw, and it
+        // is why enums get a branch of their own rather than falling into the integral one.
+        [Fact]
+        public void EnumKeyedDictionaryFollowsEnumFormatWhenDeterministic()
+        {
+            Dictionary<Signal, int> value = new Dictionary<Signal, int>
+            {
+                [Signal.Wait] = 1,
+                [Signal.Go] = 2,
+            };
+
+            CborOptions options = new CborOptions
+            {
+                Deterministic = true,
+                EnumFormat = ValueFormat.WriteToString,
+            };
+
+            // WriteToString writes each key as its member name, so these are text keys and are ordered
+            // as text: "Go" encodes in 3 bytes, "Wait" in 5, and shorter encodings sort first.
+            //
+            // A2 map(2)
+            //   62476F      "Go"    02
+            //   6457616974  "Wait"  01
+            Helper.TestWrite(value, "A262476F02645761697401", null, options);
+        }
+
+        [Fact]
+        public void ByteArrayKeyedDictionaryKeysAreSortedWhenDeterministic()
+        {
+            Dictionary<byte[], int> value = new Dictionary<byte[], int>
+            {
+                [new byte[] { 1, 1 }] = 1,
+                [new byte[] { 2 }] = 2,
+            };
+
+            // Byte-string keys (major type 2) order exactly like text keys: by encoded length first,
+            // then bytewise on the content. h'02' encodes in 2 bytes, h'0101' in 3.
+            //
+            // A2 map(2)
+            //   4102    h'02'    02
+            //   420101  h'0101'  01
+            Helper.TestWrite(value, "A241020242010101", null, new CborOptions { Deterministic = true });
+        }
+
         [Fact]
         public void NonStringNonIntDictionaryKeysThrowWhenDeterministic()
         {
@@ -391,6 +547,71 @@ namespace Dahomey.Cbor.Tests
             //   20 -1   69 6D696E7573206F6E65  "minus one"
             Helper.TestWrite(value,
                 "A300647A65726F01636F6E6520696D696E7573206F6E65",
+                null,
+                new CborOptions { Deterministic = true });
+        }
+
+        [Fact]
+        public void CborObjectByteStringKeysAreSortedWhenDeterministic()
+        {
+            CborObject value = new CborObject
+            {
+                [new ReadOnlyMemory<byte>(new byte[] { 1, 1 })] = 1,
+                [new ReadOnlyMemory<byte>(new byte[] { 2 })] = 2,
+            };
+
+            // Byte strings are legal CBOR map keys (major type 2) and are ordered by the same rule as
+            // text: encoded length first, then bytewise on the content.
+            //
+            // A2 map(2)
+            //   4102    h'02'    02
+            //   420101  h'0101'  01
+            Helper.TestWrite(value, "A241020242010101", null, new CborOptions { Deterministic = true });
+        }
+
+        // A map whose keys are all one kind is the easy case; a map read off the wire is under no
+        // obligation to be one. RFC 8949 4.2.1 orders mixed kinds by major type first, which is just the
+        // leading byte's own order: 0 unsigned, then 1 negative, then 2 byte string, then 3 text.
+        [Fact]
+        public void CborObjectMixedKeyKindsSortByMajorTypeWhenDeterministic()
+        {
+            CborObject value = new CborObject
+            {
+                ["text"] = 1,
+                [new ReadOnlyMemory<byte>(new byte[] { 0xFF })] = 2,
+                [-1] = 3,
+                [7] = 4,
+            };
+
+            // A4 map(4)
+            //   07            7        04
+            //   20           -1        03
+            //   41FF         h'FF'     02
+            //   6474657874   "text"    01
+            Helper.TestWrite(value,
+                "A40704200341FF02647465787401",
+                null,
+                new CborOptions { Deterministic = true });
+        }
+
+        // The headline use case: a document arrives, is decoded, and has to be re-encoded to be hashed.
+        // Its keys are whatever the sender chose, in whatever order the sender wrote them, so the
+        // deterministic path has to accept every key kind the reader can produce -- you cannot hash what
+        // you cannot re-encode.
+        [Fact]
+        public void CborObjectReadFromTheWireReEncodesDeterministically()
+        {
+            // A4 map(4), keys deliberately out of canonical order on the wire:
+            //   6474657874   "text"    01
+            //   41FF         h'FF'     02
+            //   20           -1        03
+            //   07            7        04
+            const string scrambled = "A464746578740141FF0220030704";
+
+            CborObject value = Cbor.Deserialize<CborObject>(scrambled.HexToBytes());
+
+            Helper.TestWrite(value,
+                "A40704200341FF02647465787401",
                 null,
                 new CborOptions { Deterministic = true });
         }
@@ -478,6 +699,50 @@ namespace Dahomey.Cbor.Tests
         {
             Assert.Equal(expected, Math.Sign(
                 Dahomey.Cbor.Serialization.CborKeyComparer.CompareIntegerKeys(negativeA, argumentA, negativeB, argumentB)));
+        }
+
+        // CompareKeys is the one comparison that spans kinds: it takes a major type plus whatever varies
+        // within that type (the argument for integers, the payload for strings). Major types are ordered
+        // by their own numeric order, which is the order of the encoded leading byte -- 0 unsigned, 1
+        // negative, 2 byte string, 3 text string -- so the comparison never has to look at the payload of
+        // two keys of different kinds, however those payloads would compare.
+        [Fact]
+        public void CompareKeysOrdersByMajorTypeBeforeAnythingElse()
+        {
+            ReadOnlySpan<byte> noContent = default;
+            ReadOnlySpan<byte> content = new byte[] { 0x41 };
+
+            // Largest possible unsigned key still sorts before the smallest possible negative key.
+            Assert.True(Serialization.CborKeyComparer.CompareKeys(
+                Serialization.CborMajorType.PositiveInteger, ulong.MaxValue, noContent,
+                Serialization.CborMajorType.NegativeInteger, 0, noContent) < 0);
+
+            // Negative before byte string.
+            Assert.True(Serialization.CborKeyComparer.CompareKeys(
+                Serialization.CborMajorType.NegativeInteger, ulong.MaxValue, noContent,
+                Serialization.CborMajorType.ByteString, 0, content) < 0);
+
+            // Byte string before text string, with identical payloads on both sides -- only the major
+            // type can be deciding this.
+            Assert.True(Serialization.CborKeyComparer.CompareKeys(
+                Serialization.CborMajorType.ByteString, 0, content,
+                Serialization.CborMajorType.TextString, 0, content) < 0);
+
+            // Within one major type the existing rules apply unchanged.
+            Assert.Equal(0, Serialization.CborKeyComparer.CompareKeys(
+                Serialization.CborMajorType.TextString, 0, content,
+                Serialization.CborMajorType.TextString, 0, content));
+        }
+
+        [Fact]
+        public void CompareKeysRejectsMajorTypesThatAreNotKeys()
+        {
+            // Nothing decorates a key as an array, so this is unreachable from the converters; it is
+            // pinned here so the rejection stays a CborException rather than, say, a silent 0 that would
+            // make the sort claim two different keys are equal.
+            Assert.Throws<CborException>(() => Serialization.CborKeyComparer.CompareKeys(
+                Serialization.CborMajorType.Array, 0, default,
+                Serialization.CborMajorType.Array, 0, default));
         }
 
         // OPTIONAL widening that fell out of CompareIntegerKeys existing: long/ulong dictionary keys no
@@ -585,6 +850,75 @@ namespace Dahomey.Cbor.Tests
             Helper.TestWrite(value, "83010203", null, options);
 
             Assert.Equal(Helper.Write(value, options), Helper.Write(value, options));
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        private class ArrayFormatWithNegativeIndex
+        {
+            [CborProperty(-1)]
+            public int Negative { get; set; }
+            [CborProperty(0)]
+            public int Zero { get; set; }
+            [CborProperty(1)]
+            public int One { get; set; }
+        }
+
+        // Array format writes members positionally and emits no keys at all, so the deterministic key
+        // order has nothing to act on: any reordering it performed would move VALUES between array
+        // positions, which changes what the document means. A negative MemberIndex is the case that
+        // exposes it, because it is the one index whose deterministic order (major type 1, so last)
+        // differs from the ascending-int order ObjectMapping already applied. Deterministic and
+        // non-deterministic output must therefore be byte-identical here.
+        [Fact]
+        public void ArrayFormatWithNegativeIndexIsUnaffectedByDeterministic()
+        {
+            ArrayFormatWithNegativeIndex value = new ArrayFormatWithNegativeIndex { Negative = 7, Zero = 8, One = 9 };
+
+            // 83 array(3) 07 08 09 -- positions follow ObjectMapping's ascending-index order (-1, 0, 1),
+            // exactly as they do without Deterministic.
+            Helper.TestWrite(value, "83070809", null, new CborOptions { Deterministic = true });
+
+            Assert.Equal(
+                Helper.Write(value),
+                Helper.Write(value, new CborOptions { Deterministic = true }));
+        }
+
+        // The converter for a type is built once and cached in CborConverterRegistry, so any ordering
+        // decision taken while building it would freeze whatever the flag happened to be at that moment.
+        // CborOptions.Default is a process-wide singleton, which makes "flag set after something was
+        // already serialized" the normal case rather than an exotic one. Deterministic output must
+        // depend only on the flag's value at write time.
+        [Fact]
+        public void DeterministicTakesEffectWhenSetAfterTheConverterIsCached()
+        {
+            CborOptions options = new CborOptions();
+            OutOfOrderObject value = new OutOfOrderObject { Zebra = 1, Apple = 2, Mango = 3 };
+
+            // Builds and caches ObjectConverter<OutOfOrderObject> while Deterministic is still false.
+            Assert.Equal("A3655A6562726101654170706C6502654D616E676F03", Helper.Write(value, options));
+
+            options.Deterministic = true;
+
+            // A3 map(3)
+            //   654170706C65 "Apple"  02
+            //   654D616E676F "Mango"  03
+            //   655A65627261 "Zebra"  01
+            Assert.Equal("A3654170706C6502654D616E676F03655A6562726101", Helper.Write(value, options));
+        }
+
+        // ... and back again: clearing the flag on options whose converters were built while it was set
+        // must restore declaration order, so the flag is never a one-way latch.
+        [Fact]
+        public void ClearingDeterministicRestoresDeclarationOrder()
+        {
+            CborOptions options = new CborOptions { Deterministic = true };
+            OutOfOrderObject value = new OutOfOrderObject { Zebra = 1, Apple = 2, Mango = 3 };
+
+            Assert.Equal("A3654170706C6502654D616E676F03655A6562726101", Helper.Write(value, options));
+
+            options.Deterministic = false;
+
+            Assert.Equal("A3655A6562726101654170706C6502654D616E676F03", Helper.Write(value, options));
         }
     }
 }

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -158,5 +158,39 @@ namespace Dahomey.Cbor.Tests
         {
             Assert.Equal(expected, Math.Sign(Dahomey.Cbor.Serialization.CborKeyComparer.CompareIntKeys(a, b)));
         }
+
+        private class OutOfOrderObject
+        {
+            public int Zebra { get; set; }
+            public int Apple { get; set; }
+            public int Mango { get; set; }
+        }
+
+        [Fact]
+        public void StringKeyMapMembersAreSortedWhenDeterministic()
+        {
+            OutOfOrderObject value = new OutOfOrderObject { Zebra = 1, Apple = 2, Mango = 3 };
+
+            // A3 map(3)
+            //   654170706C65 "Apple"  02
+            //   654D616E676F "Mango"  03
+            //   655A65627261 "Zebra"  01
+            Helper.TestWrite(value,
+                "A3654170706C6502654D616E676F03655A6562726101",
+                null,
+                new CborOptions { Deterministic = true });
+        }
+
+        [Fact]
+        public void DeclarationOrderIsPreservedWhenNotDeterministic()
+        {
+            OutOfOrderObject value = new OutOfOrderObject { Zebra = 1, Apple = 2, Mango = 3 };
+
+            // A3 map(3)
+            //   655A65627261 "Zebra"  01
+            //   654170706C65 "Apple"  02
+            //   654D616E676F "Mango"  03
+            Helper.TestWrite(value, "A3655A6562726101654170706C6502654D616E676F03");
+        }
     }
 }

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.ObjectModel;
@@ -491,17 +491,26 @@ namespace Dahomey.Cbor.Tests
             Helper.TestWrite(value, "A241020242010101", null, new CborOptions { Deterministic = true });
         }
 
+        /// <summary>
+        /// A key type with no special case anywhere in the ordering code still sorts correctly,
+        /// because the order comes from the bytes its own converter writes.
+        /// </summary>
         [Fact]
-        public void NonStringNonIntDictionaryKeysThrowWhenDeterministic()
+        public void FloatingPointDictionaryKeysAreSortedByTheirEncodedBytes()
         {
             Dictionary<double, int> value = new Dictionary<double, int>
             {
-                [1.5] = 1,
                 [2.5] = 2,
+                [1.5] = 1,
             };
 
-            CborOptions options = new CborOptions { Deterministic = true };
-            Assert.Throws<CborException>(() => Helper.Write(value, options));
+            // Both are exactly representable as half floats, so preferred float serialization writes
+            // each in three bytes and the comparison is on those.
+            //
+            // A2 map(2)
+            //   F93E00  1.5  01
+            //   F94100  2.5  02
+            Helper.TestWrite(value, "A2F93E0001F9410002", null, new CborOptions { Deterministic = true });
         }
 
         [Fact]
@@ -616,22 +625,23 @@ namespace Dahomey.Cbor.Tests
                 new CborOptions { Deterministic = true });
         }
 
+        /// <summary>
+        /// A CborObject may mix key kinds, and a boolean key is neither a string nor an integer.
+        /// Ordering by the encoded bytes covers it without needing to know what a boolean is.
+        /// </summary>
         [Fact]
-        public void CborObjectWithUnsupportedKeyTypeThrowsUnwrappedWhenDeterministic()
+        public void CborObjectMixedKeyKindsAreSortedByTheirEncodedBytes()
         {
-            // A boolean key is neither CborValueType.String nor CborValueType.Positive/Negative, so it
-            // must throw CborException -- and, per the List<T>.Sort wrapping bug fixed for
-            // NonStringNonIntDictionaryKeysThrowWhenDeterministic, it must arrive as a CborException,
-            // not wrapped in InvalidOperationException. Assert.Throws<CborException> already fails on a
-            // mismatched exception type, so this pins the unwrap without any extra assertion.
             CborObject value = new CborObject
             {
                 [true] = 1,
                 ["ok"] = 2,
             };
 
-            CborOptions options = new CborOptions { Deterministic = true };
-            Assert.Throws<CborException>(() => Helper.Write(value, options));
+            // A2 map(2)
+            //   626F6B  "ok"  02
+            //   F5      true  01
+            Helper.TestWrite(value, "A2626F6B02F501", null, new CborOptions { Deterministic = true });
         }
 
         // Reviewer's exact reproduction of the int-narrowing bug: a key that needs the 9-byte

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -184,6 +184,67 @@ namespace Dahomey.Cbor.Tests
                 new CborOptions { Deterministic = true });
         }
 
+        private class NestingObject
+        {
+            public int Yak { get; set; }
+            public OutOfOrderObject Inner { get; set; }
+            public int Ant { get; set; }
+        }
+
+        // Every other ordering test in this file works on a top-level map. Ordering is applied per map,
+        // by the converter that writes it, so a nested value has to be sorted by its own converter on
+        // its own members -- not inherited from, or skipped because of, the map that contains it.
+        [Fact]
+        public void NestedMapsAreSortedIndependentlyWhenDeterministic()
+        {
+            NestingObject value = new NestingObject
+            {
+                Yak = 1,
+                Inner = new OutOfOrderObject { Zebra = 4, Apple = 5, Mango = 6 },
+                Ant = 2,
+            };
+
+            // "Inner" is five characters, so its header byte is 0x65 against 0x63 for the two
+            // three-character names: it sorts last on header length before any name content is looked
+            // at, which is also why this test would not catch a converter that sorted alphabetically.
+            //
+            // A3 map(3)
+            //   63416E74       "Ant"    02
+            //   6359616B       "Yak"    01
+            //   65496E6E6572   "Inner"  A3 map(3)
+            //                              654170706C65 "Apple"  05
+            //                              654D616E676F "Mango"  06
+            //                              655A65627261 "Zebra"  04
+            Helper.TestWrite(value,
+                "A363416E74026359616B0165496E6E6572A3654170706C6505654D616E676F06655A6562726104",
+                null,
+                new CborOptions { Deterministic = true });
+        }
+
+        // Ordering is over the bytes a key's converter writes, so there is no kind of key the rule
+        // itself excludes: a null, an array and a map are all encodable, so all three are orderable.
+        // Each sorts after the text key here because major type decides first -- text is 3 (0x61),
+        // array 4 (0x82), map 5 (0xA1), and null is major type 7 (0xF6).
+        [Theory]
+        [InlineData("null", "A2617A02F601")]
+        [InlineData("array", "A2617A0282010201")]
+        [InlineData("map", "A2617A02A1616B0101")]
+        public void NonScalarCborObjectKeysAreOrderedRatherThanRejected(string kind, string expectedHex)
+        {
+            CborValue key = kind switch
+            {
+                "null" => CborValue.Null,
+                "array" => new CborArray(1, 2),
+                _ => new CborObject { ["k"] = 1 },
+            };
+
+            CborObject value = new CborObject();
+            value[key] = 1;
+            value["z"] = 2;
+
+            Helper.TestWrite(value, expectedHex, null, new CborOptions { Deterministic = true });
+        }
+
         [Fact]
         public void DeclarationOrderIsPreservedWhenNotDeterministic()
         {
@@ -644,14 +705,12 @@ namespace Dahomey.Cbor.Tests
             Helper.TestWrite(value, "A2626F6B02F501", null, new CborOptions { Deterministic = true });
         }
 
-        // Reviewer's exact reproduction of the int-narrowing bug: a key that needs the 9-byte
-        // (major-type + 8-byte-argument) form must still sort AFTER a key that fits in 1 byte, per RFC
-        // 8949 4.2.1's "shorter encoding always sorts first" rule -- regardless of numeric magnitude.
-        // Before CborKeyComparer.CompareIntegerKeys, CborValueConverter read both keys through
-        // Value<int>(), which silently wrapped 4294967301 (2^32 + 5) down to 5, comparing it as if it
-        // were smaller than 10 and emitting the 9-byte key first: wrong order, wrong bytes, no
-        // exception. TryGetIntegerKeyArgument now reads the full ulong via Value<ulong>(), so the
-        // 9-byte form correctly sorts last.
+        // A key that needs the 9-byte (major type + 8-byte argument) form must sort AFTER a key that
+        // fits in 1 byte, per RFC 8949 4.2.1's "shorter encoding always sorts first" rule, regardless
+        // of numeric magnitude. Both keys are encoded through their own converter and compared as
+        // bytes, so no CLR integer width sits between the value and the ordering to narrow it: this
+        // pair is 2^32 + 5 against 10, which any comparison going through a 32-bit value would order
+        // the wrong way round and emit without an exception.
         [Fact]
         public void CborObjectLargeIntegerKeysSortByEncodedLengthNotNumericValueWhenDeterministic()
         {
@@ -692,71 +751,11 @@ namespace Dahomey.Cbor.Tests
         // here: CborNegative's constructor takes a `long` and rejects anything a `long` cannot hold,
         // and the reader path (CborReader.ReadInt64 -> ReadSigned(long.MaxValue)) is bounded the same
         // way, so no CborValue in this object model can ever hold a value below long.MinValue. There is
-        // no case to construct. CborKeyComparer.CompareIntegerKeys still accepts the full ulong argument
-        // range on its own terms -- verified directly by the CborKeyComparer.CompareIntegerKeys unit
-        // tests below -- it is only CborValue's own representation that stops at long.MinValue.
+        // no case to construct; it is CborValue's own representation that stops there, not the ordering
+        // rule, which is over encoded bytes and has no numeric range of its own.
 
-        [Theory]
-        [InlineData(false, 10ul, false, 4294967301ul, -1)]     // both major type 0: shorter-encoded argument (10, 1 byte) sorts first
-        [InlineData(false, 4294967301ul, false, 10ul, 1)]
-        [InlineData(false, 0ul, true, 0ul, -1)]                // major type 0 (any argument) sorts before major type 1 (any argument)
-        [InlineData(true, 0ul, false, 0ul, 1)]
-        [InlineData(true, 0ul, true, ulong.MaxValue, -1)]      // within major type 1, ascending argument is ascending encoded order
-        [InlineData(true, ulong.MaxValue, true, 0ul, 1)]
-        [InlineData(false, ulong.MaxValue, false, ulong.MaxValue, 0)]
-        public void CompareIntegerKeysOrdersByMajorTypeThenEncodedArgument(
-            bool negativeA, ulong argumentA, bool negativeB, ulong argumentB, int expected)
-        {
-            Assert.Equal(expected, Math.Sign(
-                Dahomey.Cbor.Serialization.CborKeyComparer.CompareIntegerKeys(negativeA, argumentA, negativeB, argumentB)));
-        }
-
-        // CompareKeys is the one comparison that spans kinds: it takes a major type plus whatever varies
-        // within that type (the argument for integers, the payload for strings). Major types are ordered
-        // by their own numeric order, which is the order of the encoded leading byte -- 0 unsigned, 1
-        // negative, 2 byte string, 3 text string -- so the comparison never has to look at the payload of
-        // two keys of different kinds, however those payloads would compare.
-        [Fact]
-        public void CompareKeysOrdersByMajorTypeBeforeAnythingElse()
-        {
-            ReadOnlySpan<byte> noContent = default;
-            ReadOnlySpan<byte> content = new byte[] { 0x41 };
-
-            // Largest possible unsigned key still sorts before the smallest possible negative key.
-            Assert.True(Serialization.CborKeyComparer.CompareKeys(
-                Serialization.CborMajorType.PositiveInteger, ulong.MaxValue, noContent,
-                Serialization.CborMajorType.NegativeInteger, 0, noContent) < 0);
-
-            // Negative before byte string.
-            Assert.True(Serialization.CborKeyComparer.CompareKeys(
-                Serialization.CborMajorType.NegativeInteger, ulong.MaxValue, noContent,
-                Serialization.CborMajorType.ByteString, 0, content) < 0);
-
-            // Byte string before text string, with identical payloads on both sides -- only the major
-            // type can be deciding this.
-            Assert.True(Serialization.CborKeyComparer.CompareKeys(
-                Serialization.CborMajorType.ByteString, 0, content,
-                Serialization.CborMajorType.TextString, 0, content) < 0);
-
-            // Within one major type the existing rules apply unchanged.
-            Assert.Equal(0, Serialization.CborKeyComparer.CompareKeys(
-                Serialization.CborMajorType.TextString, 0, content,
-                Serialization.CborMajorType.TextString, 0, content));
-        }
-
-        [Fact]
-        public void CompareKeysRejectsMajorTypesThatAreNotKeys()
-        {
-            // Nothing decorates a key as an array, so this is unreachable from the converters; it is
-            // pinned here so the rejection stays a CborException rather than, say, a silent 0 that would
-            // make the sort claim two different keys are equal.
-            Assert.Throws<CborException>(() => Serialization.CborKeyComparer.CompareKeys(
-                Serialization.CborMajorType.Array, 0, default,
-                Serialization.CborMajorType.Array, 0, default));
-        }
-
-        // OPTIONAL widening that fell out of CompareIntegerKeys existing: long/ulong dictionary keys no
-        // longer have to throw, since the comparer they need already exists for CborObject keys.
+        // long/ulong dictionary keys are sorted rather than rejected, on the same encoded-bytes rule as
+        // every other key type.
         [Fact]
         public void LongKeyedDictionaryKeysAreSortedWhenDeterministic()
         {

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -906,6 +906,75 @@ namespace Dahomey.Cbor.Tests
             Assert.Equal("A3654170706C6502654D616E676F03655A6562726101", Helper.Write(value, options));
         }
 
+        // Static so that it is not itself a member to serialize: the flip has to happen from inside the
+        // write, and a property getter is the shortest way to get code to run there.
+        private static CborOptions _optionsFlippedMidWrite;
+
+        private class FlipsDeterministicWhileBeingWritten
+        {
+            public int Zebra { get; set; }
+
+            public int Bob
+            {
+                // Writing this member turns the flag on partway through the map, between the header's
+                // member count and the last member.
+                get
+                {
+                    _optionsFlippedMidWrite.Deterministic = true;
+                    return 9;
+                }
+                set { }
+            }
+
+            public int Apple { get; set; }
+            public int Mango { get; set; }
+        }
+
+        // A write must run start to finish on one member ordering. The ordering is chosen from a flag
+        // that anything running during the write can change -- a property getter as here, a custom
+        // converter, or another thread sharing CborOptions.Default -- and the two orderings are
+        // permutations of each other, so switching between them mid-map writes some members twice and
+        // drops others while the map header still claims the original count. That document is
+        // structurally corrupt and nothing downstream can tell: the count matches, every item parses.
+        [Fact]
+        public void FlippingDeterministicDuringAWriteDoesNotChangeThatWritesOrder()
+        {
+            CborOptions options = new CborOptions();
+            _optionsFlippedMidWrite = options;
+
+            FlipsDeterministicWhileBeingWritten value = new FlipsDeterministicWhileBeingWritten
+            {
+                Zebra = 1,
+                Apple = 2,
+                Mango = 3,
+            };
+
+            // The write started with the flag off, so it finishes in declaration order -- four distinct
+            // members, in the order the header's count was computed for.
+            //
+            // A4 map(4)
+            //   655A65627261 "Zebra"  01
+            //   63426F62     "Bob"    09
+            //   654170706C65 "Apple"  02
+            //   654D616E676F "Mango"  03
+            Assert.Equal(
+                "A4655A656272610163426F6209654170706C6502654D616E676F03",
+                Helper.Write(value, options));
+
+            // The flag really did flip, and the next write -- which starts after it -- is sorted:
+            // "Bob" encodes shorter than the others, so it leads.
+            //
+            // A4 map(4)
+            //   63426F62     "Bob"    09
+            //   654170706C65 "Apple"  02
+            //   654D616E676F "Mango"  03
+            //   655A65627261 "Zebra"  01
+            Assert.True(options.Deterministic);
+            Assert.Equal(
+                "A463426F6209654170706C6502654D616E676F03655A6562726101",
+                Helper.Write(value, options));
+        }
+
         // ... and back again: clearing the flag on options whose converters were built while it was set
         // must restore declaration order, so the flag is never a one-way latch.
         [Fact]

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -412,5 +412,108 @@ namespace Dahomey.Cbor.Tests
             CborOptions options = new CborOptions { Deterministic = true };
             Assert.Throws<CborException>(() => Helper.Write(value, options));
         }
+
+        // Reviewer's exact reproduction of the int-narrowing bug: a key that needs the 9-byte
+        // (major-type + 8-byte-argument) form must still sort AFTER a key that fits in 1 byte, per RFC
+        // 8949 4.2.1's "shorter encoding always sorts first" rule -- regardless of numeric magnitude.
+        // Before CborKeyComparer.CompareIntegerKeys, CborValueConverter read both keys through
+        // Value<int>(), which silently wrapped 4294967301 (2^32 + 5) down to 5, comparing it as if it
+        // were smaller than 10 and emitting the 9-byte key first: wrong order, wrong bytes, no
+        // exception. TryGetIntegerKeyArgument now reads the full ulong via Value<ulong>(), so the
+        // 9-byte form correctly sorts last.
+        [Fact]
+        public void CborObjectLargeIntegerKeysSortByEncodedLengthNotNumericValueWhenDeterministic()
+        {
+            CborObject value = new CborObject
+            {
+                [(ulong)4294967301] = "A", // 2^32 + 5: needs the 9-byte (1B + 8-byte) argument form
+                [(ulong)10] = "B",         // fits the 1-byte argument form
+            };
+
+            // A2 map(2)
+            //   0A                   10                  6142 "B"
+            //   1B0000000100000005   4294967301          6141 "A"
+            Helper.TestWrite(value,
+                "A20A61421B00000001000000056141",
+                null,
+                new CborOptions { Deterministic = true });
+        }
+
+        [Fact]
+        public void CborObjectUlongMaxValueKeySortsAfterSmallKeyWhenDeterministic()
+        {
+            CborObject value = new CborObject
+            {
+                [ulong.MaxValue] = "big",
+                [(ulong)1] = "small",
+            };
+
+            // A2 map(2)
+            //   01                    1                      65736D616C6C  "small"
+            //   1BFFFFFFFFFFFFFFFF    18446744073709551615   63626967      "big"
+            Helper.TestWrite(value,
+                "A20165736D616C6C1BFFFFFFFFFFFFFFFF63626967",
+                null,
+                new CborOptions { Deterministic = true });
+        }
+
+        // A negative key beyond long.MinValue (down to CBOR's true floor of -2^64) is not exercised
+        // here: CborNegative's constructor takes a `long` and rejects anything a `long` cannot hold,
+        // and the reader path (CborReader.ReadInt64 -> ReadSigned(long.MaxValue)) is bounded the same
+        // way, so no CborValue in this object model can ever hold a value below long.MinValue. There is
+        // no case to construct. CborKeyComparer.CompareIntegerKeys still accepts the full ulong argument
+        // range on its own terms -- verified directly by the CborKeyComparer.CompareIntegerKeys unit
+        // tests below -- it is only CborValue's own representation that stops at long.MinValue.
+
+        [Theory]
+        [InlineData(false, 10ul, false, 4294967301ul, -1)]     // both major type 0: shorter-encoded argument (10, 1 byte) sorts first
+        [InlineData(false, 4294967301ul, false, 10ul, 1)]
+        [InlineData(false, 0ul, true, 0ul, -1)]                // major type 0 (any argument) sorts before major type 1 (any argument)
+        [InlineData(true, 0ul, false, 0ul, 1)]
+        [InlineData(true, 0ul, true, ulong.MaxValue, -1)]      // within major type 1, ascending argument is ascending encoded order
+        [InlineData(true, ulong.MaxValue, true, 0ul, 1)]
+        [InlineData(false, ulong.MaxValue, false, ulong.MaxValue, 0)]
+        public void CompareIntegerKeysOrdersByMajorTypeThenEncodedArgument(
+            bool negativeA, ulong argumentA, bool negativeB, ulong argumentB, int expected)
+        {
+            Assert.Equal(expected, Math.Sign(
+                Dahomey.Cbor.Serialization.CborKeyComparer.CompareIntegerKeys(negativeA, argumentA, negativeB, argumentB)));
+        }
+
+        // OPTIONAL widening that fell out of CompareIntegerKeys existing: long/ulong dictionary keys no
+        // longer have to throw, since the comparer they need already exists for CborObject keys.
+        [Fact]
+        public void LongKeyedDictionaryKeysAreSortedWhenDeterministic()
+        {
+            Dictionary<long, string> value = new Dictionary<long, string>
+            {
+                [4294967301L] = "A",
+                [10L] = "B",
+            };
+
+            // Same wire bytes as CborObjectLargeIntegerKeysSortByEncodedLengthNotNumericValueWhenDeterministic --
+            // see that test for the byte-by-byte derivation.
+            Helper.TestWrite(value,
+                "A20A61421B00000001000000056141",
+                null,
+                new CborOptions { Deterministic = true });
+        }
+
+        [Fact]
+        public void UlongKeyedDictionaryKeysAreSortedWhenDeterministic()
+        {
+            Dictionary<ulong, string> value = new Dictionary<ulong, string>
+            {
+                [ulong.MaxValue] = "big",
+                [1UL] = "small",
+            };
+
+            // Same wire bytes as CborObjectUlongMaxValueKeySortsAfterSmallKeyWhenDeterministic -- see
+            // that test for the byte-by-byte derivation.
+            Helper.TestWrite(value,
+                "A20165736D616C6C1BFFFFFFFFFFFFFFFF63626967",
+                null,
+                new CborOptions { Deterministic = true });
+        }
     }
 }

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -515,5 +515,76 @@ namespace Dahomey.Cbor.Tests
                 null,
                 new CborOptions { Deterministic = true });
         }
+
+        // RFC 8949 4.2.1 requirement 1: "Integers must be as small as possible." CborWriter's existing
+        // shortest-form ladder already does this unconditionally (it is not gated on Deterministic at
+        // all) -- these pin that pre-existing behaviour so a future change cannot quietly widen it.
+        // Major type 0 (unsigned), one-byte header 0x00-0x17 for values 0-23, then additional-info
+        // 24/25/26 (prefix 0x18/0x19/0x1A) select the smallest argument width that still fits the value.
+        [Theory]
+        [InlineData(0, "00")]
+        [InlineData(23, "17")]
+        [InlineData(24, "1818")]
+        [InlineData(255, "18FF")]
+        [InlineData(256, "190100")]
+        [InlineData(65536, "1A00010000")]
+        public void IntegersUseShortestForm(int value, string expectedHex)
+        {
+            Helper.TestWrite(value, expectedHex, null, new CborOptions { Deterministic = true });
+        }
+
+        // RFC 8949 4.2.1 requirement 2: "the preferred serialization always uses the shortest form of
+        // representing the argument." For floats this means trying binary16 (Half), then binary32
+        // (Single), then binary64 (Double), taking the first that round-trips exactly -- CborWriter.
+        // WriteSingle/WriteDouble already does this unconditionally. These pin the three tiers:
+        //  - 1.5 is exactly representable in binary16 (Half), so it takes the 3-byte F9 form.
+        //  - float.MaxValue needs the full 24-bit mantissa of binary32, so it takes the 5-byte FA form.
+        //  - 1.1 is not exactly representable in binary16 or binary32, so it takes the 9-byte FB form.
+        [Theory]
+        [InlineData(1.5d, "F93E00")]                          // exactly representable as binary16
+        [InlineData(3.4028234663852886E38d, "FA7F7FFFFF")]    // float.MaxValue: needs binary32
+        [InlineData(1.1d, "FB3FF199999999999A")]               // needs binary64
+        public void FloatsUsePreferredSerialization(double value, string expectedHex)
+        {
+            Helper.TestWrite(value, expectedHex, null, new CborOptions { Deterministic = true });
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        private class ArrayFormatObject
+        {
+            // Deliberately alphabetically out of order, same as OutOfOrderObject above -- Array
+            // format is positional by MemberIndex, not by name, so unlike StringKeyMap/IntKeyMap there
+            // is no name to sort by in the first place.
+            [CborProperty(0)]
+            public int Zebra { get; set; }
+            [CborProperty(1)]
+            public int Apple { get; set; }
+            [CborProperty(2)]
+            public int Mango { get; set; }
+        }
+
+        // RFC 8949 4.2.1 requirement 3: "The keys in every map must be sorted in the bytewise
+        // lexicographic order of their deterministic encodings." CborObjectFormat.Array serializes
+        // members positionally by MemberIndex instead of as a map, so there are no map keys at all --
+        // nothing for the deterministic sort to do, and the output is already deterministic by
+        // construction. Pinned two ways: the encoding matches the plain positional array regardless of
+        // Deterministic, and two writes produce identical bytes.
+        [Fact]
+        public void ArrayFormatObjectsHaveNoKeysToSort()
+        {
+            CborOptions options = new CborOptions
+            {
+                Deterministic = true,
+                ObjectFormat = CborObjectFormat.Array,
+            };
+
+            ArrayFormatObject value = new ArrayFormatObject { Zebra = 1, Apple = 2, Mango = 3 };
+
+            // 83 array(3) 01 02 03 -- positions 0/1/2 are Zebra/Apple/Mango by MemberIndex, unaffected
+            // by Deterministic since there are no keys to sort.
+            Helper.TestWrite(value, "83010203", null, options);
+
+            Assert.Equal(Helper.Write(value, options), Helper.Write(value, options));
+        }
     }
 }

--- a/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicEncodingTests.cs
@@ -280,5 +280,71 @@ namespace Dahomey.Cbor.Tests
                 null,
                 options);
         }
+
+        [Fact]
+        public void DictionaryKeysAreSortedWhenDeterministic()
+        {
+            Dictionary<string, int> value = new Dictionary<string, int>
+            {
+                ["b"] = 1,
+                ["a"] = 2,
+            };
+
+            // A2 map(2) 6161 "a" 02 6162 "b" 01
+            Helper.TestWrite(value, "A2616102616201", null, new CborOptions { Deterministic = true });
+        }
+
+        [Fact]
+        public void DictionaryOrderIsIndependentOfInsertionOrderWhenDeterministic()
+        {
+            CborOptions options = new CborOptions { Deterministic = true };
+
+            Dictionary<string, int> forwards = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2, ["c"] = 3 };
+            Dictionary<string, int> backwards = new Dictionary<string, int> { ["c"] = 3, ["b"] = 2, ["a"] = 1 };
+
+            Assert.Equal(Helper.Write(forwards, options), Helper.Write(backwards, options));
+        }
+
+        [Fact]
+        public void SerializingTwiceProducesIdenticalBytes()
+        {
+            CborOptions options = new CborOptions { Deterministic = true };
+            OutOfOrderObject value = new OutOfOrderObject { Zebra = 1, Apple = 2, Mango = 3 };
+
+            Assert.Equal(Helper.Write(value, options), Helper.Write(value, options));
+        }
+
+        [Fact]
+        public void IntKeyedDictionaryKeysAreSortedWhenDeterministic()
+        {
+            Dictionary<int, string> value = new Dictionary<int, string>
+            {
+                [1] = "one",
+                [-1] = "minus one",
+                [0] = "zero",
+            };
+
+            // A3 map(3)
+            //   00  0   64 7A65726F           "zero"
+            //   01  1   63 6F6E65              "one"
+            //   20 -1   69 6D696E7573206F6E65  "minus one"
+            Helper.TestWrite(value,
+                "A300647A65726F01636F6E6520696D696E7573206F6E65",
+                null,
+                new CborOptions { Deterministic = true });
+        }
+
+        [Fact]
+        public void NonStringNonIntDictionaryKeysThrowWhenDeterministic()
+        {
+            Dictionary<double, int> value = new Dictionary<double, int>
+            {
+                [1.5] = 1,
+                [2.5] = 2,
+            };
+
+            CborOptions options = new CborOptions { Deterministic = true };
+            Assert.Throws<CborException>(() => Helper.Write(value, options));
+        }
     }
 }

--- a/src/Dahomey.Cbor.Tests/DeterministicKeyConverterTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicKeyConverterTests.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Serialization.Converters;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// Deterministic key order must be the order of the bytes the key converter actually writes.
+    /// </summary>
+    /// <remarks>
+    /// Each case here is one a sort key derived from the CLR type got wrong, because deriving one is
+    /// making a prediction about a converter's output that nothing checks.
+    /// </remarks>
+    public class DeterministicKeyConverterTests
+    {
+        public enum AliasedKey
+        {
+            First = 1,
+            AlsoFirst = 1,
+            Second = 2,
+        }
+
+        /// <summary>
+        /// Writes a Sku as text, so its order is text order and nothing about it is derivable from
+        /// the CLR type.
+        /// </summary>
+        private class SkuConverter : CborConverterBase<Sku>
+        {
+            public override Sku Read(ref CborReader reader) => new Sku { Code = reader.ReadString() };
+
+            public override void Write(ref CborWriter writer, Sku value, LengthMode lengthMode)
+                => writer.WriteString(value.Code);
+        }
+
+        [CborConverter(typeof(SkuConverter))]
+        public struct Sku
+        {
+            public string Code { get; set; }
+        }
+
+        private static CborOptions Deterministic() => new CborOptions { Deterministic = true };
+
+        /// <summary>
+        /// An enum value with two names is written as the last one, so it must be ordered as the last
+        /// one. Ordering it as <c>Enum.GetName</c>'s first name put a nine-byte key ahead of a
+        /// six-byte one.
+        /// </summary>
+        [Fact]
+        public void AnAliasedEnumKeyIsOrderedAsTheNameThatGetsWritten()
+        {
+            CborOptions options = Deterministic();
+            options.EnumFormat = ValueFormat.WriteToString;
+
+            Dictionary<AliasedKey, int> value = new Dictionary<AliasedKey, int>
+            {
+                [AliasedKey.Second] = 2,
+                [AliasedKey.First] = 1,
+            };
+
+            // "Second" encodes as 66 …, "AlsoFirst" as 69 …, so "Second" sorts first even though its
+            // numeric value is larger and its first name ("First") would have sorted before it.
+            //
+            // A2 map(2)
+            //   66 5365636F6E64          "Second"     02
+            //   69 416C736F4669727374    "AlsoFirst"  01
+            Helper.TestWrite(value, "A2665365636F6E640269416C736F466972737401", null, options);
+        }
+
+        /// <summary>
+        /// The key's own converter decides both the bytes and the order, for a type no ordering
+        /// switch could have had a case for.
+        /// </summary>
+        [Fact]
+        public void ACustomKeyConverterDecidesTheOrder()
+        {
+            Dictionary<Sku, int> value = new Dictionary<Sku, int>
+            {
+                [new Sku { Code = "zeta" }] = 20,
+                [new Sku { Code = "beta" }] = 100,
+            };
+
+            // Equal-length codes, so the comparison reaches the content and the order is the
+            // converter's text order rather than anything derivable from the struct.
+            //
+            // A2 map(2)
+            //   64 62657461   "beta"  1864
+            //   64 7A657461   "zeta"  14
+            Helper.TestWrite(value, "A264626574611864647A65746114", null, Deterministic());
+        }
+
+        /// <summary>
+        /// A key type with no case in any ordering switch is written, and ordered, by its own
+        /// converter rather than rejected.
+        /// </summary>
+        [Fact]
+        public void DateTimeKeysAreSupported()
+        {
+            Dictionary<DateTime, int> value = new Dictionary<DateTime, int>
+            {
+                [new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc)] = 2,
+                [new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc)] = 1,
+            };
+
+            string hexBuffer = Helper.Write(value, Deterministic());
+
+            // Both keys encode to the same length, so they order bytewise on the ISO 8601 text, which
+            // for these two is chronological.
+            Assert.Equal(
+                "A2C074323032302D30312D30315430303A30303A30305A01"
+                + "C074323032312D30312D30315430303A30303A30305A02",
+                hexBuffer);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/DeterministicLengthModeTests.cs
+++ b/src/Dahomey.Cbor.Tests/DeterministicLengthModeTests.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using Dahomey.Cbor.Attributes;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// The indefinite-length refusal has to hold wherever the length mode comes from, not only where
+    /// it is set on <see cref="CborOptions"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CborLengthModeAttribute"/> on a type or a member outranks
+    /// <see cref="CborOptions.ArrayLengthMode"/> and <see cref="CborOptions.MapLengthMode"/>, and a
+    /// converter may pass a mode explicitly, so a guard on the options alone is bypassable. The check
+    /// belongs at the single point every header passes through.
+    /// </remarks>
+    public class DeterministicLengthModeTests
+    {
+        [CborLengthMode(LengthMode = LengthMode.IndefiniteLength)]
+        public class IndefiniteByAttribute
+        {
+            public int A { get; set; }
+            public int B { get; set; }
+        }
+
+        public class IndefiniteMember
+        {
+            [CborLengthMode(LengthMode = LengthMode.IndefiniteLength)]
+            public List<int> Items { get; set; }
+        }
+
+        private static CborOptions Deterministic() => new CborOptions { Deterministic = true };
+
+        [Fact]
+        public void AttributeOnATypeCannotProduceAnIndefiniteMap()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Helper.Write(new IndefiniteByAttribute { A = 1, B = 2 }, Deterministic()));
+
+            Assert.Contains("indefinite-length map", exception.Message);
+        }
+
+        [Fact]
+        public void AttributeOnAMemberCannotProduceAnIndefiniteArray()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Helper.Write(
+                    new IndefiniteMember { Items = new List<int> { 1, 2 } }, Deterministic()));
+
+            Assert.Contains("indefinite-length array", exception.Message);
+        }
+
+        /// <summary>
+        /// Without the flag the attribute keeps working exactly as before.
+        /// </summary>
+        [Fact]
+        public void TheAttributeStillWorksWithoutDeterministic()
+        {
+            // bf                map(*)
+            //    6141 01        "A" 1
+            //    6142 02        "B" 2
+            //    ff             break
+            Helper.TestWrite(new IndefiniteByAttribute { A = 1, B = 2 }, "BF614101614202FF");
+        }
+
+        /// <summary>
+        /// A definite-length document under the same attribute-free type is unaffected, so the guard
+        /// costs nothing on the ordinary path.
+        /// </summary>
+        [Fact]
+        public void DefiniteLengthsAreUntouched()
+        {
+            Dictionary<string, int> map = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+
+            // a2 6161 01 6162 02
+            Helper.TestWrite(map, "A2616101616202", null, Deterministic());
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Helper.cs
+++ b/src/Dahomey.Cbor.Tests/Helper.cs
@@ -113,7 +113,7 @@ namespace Dahomey.Cbor.Tests
 
             using (ByteBufferWriter bufferWriter = new ByteBufferWriter())
             {
-                CborWriter writer = new CborWriter(bufferWriter, options.MaxDepth);
+                CborWriter writer = new CborWriter(bufferWriter, options.MaxDepth, options.Deterministic);
                 ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
                 converter.Write(ref writer, value);
                 return BitConverter.ToString(bufferWriter.WrittenSpan.ToArray()).Replace("-", "");

--- a/src/Dahomey.Cbor/Cbor.cs
+++ b/src/Dahomey.Cbor/Cbor.cs
@@ -491,7 +491,7 @@ namespace Dahomey.Cbor
             CborOptions? options = null)
         {
             options ??= CborOptions.Default;
-            CborWriter writer = new CborWriter(buffer, options.MaxDepth);
+            CborWriter writer = new CborWriter(buffer, options.MaxDepth, options.Deterministic);
             ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
             converter.Write(ref writer, input);
         }
@@ -504,7 +504,7 @@ namespace Dahomey.Cbor
             CborOptions? options = null)
         {
             options ??= CborOptions.Default;
-            CborWriter writer = new CborWriter(buffer, options.MaxDepth);
+            CborWriter writer = new CborWriter(buffer, options.MaxDepth, options.Deterministic);
             if (input is null)
             {
                 writer.WriteNull();
@@ -523,7 +523,7 @@ namespace Dahomey.Cbor
             CborOptions? options = null)
         {
             options ??= CborOptions.Default;
-            CborWriter writer = new CborWriter(buffer, options.MaxDepth);
+            CborWriter writer = new CborWriter(buffer, options.MaxDepth, options.Deterministic);
             ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
             for (int i = 0; i < input.Length; i++)
             {
@@ -540,7 +540,7 @@ namespace Dahomey.Cbor
             CborOptions? options = null)
         {
             options ??= CborOptions.Default;
-            CborWriter writer = new CborWriter(buffer, options.MaxDepth);
+            CborWriter writer = new CborWriter(buffer, options.MaxDepth, options.Deterministic);
             if (input is null)
             {
                 writer.WriteNull();

--- a/src/Dahomey.Cbor/CborOptions.cs
+++ b/src/Dahomey.Cbor/CborOptions.cs
@@ -51,8 +51,80 @@ namespace Dahomey.Cbor
         public DateTimeKind UnqualifiedTimeZoneDateTimeKind { get; set; }
         public CborDiscriminatorPolicy DiscriminatorPolicy { get; set; }
         public CborObjectFormat ObjectFormat { get; set; } = CborObjectFormat.StringKeyMap;
-        public LengthMode ArrayLengthMode { get; set; } = LengthMode.DefiniteLength;
-        public LengthMode MapLengthMode { get; set; } = LengthMode.DefiniteLength;
+
+        private LengthMode _arrayLengthMode = LengthMode.DefiniteLength;
+        private LengthMode _mapLengthMode = LengthMode.DefiniteLength;
+        private bool _deterministic;
+
+        public LengthMode ArrayLengthMode
+        {
+            get => _arrayLengthMode;
+            set
+            {
+                if (_deterministic)
+                {
+                    RejectIndefinite(value, nameof(ArrayLengthMode));
+                }
+
+                _arrayLengthMode = value;
+            }
+        }
+
+        public LengthMode MapLengthMode
+        {
+            get => _mapLengthMode;
+            set
+            {
+                if (_deterministic)
+                {
+                    RejectIndefinite(value, nameof(MapLengthMode));
+                }
+
+                _mapLengthMode = value;
+            }
+        }
+
+        /// <summary>
+        /// Produce RFC 8949 section 4.2.1 deterministic output: shortest-form arguments, preferred
+        /// float serialization, definite lengths, and map keys sorted bytewise on their encoded form.
+        /// </summary>
+        /// <remarks>
+        /// Deterministic mode refuses any setting that admits more than one encoding of the same
+        /// value, because such a setting would leave the bytes — and therefore any hash over them —
+        /// undetermined.
+        /// </remarks>
+        public bool Deterministic
+        {
+            get => _deterministic;
+            set
+            {
+                // Guard on `value`, not on `_deterministic` — the field has not been assigned yet, so
+                // the shared helper below would read the OLD state and never fire while enabling.
+                if (value)
+                {
+                    RejectIndefinite(_arrayLengthMode, nameof(ArrayLengthMode));
+                    RejectIndefinite(_mapLengthMode, nameof(MapLengthMode));
+                }
+
+                _deterministic = value;
+            }
+        }
+
+        /// <summary>
+        /// Rejects a length mode that admits more than one encoding of the same value. Callers decide
+        /// whether deterministic mode is in force; this method does not consult <c>_deterministic</c>,
+        /// because the property setter calls it while that field is still stale.
+        /// </summary>
+        private static void RejectIndefinite(LengthMode lengthMode, string propertyName)
+        {
+            if (lengthMode == LengthMode.IndefiniteLength)
+            {
+                throw new CborException(
+                    $"{propertyName} cannot be {nameof(LengthMode.IndefiniteLength)} when {nameof(Deterministic)} is enabled: "
+                    + "indefinite lengths admit more than one encoding of the same value.");
+            }
+        }
+
         /// <summary>
         /// Semantic Tag to check if the discriminator is present when ObjectFormat is Array
         /// </summary>

--- a/src/Dahomey.Cbor/Dahomey.Cbor.csproj
+++ b/src/Dahomey.Cbor/Dahomey.Cbor.csproj
@@ -36,4 +36,12 @@
       <PackageReference Include="System.IO.Pipelines" Version="10.0.1" />
   </ItemGroup>
 
+  <!-- CborKeyComparer is internal: its rules are exercised directly by unit tests that the encoded
+       bytes cannot reach, such as a 65536-character key or int.MinValue. A strong-named assembly may
+       only grant friend access to another strong-named assembly, which is why the test project is
+       signed with the same key. -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="Dahomey.Cbor.Tests" Key="0024000004800000940000000602000000240000525341310004000001000100a1d13d213c4ddbe57c8cfdd25d1775a32e40eeca99c937fb91e124f672b891dde0b874d5495efd49fd23fcaef1a66d82482a52b8ba3c000d299679b39d1655b54e3cdd7fb5b7e365ecbe58cea1b94ef9a60d01ae93a0ed2e932d23830f7816c321ff3e987c547ffa0994c5e169ddd8ba09440261746b708a80ba0859b5378ba9" />
+  </ItemGroup>
+
 </Project>

--- a/src/Dahomey.Cbor/Serialization/CborKeyComparer.cs
+++ b/src/Dahomey.Cbor/Serialization/CborKeyComparer.cs
@@ -56,6 +56,16 @@ namespace Dahomey.Cbor.Serialization
         /// Compares two arguments by the encoded form the shortest-form ladder gives them: first by
         /// how many bytes they occupy, then by value.
         /// </summary>
+        /// <remarks>
+        /// The tiering is load-bearing for <see cref="CompareTextKeys"/>: there, tier (header length)
+        /// and tiebreaker (name content) are different data, so a shorter-tier key can and does sort
+        /// before a longer-tier one whose content would otherwise compare smaller. For
+        /// <see cref="CompareIntKeys"/> it is redundant but harmless: <see cref="ArgumentEncodedSize"/>
+        /// partitions <see cref="ulong"/> into contiguous, strictly increasing ranges, so a lower tier
+        /// always holds numerically smaller values, which makes this method identical to plain
+        /// <c>a.CompareTo(b)</c> for every <see cref="ulong"/> pair. It is kept anyway so both call
+        /// sites share one implementation of the rule.
+        /// </remarks>
         private static int CompareArgumentEncoding(ulong a, ulong b)
         {
             int sizeComparison = ArgumentEncodedSize(a).CompareTo(ArgumentEncodedSize(b));

--- a/src/Dahomey.Cbor/Serialization/CborKeyComparer.cs
+++ b/src/Dahomey.Cbor/Serialization/CborKeyComparer.cs
@@ -15,9 +15,69 @@ namespace Dahomey.Cbor.Serialization
         /// <param name="b">Raw UTF-8 member name, without the CBOR text-string header.</param>
         public static int CompareTextKeys(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
         {
-            // The encoded key is header || bytes, and the header encodes the length, so a shorter
-            // encoded key always sorts before a longer one. Comparing encoded headers reduces to
-            // comparing the encoded length of each key.
+            return CompareContentKeys(a, b);
+        }
+
+        /// <summary>
+        /// Compares two CBOR map keys of any supported kind by their encoded form: by major type
+        /// first, then within a major type by the rule for that type. Major type order is the byte
+        /// order of the leading byte, which is what puts unsigned (0) before negative (1) before byte
+        /// string (2) before text string (3).
+        /// </summary>
+        /// <remarks>
+        /// Each side is described by a major type plus the data that varies within it, so one method
+        /// covers both a map whose keys are all one kind and a map that mixes kinds — which a
+        /// <see cref="Dahomey.Cbor.ObjectModel.CborObject"/> read off the wire is free to do.
+        /// </remarks>
+        /// <param name="majorTypeA">Key A's CBOR major type.</param>
+        /// <param name="argumentA">
+        /// Key A's CBOR argument when <paramref name="majorTypeA"/> is an integer type, as defined by
+        /// <see cref="CompareIntegerKeys"/>. Ignored for string types, whose argument is their content
+        /// length.
+        /// </param>
+        /// <param name="contentA">
+        /// Key A's raw payload when <paramref name="majorTypeA"/> is a string type: UTF-8 bytes for
+        /// text, the bytes themselves for a byte string, in both cases without the CBOR header.
+        /// Ignored for integer types.
+        /// </param>
+        /// <param name="majorTypeB">Key B's CBOR major type.</param>
+        /// <param name="argumentB">Key B's CBOR argument, as above.</param>
+        /// <param name="contentB">Key B's raw payload, as above.</param>
+        public static int CompareKeys(
+            CborMajorType majorTypeA, ulong argumentA, ReadOnlySpan<byte> contentA,
+            CborMajorType majorTypeB, ulong argumentB, ReadOnlySpan<byte> contentB)
+        {
+            if (majorTypeA != majorTypeB)
+            {
+                return majorTypeA < majorTypeB ? -1 : 1;
+            }
+
+            switch (majorTypeA)
+            {
+                case CborMajorType.PositiveInteger:
+                case CborMajorType.NegativeInteger:
+                    // Same major type on both sides, so the leading byte's high bits agree and only the
+                    // argument distinguishes them -- exactly what CompareIntegerKeys does once it has
+                    // decided the major types match.
+                    return CompareArgumentEncoding(argumentA, argumentB);
+
+                case CborMajorType.ByteString:
+                case CborMajorType.TextString:
+                    return CompareContentKeys(contentA, contentB);
+
+                default:
+                    throw new CborException(
+                        $"CBOR major type {majorTypeA} is not supported as a deterministic map key.");
+            }
+        }
+
+        /// <summary>
+        /// Orders the two string major types (2 and 3), which share one rule: the encoded key is
+        /// header || content and the header encodes the content length, so a shorter encoded key
+        /// always sorts before a longer one and comparing headers reduces to comparing lengths.
+        /// </summary>
+        private static int CompareContentKeys(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+        {
             int headerComparison = CompareArgumentEncoding((ulong)a.Length, (ulong)b.Length);
 
             if (headerComparison != 0)

--- a/src/Dahomey.Cbor/Serialization/CborKeyComparer.cs
+++ b/src/Dahomey.Cbor/Serialization/CborKeyComparer.cs
@@ -9,66 +9,13 @@ namespace Dahomey.Cbor.Serialization
     /// This is the single definition of deterministic key order. It is not the deprecated
     /// section 4.2.3 length-first variant, which is not implemented.
     /// </remarks>
-    public static class CborKeyComparer
+    internal static class CborKeyComparer
     {
         /// <param name="a">Raw UTF-8 member name, without the CBOR text-string header.</param>
         /// <param name="b">Raw UTF-8 member name, without the CBOR text-string header.</param>
         public static int CompareTextKeys(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
         {
             return CompareContentKeys(a, b);
-        }
-
-        /// <summary>
-        /// Compares two CBOR map keys of any supported kind by their encoded form: by major type
-        /// first, then within a major type by the rule for that type. Major type order is the byte
-        /// order of the leading byte, which is what puts unsigned (0) before negative (1) before byte
-        /// string (2) before text string (3).
-        /// </summary>
-        /// <remarks>
-        /// Each side is described by a major type plus the data that varies within it, so one method
-        /// covers both a map whose keys are all one kind and a map that mixes kinds — which a
-        /// <see cref="Dahomey.Cbor.ObjectModel.CborObject"/> read off the wire is free to do.
-        /// </remarks>
-        /// <param name="majorTypeA">Key A's CBOR major type.</param>
-        /// <param name="argumentA">
-        /// Key A's CBOR argument when <paramref name="majorTypeA"/> is an integer type, as defined by
-        /// <see cref="CompareIntegerKeys"/>. Ignored for string types, whose argument is their content
-        /// length.
-        /// </param>
-        /// <param name="contentA">
-        /// Key A's raw payload when <paramref name="majorTypeA"/> is a string type: UTF-8 bytes for
-        /// text, the bytes themselves for a byte string, in both cases without the CBOR header.
-        /// Ignored for integer types.
-        /// </param>
-        /// <param name="majorTypeB">Key B's CBOR major type.</param>
-        /// <param name="argumentB">Key B's CBOR argument, as above.</param>
-        /// <param name="contentB">Key B's raw payload, as above.</param>
-        public static int CompareKeys(
-            CborMajorType majorTypeA, ulong argumentA, ReadOnlySpan<byte> contentA,
-            CborMajorType majorTypeB, ulong argumentB, ReadOnlySpan<byte> contentB)
-        {
-            if (majorTypeA != majorTypeB)
-            {
-                return majorTypeA < majorTypeB ? -1 : 1;
-            }
-
-            switch (majorTypeA)
-            {
-                case CborMajorType.PositiveInteger:
-                case CborMajorType.NegativeInteger:
-                    // Same major type on both sides, so the leading byte's high bits agree and only the
-                    // argument distinguishes them -- exactly what CompareIntegerKeys does once it has
-                    // decided the major types match.
-                    return CompareArgumentEncoding(argumentA, argumentB);
-
-                case CborMajorType.ByteString:
-                case CborMajorType.TextString:
-                    return CompareContentKeys(contentA, contentB);
-
-                default:
-                    throw new CborException(
-                        $"CBOR major type {majorTypeA} is not supported as a deterministic map key.");
-            }
         }
 
         /// <summary>
@@ -88,35 +35,16 @@ namespace Dahomey.Cbor.Serialization
             return a.SequenceCompareTo(b);
         }
 
-        public static int CompareIntKeys(int a, int b)
-        {
-            // A thin wrapper over CompareIntegerKeys, converting each int to the (major-type,
-            // argument) representation CBOR itself uses. Kept as the int-typed public entry point so
-            // existing callers (ObjectConverter's member sort) are untouched; see CompareIntegerKeys
-            // for a key space CBOR allows but int cannot represent (down to -2^64).
-            bool negativeA = a < 0;
-            bool negativeB = b < 0;
-            ulong argumentA = negativeA ? (ulong)(-1L - a) : (ulong)a;
-            ulong argumentB = negativeB ? (ulong)(-1L - b) : (ulong)b;
-            return CompareIntegerKeys(negativeA, argumentA, negativeB, argumentB);
-        }
-
         /// <summary>
         /// Compares two CBOR integer keys by their wire representation: a major type (0 for
-        /// non-negative, 1 for negative) plus a <see cref="ulong"/> argument. For major type 0 the
-        /// argument is the value itself; for major type 1 the argument is <c>-1 - value</c>, per RFC
-        /// 8949 -- which is why this takes an argument rather than a signed value: major type 1's
-        /// argument reaches <see cref="ulong.MaxValue"/>, representing values down to -2^64, a range no
-        /// signed 64-bit CLR integer (<see cref="long"/> bottoms out at -2^63) can hold. Any caller that
-        /// already has a CLR integer narrower than that full range -- <see cref="CompareIntKeys"/>
-        /// included -- converts to this shape first.
+        /// non-negative, 1 for negative) plus an argument, which for major type 0 is the value itself
+        /// and for major type 1 is <c>-1 - value</c>, per RFC 8949.
         /// </summary>
-        /// <param name="negativeA">Whether key A is CBOR major type 1 (a negative value).</param>
-        /// <param name="argumentA">Key A's CBOR argument, as defined above.</param>
-        /// <param name="negativeB">Whether key B is CBOR major type 1 (a negative value).</param>
-        /// <param name="argumentB">Key B's CBOR argument, as defined above.</param>
-        public static int CompareIntegerKeys(bool negativeA, ulong argumentA, bool negativeB, ulong argumentB)
+        public static int CompareIntKeys(int a, int b)
         {
+            bool negativeA = a < 0;
+            bool negativeB = b < 0;
+
             // Major type 1's leading byte range (0x20-0x3B) is entirely above major type 0's
             // (0x00-0x1B), so every negative key sorts after every non-negative one regardless of
             // argument.
@@ -125,7 +53,9 @@ namespace Dahomey.Cbor.Serialization
                 return negativeA ? 1 : -1;
             }
 
-            return CompareArgumentEncoding(argumentA, argumentB);
+            return CompareArgumentEncoding(
+                negativeA ? (ulong)(-1L - a) : (ulong)a,
+                negativeB ? (ulong)(-1L - b) : (ulong)b);
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor/Serialization/CborKeyComparer.cs
+++ b/src/Dahomey.Cbor/Serialization/CborKeyComparer.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace Dahomey.Cbor.Serialization
+{
+    /// <summary>
+    /// RFC 8949 section 4.2.1 map key ordering: bytewise lexicographic on the encoded key.
+    /// </summary>
+    /// <remarks>
+    /// This is the single definition of deterministic key order. It is not the deprecated
+    /// section 4.2.3 length-first variant, which is not implemented.
+    /// </remarks>
+    public static class CborKeyComparer
+    {
+        /// <param name="a">Raw UTF-8 member name, without the CBOR text-string header.</param>
+        /// <param name="b">Raw UTF-8 member name, without the CBOR text-string header.</param>
+        public static int CompareTextKeys(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+        {
+            // The encoded key is header || bytes, and the header encodes the length, so a shorter
+            // encoded key always sorts before a longer one. Comparing encoded headers reduces to
+            // comparing the encoded length of each key.
+            int headerComparison = CompareArgumentEncoding((ulong)a.Length, (ulong)b.Length);
+
+            if (headerComparison != 0)
+            {
+                return headerComparison;
+            }
+
+            return a.SequenceCompareTo(b);
+        }
+
+        public static int CompareIntKeys(int a, int b)
+        {
+            // Non-negative keys are major type 0 and encode monotonically, so numeric order is
+            // bytewise order. Negative keys are major type 1, whose leading byte is always greater
+            // than any major type 0 leading byte, so every negative key sorts after every
+            // non-negative one. Within the negatives, -1 encodes as 0x20 and -2 as 0x21, so
+            // descending magnitude is ascending bytewise.
+            if (a >= 0 && b >= 0)
+            {
+                return a.CompareTo(b);
+            }
+
+            if (a < 0 && b < 0)
+            {
+                ulong argumentA = (ulong)(-1L - a);
+                ulong argumentB = (ulong)(-1L - b);
+                return CompareArgumentEncoding(argumentA, argumentB) is int c and not 0
+                    ? c
+                    : argumentA.CompareTo(argumentB);
+            }
+
+            return a >= 0 ? -1 : 1;
+        }
+
+        /// <summary>
+        /// Compares two arguments by the encoded form the shortest-form ladder gives them: first by
+        /// how many bytes they occupy, then by value.
+        /// </summary>
+        private static int CompareArgumentEncoding(ulong a, ulong b)
+        {
+            int sizeComparison = ArgumentEncodedSize(a).CompareTo(ArgumentEncodedSize(b));
+            return sizeComparison != 0 ? sizeComparison : a.CompareTo(b);
+        }
+
+        private static int ArgumentEncodedSize(ulong value)
+        {
+            if (value < 24) return 1;
+            if (value <= byte.MaxValue) return 2;
+            if (value <= ushort.MaxValue) return 3;
+            if (value <= uint.MaxValue) return 5;
+            return 9;
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/CborKeyComparer.cs
+++ b/src/Dahomey.Cbor/Serialization/CborKeyComparer.cs
@@ -30,26 +30,42 @@ namespace Dahomey.Cbor.Serialization
 
         public static int CompareIntKeys(int a, int b)
         {
-            // Non-negative keys are major type 0 and encode monotonically, so numeric order is
-            // bytewise order. Negative keys are major type 1, whose leading byte is always greater
-            // than any major type 0 leading byte, so every negative key sorts after every
-            // non-negative one. Within the negatives, -1 encodes as 0x20 and -2 as 0x21, so
-            // descending magnitude is ascending bytewise.
-            if (a >= 0 && b >= 0)
+            // A thin wrapper over CompareIntegerKeys, converting each int to the (major-type,
+            // argument) representation CBOR itself uses. Kept as the int-typed public entry point so
+            // existing callers (ObjectConverter's member sort) are untouched; see CompareIntegerKeys
+            // for a key space CBOR allows but int cannot represent (down to -2^64).
+            bool negativeA = a < 0;
+            bool negativeB = b < 0;
+            ulong argumentA = negativeA ? (ulong)(-1L - a) : (ulong)a;
+            ulong argumentB = negativeB ? (ulong)(-1L - b) : (ulong)b;
+            return CompareIntegerKeys(negativeA, argumentA, negativeB, argumentB);
+        }
+
+        /// <summary>
+        /// Compares two CBOR integer keys by their wire representation: a major type (0 for
+        /// non-negative, 1 for negative) plus a <see cref="ulong"/> argument. For major type 0 the
+        /// argument is the value itself; for major type 1 the argument is <c>-1 - value</c>, per RFC
+        /// 8949 -- which is why this takes an argument rather than a signed value: major type 1's
+        /// argument reaches <see cref="ulong.MaxValue"/>, representing values down to -2^64, a range no
+        /// signed 64-bit CLR integer (<see cref="long"/> bottoms out at -2^63) can hold. Any caller that
+        /// already has a CLR integer narrower than that full range -- <see cref="CompareIntKeys"/>
+        /// included -- converts to this shape first.
+        /// </summary>
+        /// <param name="negativeA">Whether key A is CBOR major type 1 (a negative value).</param>
+        /// <param name="argumentA">Key A's CBOR argument, as defined above.</param>
+        /// <param name="negativeB">Whether key B is CBOR major type 1 (a negative value).</param>
+        /// <param name="argumentB">Key B's CBOR argument, as defined above.</param>
+        public static int CompareIntegerKeys(bool negativeA, ulong argumentA, bool negativeB, ulong argumentB)
+        {
+            // Major type 1's leading byte range (0x20-0x3B) is entirely above major type 0's
+            // (0x00-0x1B), so every negative key sorts after every non-negative one regardless of
+            // argument.
+            if (negativeA != negativeB)
             {
-                return a.CompareTo(b);
+                return negativeA ? 1 : -1;
             }
 
-            if (a < 0 && b < 0)
-            {
-                ulong argumentA = (ulong)(-1L - a);
-                ulong argumentB = (ulong)(-1L - b);
-                return CompareArgumentEncoding(argumentA, argumentB) is int c and not 0
-                    ? c
-                    : argumentA.CompareTo(argumentB);
-            }
-
-            return a >= 0 ? -1 : 1;
+            return CompareArgumentEncoding(argumentA, argumentB);
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor/Serialization/CborWriter.cs
+++ b/src/Dahomey.Cbor/Serialization/CborWriter.cs
@@ -40,6 +40,8 @@ namespace Dahomey.Cbor.Serialization
         /// <summary>Maximum permitted nesting depth of maps and arrays.</summary>
         public int MaxDepth => _maxDepth;
 
+        private readonly bool _deterministic;
+
         public CborWriter(IBufferWriter<byte> bufferWriter)
             : this(bufferWriter, DefaultMaxDepth)
         {
@@ -51,6 +53,18 @@ namespace Dahomey.Cbor.Serialization
         /// containing a reference cycle would otherwise do. Must be positive.
         /// </param>
         public CborWriter(IBufferWriter<byte> bufferWriter, int maxDepth)
+            : this(bufferWriter, maxDepth, deterministic: false)
+        {
+        }
+
+        /// <param name="deterministic">
+        /// Refuse indefinite lengths, which admit more than one encoding of the same value. Checked
+        /// here rather than only on <see cref="CborOptions"/> because the options are the
+        /// lowest-priority source of the length mode: <see cref="Attributes.CborLengthModeAttribute"/>
+        /// on a type or member outranks them, and a converter may pass a mode explicitly. This is the
+        /// one point every definite or indefinite header passes through.
+        /// </param>
+        public CborWriter(IBufferWriter<byte> bufferWriter, int maxDepth, bool deterministic)
         {
             if (maxDepth <= 0)
             {
@@ -60,6 +74,7 @@ namespace Dahomey.Cbor.Serialization
             _bufferWriter = bufferWriter;
             _maxDepth = maxDepth;
             _depth = 0;
+            _deterministic = deterministic;
         }
 
         public void WriteSemanticTag(ulong semanticTag)
@@ -297,6 +312,7 @@ namespace Dahomey.Cbor.Serialization
 
         public void WriteBeginMap(int size)
         {
+            RejectIndefiniteWhenDeterministic(size, "map");
             WriteSize(CborMajorType.Map, size);
         }
 
@@ -321,7 +337,20 @@ namespace Dahomey.Cbor.Serialization
 
         public void WriteBeginArray(int size)
         {
+            RejectIndefiniteWhenDeterministic(size, "array");
             WriteSize(CborMajorType.Array, size);
+        }
+
+        private readonly void RejectIndefiniteWhenDeterministic(int size, string kind)
+        {
+            if (_deterministic && size < 0)
+            {
+                throw new CborException(
+                    $"An indefinite-length {kind} cannot be written while Deterministic is enabled: "
+                    + "indefinite lengths admit more than one encoding of the same value. This can come "
+                    + "from CborOptions.ArrayLengthMode or MapLengthMode, or from a CborLengthMode "
+                    + "attribute on a type or member, which takes priority over both.");
+            }
         }
 
         public void WriteEndArray(int size)

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Dahomey.Cbor.Serialization.Converters
 {
@@ -24,6 +23,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         }
 
         private readonly CborOptions _options;
+        private Func<TK, DeterministicKeyOrder.SortKey>? _decorateKey;
 
         protected abstract IDictionary<TK, TV> InstantiateTempCollection();
         protected abstract TC InstantiateCollection(IDictionary<TK, TV> tempCollection);
@@ -60,7 +60,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 count = value.Count,
                 enumerator = _options.Deterministic
-                    ? SortedEntries(value).GetEnumerator()
+                    ? SortedEntries(value)
                     : value.GetEnumerator(),
                 lengthMode = lengthMode != LengthMode.Default
                     ? lengthMode : _options.MapLengthMode
@@ -69,65 +69,19 @@ namespace Dahomey.Cbor.Serialization.Converters
             writer.WriteMap(this, ref context);
         }
 
-        // The key set is only known at write time (unlike fixed object members, which are sorted once
-        // at mapping build time in ObjectConverter), so this materialises and sorts on every write.
-        // GetMapSize/WriteMapItem are untouched: they only ever pump context.enumerator, so handing
-        // them a sorted list's enumerator instead of the dictionary's is enough.
-        private static List<KeyValuePair<TK, TV>> SortedEntries(IDictionary<TK, TV> dictionary)
+        // The key set is only known at write time (unlike fixed object members, which ObjectConverter
+        // sorts once per type), so this materialises and sorts on every write. GetMapSize/WriteMapItem
+        // are untouched: they only ever pump context.enumerator, so handing them the sorted sequence's
+        // enumerator instead of the dictionary's is enough.
+        private IEnumerator<KeyValuePair<TK, TV>> SortedEntries(IDictionary<TK, TV> dictionary)
         {
-            List<KeyValuePair<TK, TV>> entries = new List<KeyValuePair<TK, TV>>(dictionary);
+            // Held in a field rather than written inline: the lambda closes over _options, so writing it
+            // at the call site would allocate a closure on every write.
+            _decorateKey ??= key => DeterministicKeyOrder.ForDictionaryKey(key, _options);
 
-            try
-            {
-                entries.Sort(CompareEntriesForDeterministicOrder);
-            }
-            catch (InvalidOperationException ex) when (ex.InnerException is CborException cborException)
-            {
-                // List<T>.Sort wraps any exception thrown by the comparison delegate in an
-                // InvalidOperationException (mirrors Activator.CreateInstance wrapping construction
-                // failures in TargetInvocationException). Unwrap so callers see the CborException
-                // thrown by CompareEntriesForDeterministicOrder for unsupported key types, not an
-                // opaque "failed to compare two elements" message.
-                throw cborException;
-            }
+            KeyValuePair<TK, TV>[] sorted = DeterministicKeyOrder.Sort(dictionary, _decorateKey);
 
-            return entries;
-        }
-
-        private static int CompareEntriesForDeterministicOrder(KeyValuePair<TK, TV> x, KeyValuePair<TK, TV> y)
-        {
-            if (x.Key is string stringX && y.Key is string stringY)
-            {
-                return CborKeyComparer.CompareTextKeys(
-                    Encoding.UTF8.GetBytes(stringX),
-                    Encoding.UTF8.GetBytes(stringY));
-            }
-
-            if (x.Key is int intX && y.Key is int intY)
-            {
-                return CborKeyComparer.CompareIntKeys(intX, intY);
-            }
-
-            // long/ulong fall out of the same widened comparer used for CborObject keys
-            // (CborValueConverter.TryGetIntegerKeyArgument): int alone cannot address CBOR's full
-            // integer key range (a negative argument reaches -2^64), so once CompareIntegerKeys existed
-            // to handle that, extending it to these two CLR types cost nothing extra here.
-            if (x.Key is long longX && y.Key is long longY)
-            {
-                bool negativeX = longX < 0;
-                bool negativeY = longY < 0;
-                ulong argumentX = negativeX ? (ulong)(-1L - longX) : (ulong)longX;
-                ulong argumentY = negativeY ? (ulong)(-1L - longY) : (ulong)longY;
-                return CborKeyComparer.CompareIntegerKeys(negativeX, argumentX, negativeY, argumentY);
-            }
-
-            if (x.Key is ulong ulongX && y.Key is ulong ulongY)
-            {
-                return CborKeyComparer.CompareIntegerKeys(false, ulongX, false, ulongY);
-            }
-
-            throw new CborException(
-                $"Deterministic encoding supports only string and int/long/ulong dictionary keys; found {typeof(TK)}.");
+            return ((IEnumerable<KeyValuePair<TK, TV>>)sorted).GetEnumerator();
         }
 
         public void ReadBeginMap(int size, ref ReaderContext context)

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace Dahomey.Cbor.Serialization.Converters
 {
@@ -57,12 +59,57 @@ namespace Dahomey.Cbor.Serialization.Converters
             WriterContext context = new WriterContext
             {
                 count = value.Count,
-                enumerator = value.GetEnumerator(),
+                enumerator = _options.Deterministic
+                    ? SortedEntries(value).GetEnumerator()
+                    : value.GetEnumerator(),
                 lengthMode = lengthMode != LengthMode.Default
                     ? lengthMode : _options.MapLengthMode
             };
 
             writer.WriteMap(this, ref context);
+        }
+
+        // The key set is only known at write time (unlike fixed object members, which are sorted once
+        // at mapping build time in ObjectConverter), so this materialises and sorts on every write.
+        // GetMapSize/WriteMapItem are untouched: they only ever pump context.enumerator, so handing
+        // them a sorted list's enumerator instead of the dictionary's is enough.
+        private static List<KeyValuePair<TK, TV>> SortedEntries(IDictionary<TK, TV> dictionary)
+        {
+            List<KeyValuePair<TK, TV>> entries = new List<KeyValuePair<TK, TV>>(dictionary);
+
+            try
+            {
+                entries.Sort(CompareEntriesForDeterministicOrder);
+            }
+            catch (InvalidOperationException ex) when (ex.InnerException is CborException cborException)
+            {
+                // List<T>.Sort wraps any exception thrown by the comparison delegate in an
+                // InvalidOperationException (mirrors Activator.CreateInstance wrapping construction
+                // failures in TargetInvocationException). Unwrap so callers see the CborException
+                // thrown by CompareEntriesForDeterministicOrder for unsupported key types, not an
+                // opaque "failed to compare two elements" message.
+                throw cborException;
+            }
+
+            return entries;
+        }
+
+        private static int CompareEntriesForDeterministicOrder(KeyValuePair<TK, TV> x, KeyValuePair<TK, TV> y)
+        {
+            if (x.Key is string stringX && y.Key is string stringY)
+            {
+                return CborKeyComparer.CompareTextKeys(
+                    Encoding.UTF8.GetBytes(stringX),
+                    Encoding.UTF8.GetBytes(stringY));
+            }
+
+            if (x.Key is int intX && y.Key is int intY)
+            {
+                return CborKeyComparer.CompareIntKeys(intX, intY);
+            }
+
+            throw new CborException(
+                $"Deterministic encoding supports only string and int dictionary keys; found {typeof(TK)}.");
         }
 
         public void ReadBeginMap(int size, ref ReaderContext context)

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -108,8 +108,26 @@ namespace Dahomey.Cbor.Serialization.Converters
                 return CborKeyComparer.CompareIntKeys(intX, intY);
             }
 
+            // long/ulong fall out of the same widened comparer used for CborObject keys
+            // (CborValueConverter.TryGetIntegerKeyArgument): int alone cannot address CBOR's full
+            // integer key range (a negative argument reaches -2^64), so once CompareIntegerKeys existed
+            // to handle that, extending it to these two CLR types cost nothing extra here.
+            if (x.Key is long longX && y.Key is long longY)
+            {
+                bool negativeX = longX < 0;
+                bool negativeY = longY < 0;
+                ulong argumentX = negativeX ? (ulong)(-1L - longX) : (ulong)longX;
+                ulong argumentY = negativeY ? (ulong)(-1L - longY) : (ulong)longY;
+                return CborKeyComparer.CompareIntegerKeys(negativeX, argumentX, negativeY, argumentY);
+            }
+
+            if (x.Key is ulong ulongX && y.Key is ulong ulongY)
+            {
+                return CborKeyComparer.CompareIntegerKeys(false, ulongX, false, ulongY);
+            }
+
             throw new CborException(
-                $"Deterministic encoding supports only string and int dictionary keys; found {typeof(TK)}.");
+                $"Deterministic encoding supports only string and int/long/ulong dictionary keys; found {typeof(TK)}.");
         }
 
         public void ReadBeginMap(int size, ref ReaderContext context)

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -23,7 +23,6 @@ namespace Dahomey.Cbor.Serialization.Converters
         }
 
         private readonly CborOptions _options;
-        private Func<TK, DeterministicKeyOrder.SortKey>? _decorateKey;
 
         protected abstract IDictionary<TK, TV> InstantiateTempCollection();
         protected abstract TC InstantiateCollection(IDictionary<TK, TV> tempCollection);
@@ -75,11 +74,11 @@ namespace Dahomey.Cbor.Serialization.Converters
         // enumerator instead of the dictionary's is enough.
         private IEnumerator<KeyValuePair<TK, TV>> SortedEntries(IDictionary<TK, TV> dictionary)
         {
-            // Held in a field rather than written inline: the lambda closes over _options, so writing it
-            // at the call site would allocate a closure on every write.
-            _decorateKey ??= key => DeterministicKeyOrder.ForDictionaryKey(key, _options);
-
-            KeyValuePair<TK, TV>[] sorted = DeterministicKeyOrder.Sort(dictionary, _decorateKey);
+            // KeyConverter is the same converter WriteMapItem uses, so the order is the order of the
+            // bytes that actually get written -- including any converter the caller registered for the
+            // key type themselves.
+            KeyValuePair<TK, TV>[] sorted =
+                DeterministicKeyOrder.Sort(dictionary, KeyConverter, _options.MaxDepth);
 
             return ((IEnumerable<KeyValuePair<TK, TV>>)sorted).GetEnumerator();
         }

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -1,6 +1,7 @@
 ﻿using Dahomey.Cbor.ObjectModel;
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Dahomey.Cbor.Serialization.Converters
 {
@@ -247,11 +248,69 @@ namespace Dahomey.Cbor.Serialization.Converters
             MapWriterContext mapWriterContext = new MapWriterContext
             {
                 obj = value,
-                enumerator = value.GetEnumerator(),
+                enumerator = _options.Deterministic
+                    ? SortedEntries(value).GetEnumerator()
+                    : value.GetEnumerator(),
                 lengthMode = lengthMode != LengthMode.Default
                     ? lengthMode : _options.MapLengthMode
             };
             writer.WriteMap(this, ref mapWriterContext);
+        }
+
+        // Same shape as AbstractDictionaryConverter.SortedEntries: the key set is only known at write
+        // time, so this materialises and sorts on every write. GetMapSize only reads context.obj.Count,
+        // which sorting cannot change, so it needs no edit -- only which sequence the enumerator walks
+        // differs.
+        private static List<KeyValuePair<CborValue, CborValue>> SortedEntries(CborObject obj)
+        {
+            List<KeyValuePair<CborValue, CborValue>> entries = new List<KeyValuePair<CborValue, CborValue>>(obj);
+
+            try
+            {
+                entries.Sort(CompareEntriesForDeterministicOrder);
+            }
+            catch (InvalidOperationException ex) when (ex.InnerException is CborException cborException)
+            {
+                // List<T>.Sort wraps any exception thrown by the comparison delegate in an
+                // InvalidOperationException; unwrap so callers see the CborException itself, matching
+                // AbstractDictionaryConverter.SortedEntries.
+                throw cborException;
+            }
+
+            return entries;
+        }
+
+        private static int CompareEntriesForDeterministicOrder(
+            KeyValuePair<CborValue, CborValue> x, KeyValuePair<CborValue, CborValue> y)
+        {
+            // CborValue exposes its underlying wire type via Type rather than via a distinct CLR type
+            // per key kind the way Dictionary<TK, TV> did, so dispatch on that discriminator instead of
+            // a CLR `is` pattern.
+            CborValue keyX = x.Key;
+            CborValue keyY = y.Key;
+
+            if (keyX.Type == CborValueType.String && keyY.Type == CborValueType.String)
+            {
+                return CborKeyComparer.CompareTextKeys(
+                    Encoding.UTF8.GetBytes(keyX.Value<string>()),
+                    Encoding.UTF8.GetBytes(keyY.Value<string>()));
+            }
+
+            if (IsIntegerKey(keyX.Type) && IsIntegerKey(keyY.Type))
+            {
+                return CborKeyComparer.CompareIntKeys(keyX.Value<int>(), keyY.Value<int>());
+            }
+
+            throw new CborException(
+                $"Deterministic encoding supports only string and int CborObject keys; found {keyX.Type} key.");
+        }
+
+        // CborPositive (major type 0) and CborNegative (major type 1) are both integer-keyed; CBOR
+        // itself does not distinguish "positive int" and "negative int" as separate key kinds the way
+        // CborValueType does.
+        private static bool IsIntegerKey(CborValueType type)
+        {
+            return type == CborValueType.Positive || type == CborValueType.Negative;
         }
 
         CborArray? ICborConverter<CborArray?>.Read(ref CborReader reader)

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -261,10 +261,10 @@ namespace Dahomey.Cbor.Serialization.Converters
         // which sorting cannot change, so it needs no edit -- only which sequence the enumerator walks
         // differs. A CborObject may mix key kinds, which is why the order comes from
         // DeterministicKeyOrder (major type first) rather than from a same-kind-only comparison.
-        private static IEnumerator<KeyValuePair<CborValue, CborValue>> SortedEntries(CborObject obj)
+        private IEnumerator<KeyValuePair<CborValue, CborValue>> SortedEntries(CborObject obj)
         {
             KeyValuePair<CborValue, CborValue>[] sorted =
-                DeterministicKeyOrder.Sort(obj, DeterministicKeyOrder.ForCborValueKey);
+                DeterministicKeyOrder.Sort(obj, this, _options.MaxDepth);
 
             return ((IEnumerable<KeyValuePair<CborValue, CborValue>>)sorted).GetEnumerator();
         }

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -296,21 +296,45 @@ namespace Dahomey.Cbor.Serialization.Converters
                     Encoding.UTF8.GetBytes(keyY.Value<string>()));
             }
 
-            if (IsIntegerKey(keyX.Type) && IsIntegerKey(keyY.Type))
+            if (TryGetIntegerKeyArgument(keyX, out bool negativeX, out ulong argumentX) &&
+                TryGetIntegerKeyArgument(keyY, out bool negativeY, out ulong argumentY))
             {
-                return CborKeyComparer.CompareIntKeys(keyX.Value<int>(), keyY.Value<int>());
+                return CborKeyComparer.CompareIntegerKeys(negativeX, argumentX, negativeY, argumentY);
             }
 
             throw new CborException(
                 $"Deterministic encoding supports only string and int CborObject keys; found {keyX.Type} key.");
         }
 
-        // CborPositive (major type 0) and CborNegative (major type 1) are both integer-keyed; CBOR
-        // itself does not distinguish "positive int" and "negative int" as separate key kinds the way
-        // CborValueType does.
-        private static bool IsIntegerKey(CborValueType type)
+        // Reads a CborPositive/CborNegative key at full width -- via Value<ulong>()/Value<long>(),
+        // never Value<int>() -- into the (major-type, argument) shape CborKeyComparer.CompareIntegerKeys
+        // takes. CborPositive stores a ulong directly (Value<ulong>() is an identity conversion, so
+        // "argument" is just the value). CborNegative stores a long (also an identity conversion via
+        // Value<long>()); its CBOR argument is -1-value, which needs the full ulong range because CBOR's
+        // negative major type reaches an argument of ulong.MaxValue (a logical value of -2^64) even
+        // though no CborNegative instance can actually hold anything below long.MinValue -- see
+        // CborNegative's constructor, which takes a `long`. Narrowing through Value<int>() would silently
+        // wrap any key outside int range instead of comparing it correctly; this is precisely the bug
+        // this method exists to avoid.
+        private static bool TryGetIntegerKeyArgument(CborValue key, out bool negative, out ulong argument)
         {
-            return type == CborValueType.Positive || type == CborValueType.Negative;
+            switch (key.Type)
+            {
+                case CborValueType.Positive:
+                    negative = false;
+                    argument = key.Value<ulong>();
+                    return true;
+
+                case CborValueType.Negative:
+                    negative = true;
+                    argument = (ulong)(-1L - key.Value<long>());
+                    return true;
+
+                default:
+                    negative = false;
+                    argument = 0;
+                    return false;
+            }
         }
 
         CborArray? ICborConverter<CborArray?>.Read(ref CborReader reader)

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -1,7 +1,6 @@
 ﻿using Dahomey.Cbor.ObjectModel;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Dahomey.Cbor.Serialization.Converters
 {
@@ -249,7 +248,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 obj = value,
                 enumerator = _options.Deterministic
-                    ? SortedEntries(value).GetEnumerator()
+                    ? SortedEntries(value)
                     : value.GetEnumerator(),
                 lengthMode = lengthMode != LengthMode.Default
                     ? lengthMode : _options.MapLengthMode
@@ -260,81 +259,14 @@ namespace Dahomey.Cbor.Serialization.Converters
         // Same shape as AbstractDictionaryConverter.SortedEntries: the key set is only known at write
         // time, so this materialises and sorts on every write. GetMapSize only reads context.obj.Count,
         // which sorting cannot change, so it needs no edit -- only which sequence the enumerator walks
-        // differs.
-        private static List<KeyValuePair<CborValue, CborValue>> SortedEntries(CborObject obj)
+        // differs. A CborObject may mix key kinds, which is why the order comes from
+        // DeterministicKeyOrder (major type first) rather than from a same-kind-only comparison.
+        private static IEnumerator<KeyValuePair<CborValue, CborValue>> SortedEntries(CborObject obj)
         {
-            List<KeyValuePair<CborValue, CborValue>> entries = new List<KeyValuePair<CborValue, CborValue>>(obj);
+            KeyValuePair<CborValue, CborValue>[] sorted =
+                DeterministicKeyOrder.Sort(obj, DeterministicKeyOrder.ForCborValueKey);
 
-            try
-            {
-                entries.Sort(CompareEntriesForDeterministicOrder);
-            }
-            catch (InvalidOperationException ex) when (ex.InnerException is CborException cborException)
-            {
-                // List<T>.Sort wraps any exception thrown by the comparison delegate in an
-                // InvalidOperationException; unwrap so callers see the CborException itself, matching
-                // AbstractDictionaryConverter.SortedEntries.
-                throw cborException;
-            }
-
-            return entries;
-        }
-
-        private static int CompareEntriesForDeterministicOrder(
-            KeyValuePair<CborValue, CborValue> x, KeyValuePair<CborValue, CborValue> y)
-        {
-            // CborValue exposes its underlying wire type via Type rather than via a distinct CLR type
-            // per key kind the way Dictionary<TK, TV> did, so dispatch on that discriminator instead of
-            // a CLR `is` pattern.
-            CborValue keyX = x.Key;
-            CborValue keyY = y.Key;
-
-            if (keyX.Type == CborValueType.String && keyY.Type == CborValueType.String)
-            {
-                return CborKeyComparer.CompareTextKeys(
-                    Encoding.UTF8.GetBytes(keyX.Value<string>()),
-                    Encoding.UTF8.GetBytes(keyY.Value<string>()));
-            }
-
-            if (TryGetIntegerKeyArgument(keyX, out bool negativeX, out ulong argumentX) &&
-                TryGetIntegerKeyArgument(keyY, out bool negativeY, out ulong argumentY))
-            {
-                return CborKeyComparer.CompareIntegerKeys(negativeX, argumentX, negativeY, argumentY);
-            }
-
-            throw new CborException(
-                $"Deterministic encoding supports only string and int CborObject keys; found {keyX.Type} key.");
-        }
-
-        // Reads a CborPositive/CborNegative key at full width -- via Value<ulong>()/Value<long>(),
-        // never Value<int>() -- into the (major-type, argument) shape CborKeyComparer.CompareIntegerKeys
-        // takes. CborPositive stores a ulong directly (Value<ulong>() is an identity conversion, so
-        // "argument" is just the value). CborNegative stores a long (also an identity conversion via
-        // Value<long>()); its CBOR argument is -1-value, which needs the full ulong range because CBOR's
-        // negative major type reaches an argument of ulong.MaxValue (a logical value of -2^64) even
-        // though no CborNegative instance can actually hold anything below long.MinValue -- see
-        // CborNegative's constructor, which takes a `long`. Narrowing through Value<int>() would silently
-        // wrap any key outside int range instead of comparing it correctly; this is precisely the bug
-        // this method exists to avoid.
-        private static bool TryGetIntegerKeyArgument(CborValue key, out bool negative, out ulong argument)
-        {
-            switch (key.Type)
-            {
-                case CborValueType.Positive:
-                    negative = false;
-                    argument = key.Value<ulong>();
-                    return true;
-
-                case CborValueType.Negative:
-                    negative = true;
-                    argument = (ulong)(-1L - key.Value<long>());
-                    return true;
-
-                default:
-                    negative = false;
-                    argument = 0;
-                    return false;
-            }
+            return ((IEnumerable<KeyValuePair<CborValue, CborValue>>)sorted).GetEnumerator();
         }
 
         CborArray? ICborConverter<CborArray?>.Read(ref CborReader reader)

--- a/src/Dahomey.Cbor/Serialization/Converters/DeterministicKeyOrder.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/DeterministicKeyOrder.cs
@@ -1,0 +1,267 @@
+using Dahomey.Cbor.ObjectModel;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// Puts the entries of a map in RFC 8949 section 4.2.1 key order, for the two converters whose key
+    /// set is only known at write time: <see cref="AbstractDictionaryConverter{TC, TK, TV}"/> and the
+    /// <see cref="CborObject"/> half of <see cref="CborValueConverter"/>. Fixed object members are not
+    /// routed through here; <see cref="ObjectConverter{T}"/> sorts its own member list, which is known
+    /// once per type rather than once per write.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Decorate-sort-undecorate: every key is reduced to a <see cref="SortKey"/> once, up front, and the
+    /// sort then compares those. Doing the reduction inside the comparison instead would re-encode both
+    /// sides of every comparison, which is O(n log n) encodings for a result that only ever needs n.
+    /// </para>
+    /// <para>
+    /// A key kind that has no deterministic order is rejected during decoration, before the sort starts.
+    /// That is also why neither caller unwraps an exception: <see cref="List{T}.Sort(Comparison{T})"/>
+    /// and <see cref="Array.Sort{TKey, TValue}(TKey[], TValue[], IComparer{TKey})"/> wrap anything the
+    /// comparison throws in an <see cref="InvalidOperationException"/>, and the way to keep a
+    /// <see cref="CborException"/> intact is to not throw it from the comparison in the first place.
+    /// </para>
+    /// </remarks>
+    internal static class DeterministicKeyOrder
+    {
+        /// <summary>
+        /// A map key reduced to what its encoded form is ordered by: its major type, plus the argument
+        /// (integer keys) or the raw payload (string keys) that distinguishes keys of that major type.
+        /// </summary>
+        internal readonly struct SortKey
+        {
+            public readonly CborMajorType MajorType;
+            public readonly ulong Argument;
+            public readonly byte[] Content;
+
+            private SortKey(CborMajorType majorType, ulong argument, byte[] content)
+            {
+                MajorType = majorType;
+                Argument = argument;
+                Content = content;
+            }
+
+            public static SortKey Integer(bool negative, ulong argument)
+            {
+                return new SortKey(
+                    negative ? CborMajorType.NegativeInteger : CborMajorType.PositiveInteger,
+                    argument,
+                    Array.Empty<byte>());
+            }
+
+            public static SortKey Text(byte[] utf8Content)
+            {
+                return new SortKey(CborMajorType.TextString, 0, utf8Content);
+            }
+
+            public static SortKey Bytes(byte[] content)
+            {
+                return new SortKey(CborMajorType.ByteString, 0, content);
+            }
+        }
+
+        private sealed class SortKeyComparer : IComparer<SortKey>
+        {
+            public static readonly SortKeyComparer Instance = new SortKeyComparer();
+
+            public int Compare(SortKey x, SortKey y)
+            {
+                return CborKeyComparer.CompareKeys(
+                    x.MajorType, x.Argument, x.Content,
+                    y.MajorType, y.Argument, y.Content);
+            }
+        }
+
+        /// <summary>
+        /// Returns the entries of <paramref name="entries"/> in deterministic key order, decorating each
+        /// key exactly once with <paramref name="decorate"/>.
+        /// </summary>
+        public static KeyValuePair<TK, TV>[] Sort<TK, TV>(
+            ICollection<KeyValuePair<TK, TV>> entries,
+            Func<TK, SortKey> decorate)
+        {
+            KeyValuePair<TK, TV>[] sorted = new KeyValuePair<TK, TV>[entries.Count];
+            entries.CopyTo(sorted, 0);
+
+            SortKey[] sortKeys = new SortKey[sorted.Length];
+
+            for (int i = 0; i < sorted.Length; i++)
+            {
+                sortKeys[i] = decorate(sorted[i].Key);
+            }
+
+            // The paired overload permutes both arrays together, so the entries end up ordered by their
+            // decorated keys without the comparison ever touching an entry. Stability is not needed:
+            // map keys are unique, and distinct keys have distinct encodings.
+            Array.Sort(sortKeys, sorted, SortKeyComparer.Instance);
+
+            return sorted;
+        }
+
+        /// <summary>
+        /// Decorates a CLR dictionary key. Every kind handled here is one the corresponding key
+        /// converter can already write, and each is decorated as the major type that converter emits --
+        /// so the order computed here is the order of the bytes that actually get written.
+        /// </summary>
+        public static SortKey ForDictionaryKey(object key, CborOptions options)
+        {
+            switch (key)
+            {
+                case string text:
+                    return SortKey.Text(Encoding.UTF8.GetBytes(text));
+
+                // CharConverter writes a char as a one-character text string (CborWriter.WriteChar
+                // UTF-8-encodes it), not as an integer, so it is ordered as text.
+                case char character:
+                    return SortKey.Text(Encoding.UTF8.GetBytes(character.ToString()));
+
+                case byte[] bytes:
+                    return SortKey.Bytes(bytes);
+
+                case ReadOnlyMemory<byte> memory:
+                    return SortKey.Bytes(memory.ToArray());
+
+                case Enum enumKey:
+                    return ForEnumKey(enumKey, options);
+            }
+
+            if (TryGetIntegerArgument(key, out bool negative, out ulong argument))
+            {
+                return SortKey.Integer(negative, argument);
+            }
+
+            throw new CborException(
+                $"Deterministic encoding does not define an order for {key.GetType()} map keys; "
+                + "supported key types are string, char, byte string, any integral type and enums.");
+        }
+
+        /// <summary>
+        /// Decorates a <see cref="CborObject"/> key, which carries its wire type as
+        /// <see cref="CborValue.Type"/> rather than as a distinct CLR type per kind.
+        /// </summary>
+        public static SortKey ForCborValueKey(CborValue key)
+        {
+            switch (key.Type)
+            {
+                case CborValueType.String:
+                    return SortKey.Text(Encoding.UTF8.GetBytes(key.Value<string>()));
+
+                // Byte strings are legal map keys and are what a map read off the wire may well be keyed
+                // by; CborValueConverter writes them with WriteByteString, i.e. major type 2.
+                case CborValueType.ByteString:
+                    return SortKey.Bytes(key.Value<ReadOnlyMemory<byte>>().ToArray());
+
+                // Read at full width -- Value<ulong>()/Value<long>(), never Value<int>() -- because a
+                // key outside int range would otherwise wrap silently and compare as some other key.
+                case CborValueType.Positive:
+                    FromUnsigned(key.Value<ulong>(), out bool positiveNegative, out ulong positiveArgument);
+                    return SortKey.Integer(positiveNegative, positiveArgument);
+
+                case CborValueType.Negative:
+                    FromSigned(key.Value<long>(), out bool negativeNegative, out ulong negativeArgument);
+                    return SortKey.Integer(negativeNegative, negativeArgument);
+
+                default:
+                    throw new CborException(
+                        $"Deterministic encoding does not define an order for {key.Type} CborObject keys; "
+                        + "supported key types are String, ByteString, Positive and Negative.");
+            }
+        }
+
+        /// <summary>
+        /// Converts a boxed CLR integer of any width and signedness to the (major type, argument)
+        /// representation <see cref="CborKeyComparer.CompareIntegerKeys"/> takes.
+        /// </summary>
+        /// <remarks>
+        /// The narrow types all widen losslessly, so they need no case of their own beyond naming them:
+        /// a boxed <see cref="short"/> does not match <c>case int</c>, because unboxing is exact-type.
+        /// That is the same reason <see cref="Enum"/> needs its own branch above.
+        /// </remarks>
+        internal static bool TryGetIntegerArgument(object key, out bool negative, out ulong argument)
+        {
+            switch (key)
+            {
+                case sbyte value:
+                    return FromSigned(value, out negative, out argument);
+                case short value:
+                    return FromSigned(value, out negative, out argument);
+                case int value:
+                    return FromSigned(value, out negative, out argument);
+                case long value:
+                    return FromSigned(value, out negative, out argument);
+                case byte value:
+                    return FromUnsigned(value, out negative, out argument);
+                case ushort value:
+                    return FromUnsigned(value, out negative, out argument);
+                case uint value:
+                    return FromUnsigned(value, out negative, out argument);
+                case ulong value:
+                    return FromUnsigned(value, out negative, out argument);
+            }
+
+            negative = false;
+            argument = 0;
+            return false;
+        }
+
+        private static bool FromSigned(long value, out bool negative, out ulong argument)
+        {
+            negative = value < 0;
+            // Computed in long, where -1 - long.MinValue is long.MaxValue and stays in range; the
+            // negative major type's argument is -1 - value per RFC 8949.
+            argument = negative ? (ulong)(-1L - value) : (ulong)value;
+            return true;
+        }
+
+        private static bool FromUnsigned(ulong value, out bool negative, out ulong argument)
+        {
+            negative = false;
+            argument = value;
+            return true;
+        }
+
+        /// <summary>
+        /// Decorates an enum key the way <see cref="EnumConverter{T}"/> writes one.
+        /// </summary>
+        /// <remarks>
+        /// Two branches, matching that converter: with <see cref="ValueFormat.WriteToString"/> a named
+        /// value is written as its name, and everything else is written through
+        /// <c>Unsafe.As&lt;T, int&gt;</c> -- a 32-bit reinterpretation, so an enum whose underlying type
+        /// is wider than 32 bits is written truncated. The order has to follow the bytes that are
+        /// actually emitted, so the truncation is reproduced here rather than corrected.
+        /// </remarks>
+        private static SortKey ForEnumKey(Enum key, CborOptions options)
+        {
+            if (options.EnumFormat == ValueFormat.WriteToString)
+            {
+                string? name = Enum.GetName(key.GetType(), key);
+
+                if (name != null)
+                {
+                    // EnumConverter holds its names as ASCII, and an enum member name is an identifier,
+                    // so ASCII and UTF-8 agree byte for byte here.
+                    return SortKey.Text(Encoding.ASCII.GetBytes(name));
+                }
+
+                // An unnamed value falls back to the integer form, exactly as EnumConverter.WriteString
+                // does.
+            }
+
+            Type underlyingType = Enum.GetUnderlyingType(key.GetType());
+            IConvertible convertible = key;
+
+            // Only UInt64 can hold a value that ToInt64 would reject; every narrower unsigned type
+            // widens into long without loss.
+            ulong bits = Type.GetTypeCode(underlyingType) == TypeCode.UInt64
+                ? convertible.ToUInt64(null)
+                : unchecked((ulong)convertible.ToInt64(null));
+
+            FromSigned(unchecked((int)(uint)bits), out bool negative, out ulong argument);
+            return SortKey.Integer(negative, argument);
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/DeterministicKeyOrder.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/DeterministicKeyOrder.cs
@@ -1,7 +1,7 @@
 using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Util;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Dahomey.Cbor.Serialization.Converters
 {
@@ -14,254 +14,96 @@ namespace Dahomey.Cbor.Serialization.Converters
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Decorate-sort-undecorate: every key is reduced to a <see cref="SortKey"/> once, up front, and the
-    /// sort then compares those. Doing the reduction inside the comparison instead would re-encode both
-    /// sides of every comparison, which is O(n log n) encodings for a result that only ever needs n.
+    /// Section 4.2.1 orders keys by the bytes of their encoded form, so that is what this sorts on:
+    /// every key is encoded once, through the same converter that will write it into the document, and
+    /// the sort compares those bytes directly. Nothing here knows what any particular key type encodes
+    /// to, which is the point — a sort key derived from the CLR type would be a second opinion about
+    /// what the converter emits, and a second opinion can be wrong. It was: an enum whose value has two
+    /// names sorted under the first name and wrote the last one, a user-registered converter for a
+    /// built-in type was ignored entirely, and key types with no case in the switch threw even though
+    /// their converter could write them perfectly well.
     /// </para>
     /// <para>
-    /// A key kind that has no deterministic order is rejected during decoration, before the sort starts.
-    /// That is also why neither caller unwraps an exception: <see cref="List{T}.Sort(Comparison{T})"/>
-    /// and <see cref="Array.Sort{TKey, TValue}(TKey[], TValue[], IComparer{TKey})"/> wrap anything the
-    /// comparison throws in an <see cref="InvalidOperationException"/>, and the way to keep a
-    /// <see cref="CborException"/> intact is to not throw it from the comparison in the first place.
+    /// Decorate-sort-undecorate, still: n encodings up front rather than the O(n log n) a comparison
+    /// that encoded both sides would cost. The keys are encoded a second time when the map is written,
+    /// which is the price of not holding an intermediate representation of the whole map.
+    /// </para>
+    /// <para>
+    /// Encoding happens before the sort starts, so a converter that throws does so outside the
+    /// comparison. That matters: <see cref="Array.Sort{TKey, TValue}(TKey[], TValue[], IComparer{TKey})"/>
+    /// wraps anything the comparison throws in an <see cref="InvalidOperationException"/>, and the way
+    /// to keep a <see cref="CborException"/> intact is not to throw it from there.
     /// </para>
     /// </remarks>
     internal static class DeterministicKeyOrder
     {
         /// <summary>
-        /// A map key reduced to what its encoded form is ordered by: its major type, plus the argument
-        /// (integer keys) or the raw payload (string keys) that distinguishes keys of that major type.
+        /// Returns the entries in deterministic key order, encoding each key exactly once with
+        /// <paramref name="keyConverter" />.
         /// </summary>
-        internal readonly struct SortKey
-        {
-            public readonly CborMajorType MajorType;
-            public readonly ulong Argument;
-            public readonly byte[] Content;
-
-            private SortKey(CborMajorType majorType, ulong argument, byte[] content)
-            {
-                MajorType = majorType;
-                Argument = argument;
-                Content = content;
-            }
-
-            public static SortKey Integer(bool negative, ulong argument)
-            {
-                return new SortKey(
-                    negative ? CborMajorType.NegativeInteger : CborMajorType.PositiveInteger,
-                    argument,
-                    Array.Empty<byte>());
-            }
-
-            public static SortKey Text(byte[] utf8Content)
-            {
-                return new SortKey(CborMajorType.TextString, 0, utf8Content);
-            }
-
-            public static SortKey Bytes(byte[] content)
-            {
-                return new SortKey(CborMajorType.ByteString, 0, content);
-            }
-        }
-
-        private sealed class SortKeyComparer : IComparer<SortKey>
-        {
-            public static readonly SortKeyComparer Instance = new SortKeyComparer();
-
-            public int Compare(SortKey x, SortKey y)
-            {
-                return CborKeyComparer.CompareKeys(
-                    x.MajorType, x.Argument, x.Content,
-                    y.MajorType, y.Argument, y.Content);
-            }
-        }
-
-        /// <summary>
-        /// Returns the entries of <paramref name="entries"/> in deterministic key order, decorating each
-        /// key exactly once with <paramref name="decorate"/>.
-        /// </summary>
+        /// <param name="maxDepth">
+        /// Depth bound for the scratch writer. A key is normally a scalar, but nothing forbids a
+        /// composite one, and the bound should be the caller's rather than the default.
+        /// </param>
         public static KeyValuePair<TK, TV>[] Sort<TK, TV>(
             ICollection<KeyValuePair<TK, TV>> entries,
-            Func<TK, SortKey> decorate)
+            ICborConverter<TK> keyConverter,
+            int maxDepth)
         {
             KeyValuePair<TK, TV>[] sorted = new KeyValuePair<TK, TV>[entries.Count];
             entries.CopyTo(sorted, 0);
 
-            SortKey[] sortKeys = new SortKey[sorted.Length];
-
-            for (int i = 0; i < sorted.Length; i++)
+            if (sorted.Length < 2)
             {
-                sortKeys[i] = decorate(sorted[i].Key);
+                return sorted;
             }
 
-            // The paired overload permutes both arrays together, so the entries end up ordered by their
-            // decorated keys without the comparison ever touching an entry. Stability is not needed:
-            // map keys are unique, and distinct keys have distinct encodings.
-            Array.Sort(sortKeys, sorted, SortKeyComparer.Instance);
+            byte[] encoded;
+            int[] offsets = new int[sorted.Length + 1];
 
-            return sorted;
-        }
-
-        /// <summary>
-        /// Decorates a CLR dictionary key. Every kind handled here is one the corresponding key
-        /// converter can already write, and each is decorated as the major type that converter emits --
-        /// so the order computed here is the order of the bytes that actually get written.
-        /// </summary>
-        public static SortKey ForDictionaryKey(object key, CborOptions options)
-        {
-            switch (key)
+            // One buffer for every key, with the boundaries recorded as we go, so the whole set costs
+            // a single growing allocation rather than one per key.
+            using (ByteBufferWriter keyBuffer = new ByteBufferWriter())
             {
-                case string text:
-                    return SortKey.Text(Encoding.UTF8.GetBytes(text));
+                CborWriter keyWriter = new CborWriter(keyBuffer, maxDepth, deterministic: true);
 
-                // CharConverter writes a char as a one-character text string (CborWriter.WriteChar
-                // UTF-8-encodes it), not as an integer, so it is ordered as text.
-                case char character:
-                    return SortKey.Text(Encoding.UTF8.GetBytes(character.ToString()));
-
-                case byte[] bytes:
-                    return SortKey.Bytes(bytes);
-
-                case ReadOnlyMemory<byte> memory:
-                    return SortKey.Bytes(memory.ToArray());
-
-                case Enum enumKey:
-                    return ForEnumKey(enumKey, options);
-            }
-
-            if (TryGetIntegerArgument(key, out bool negative, out ulong argument))
-            {
-                return SortKey.Integer(negative, argument);
-            }
-
-            throw new CborException(
-                $"Deterministic encoding does not define an order for {key.GetType()} map keys; "
-                + "supported key types are string, char, byte string, any integral type and enums.");
-        }
-
-        /// <summary>
-        /// Decorates a <see cref="CborObject"/> key, which carries its wire type as
-        /// <see cref="CborValue.Type"/> rather than as a distinct CLR type per kind.
-        /// </summary>
-        public static SortKey ForCborValueKey(CborValue key)
-        {
-            switch (key.Type)
-            {
-                case CborValueType.String:
-                    return SortKey.Text(Encoding.UTF8.GetBytes(key.Value<string>()));
-
-                // Byte strings are legal map keys and are what a map read off the wire may well be keyed
-                // by; CborValueConverter writes them with WriteByteString, i.e. major type 2.
-                case CborValueType.ByteString:
-                    return SortKey.Bytes(key.Value<ReadOnlyMemory<byte>>().ToArray());
-
-                // Read at full width -- Value<ulong>()/Value<long>(), never Value<int>() -- because a
-                // key outside int range would otherwise wrap silently and compare as some other key.
-                case CborValueType.Positive:
-                    FromUnsigned(key.Value<ulong>(), out bool positiveNegative, out ulong positiveArgument);
-                    return SortKey.Integer(positiveNegative, positiveArgument);
-
-                case CborValueType.Negative:
-                    FromSigned(key.Value<long>(), out bool negativeNegative, out ulong negativeArgument);
-                    return SortKey.Integer(negativeNegative, negativeArgument);
-
-                default:
-                    throw new CborException(
-                        $"Deterministic encoding does not define an order for {key.Type} CborObject keys; "
-                        + "supported key types are String, ByteString, Positive and Negative.");
-            }
-        }
-
-        /// <summary>
-        /// Converts a boxed CLR integer of any width and signedness to the (major type, argument)
-        /// representation <see cref="CborKeyComparer.CompareIntegerKeys"/> takes.
-        /// </summary>
-        /// <remarks>
-        /// The narrow types all widen losslessly, so they need no case of their own beyond naming them:
-        /// a boxed <see cref="short"/> does not match <c>case int</c>, because unboxing is exact-type.
-        /// That is the same reason <see cref="Enum"/> needs its own branch above.
-        /// </remarks>
-        internal static bool TryGetIntegerArgument(object key, out bool negative, out ulong argument)
-        {
-            switch (key)
-            {
-                case sbyte value:
-                    return FromSigned(value, out negative, out argument);
-                case short value:
-                    return FromSigned(value, out negative, out argument);
-                case int value:
-                    return FromSigned(value, out negative, out argument);
-                case long value:
-                    return FromSigned(value, out negative, out argument);
-                case byte value:
-                    return FromUnsigned(value, out negative, out argument);
-                case ushort value:
-                    return FromUnsigned(value, out negative, out argument);
-                case uint value:
-                    return FromUnsigned(value, out negative, out argument);
-                case ulong value:
-                    return FromUnsigned(value, out negative, out argument);
-            }
-
-            negative = false;
-            argument = 0;
-            return false;
-        }
-
-        private static bool FromSigned(long value, out bool negative, out ulong argument)
-        {
-            negative = value < 0;
-            // Computed in long, where -1 - long.MinValue is long.MaxValue and stays in range; the
-            // negative major type's argument is -1 - value per RFC 8949.
-            argument = negative ? (ulong)(-1L - value) : (ulong)value;
-            return true;
-        }
-
-        private static bool FromUnsigned(ulong value, out bool negative, out ulong argument)
-        {
-            negative = false;
-            argument = value;
-            return true;
-        }
-
-        /// <summary>
-        /// Decorates an enum key the way <see cref="EnumConverter{T}"/> writes one.
-        /// </summary>
-        /// <remarks>
-        /// Two branches, matching that converter: with <see cref="ValueFormat.WriteToString"/> a named
-        /// value is written as its name, and everything else is written through
-        /// <c>Unsafe.As&lt;T, int&gt;</c> -- a 32-bit reinterpretation, so an enum whose underlying type
-        /// is wider than 32 bits is written truncated. The order has to follow the bytes that are
-        /// actually emitted, so the truncation is reproduced here rather than corrected.
-        /// </remarks>
-        private static SortKey ForEnumKey(Enum key, CborOptions options)
-        {
-            if (options.EnumFormat == ValueFormat.WriteToString)
-            {
-                string? name = Enum.GetName(key.GetType(), key);
-
-                if (name != null)
+                for (int i = 0; i < sorted.Length; i++)
                 {
-                    // EnumConverter holds its names as ASCII, and an enum member name is an identifier,
-                    // so ASCII and UTF-8 agree byte for byte here.
-                    return SortKey.Text(Encoding.ASCII.GetBytes(name));
+                    keyConverter.Write(ref keyWriter, sorted[i].Key);
+                    offsets[i + 1] = keyBuffer.WrittenSpan.Length;
                 }
 
-                // An unnamed value falls back to the integer form, exactly as EnumConverter.WriteString
-                // does.
+                encoded = keyBuffer.WrittenSpan.ToArray();
             }
 
-            Type underlyingType = Enum.GetUnderlyingType(key.GetType());
-            IConvertible convertible = key;
+            int[] order = new int[sorted.Length];
 
-            // Only UInt64 can hold a value that ToInt64 would reject; every narrower unsigned type
-            // widens into long without loss.
-            ulong bits = Type.GetTypeCode(underlyingType) == TypeCode.UInt64
-                ? convertible.ToUInt64(null)
-                : unchecked((ulong)convertible.ToInt64(null));
+            for (int i = 0; i < order.Length; i++)
+            {
+                order[i] = i;
+            }
 
-            FromSigned(unchecked((int)(uint)bits), out bool negative, out ulong argument);
-            return SortKey.Integer(negative, argument);
+            // Bytewise over the encoded keys, which is section 4.2.1 read literally. Length is not
+            // compared separately: a shorter key already sorts first because the length is part of the
+            // header byte the comparison starts at.
+            Array.Sort(order, (x, y) => Compare(encoded, offsets, x, y));
+
+            KeyValuePair<TK, TV>[] result = new KeyValuePair<TK, TV>[sorted.Length];
+
+            for (int i = 0; i < result.Length; i++)
+            {
+                result[i] = sorted[order[i]];
+            }
+
+            return result;
+        }
+
+        private static int Compare(byte[] encoded, int[] offsets, int x, int y)
+        {
+            ReadOnlySpan<byte> left = encoded.AsSpan(offsets[x], offsets[x + 1] - offsets[x]);
+            ReadOnlySpan<byte> right = encoded.AsSpan(offsets[y], offsets[y + 1] - offsets[y]);
+
+            return left.SequenceCompareTo(right);
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -56,6 +56,21 @@ namespace Dahomey.Cbor.Serialization.Converters
             public T obj;
             public int memberIndex;
             public IObjectConverter objectConverter;
+            /// <summary>
+            /// The member list this write runs on, read from
+            /// <see cref="IObjectConverter.MemberConvertersForWrite"/> once, when the write starts.
+            /// </summary>
+            /// <remarks>
+            /// That property answers from <see cref="CborOptions.Deterministic"/>, which any code
+            /// running during the write -- a property getter, a custom converter, another thread
+            /// sharing <see cref="CborOptions.Default"/> -- is free to change. Consulting it per item
+            /// would let one write start on one ordering and finish on the other, writing some members
+            /// twice and dropping others while the map header still claims the original count: a
+            /// structurally corrupt document that nothing downstream can detect. Snapshotting also
+            /// keeps the property off the per-member path, where it costs a non-inlineable call on
+            /// every object write, deterministic or not.
+            /// </remarks>
+            public IReadOnlyList<IMemberConverter> memberConvertersForWrite;
             public LengthMode lengthMode;
         }
 
@@ -443,6 +458,10 @@ namespace Dahomey.Cbor.Serialization.Converters
                 context.objectConverter = this;
             }
 
+            // One read, here, now that the converter this write runs on is settled -- see
+            // WriterContext.memberConvertersForWrite.
+            context.memberConvertersForWrite = context.objectConverter.MemberConvertersForWrite;
+
             switch (_objectMapping.ObjectFormat)
             {
                 case CborObjectFormat.StringKeyMap:
@@ -802,7 +821,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             int writableMembersCount = 0;
 
-            foreach (IMemberConverter memberConverter in context.objectConverter.MemberConvertersForWrite)
+            foreach (IMemberConverter memberConverter in context.memberConvertersForWrite)
             {
                 if (_isStruct)
                 {
@@ -824,9 +843,9 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         private bool WriteItem(ref CborWriter writer, ref WriterContext context)
         {
-            while (context.memberIndex < context.objectConverter.MemberConvertersForWrite.Count)
+            while (context.memberIndex < context.memberConvertersForWrite.Count)
             {
-                IMemberConverter memberConverter = context.objectConverter.MemberConvertersForWrite[context.memberIndex++];
+                IMemberConverter memberConverter = context.memberConvertersForWrite[context.memberIndex++];
                 if (_isStruct)
                 {
                     IMemberConverter<T> typedMemberConverter = (IMemberConverter<T>)memberConverter;
@@ -876,7 +895,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                 }
             }
 
-            return context.memberIndex < context.objectConverter.MemberConvertersForWrite.Count;
+            return context.memberIndex < context.memberConvertersForWrite.Count;
         }
 
         private void HandleUnknownName(ref CborReader reader, Type type, ReadOnlySpan<byte> rawName)

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -1,4 +1,5 @@
 ﻿using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
 using Dahomey.Cbor.Serialization.Conventions;
 using Dahomey.Cbor.Serialization.Converters.Mappings;
 using Dahomey.Cbor.Util;
@@ -129,6 +130,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                 {
                     _memberConvertersForWrite.Add(memberConverter);
                 }
+            }
+
+            if (options.Deterministic)
+            {
+                _memberConvertersForWrite.Sort(CompareMembersForDeterministicOrder);
             }
 
             _isInterfaceOrAbstract = typeof(T).IsInterface || typeof(T).IsAbstract;
@@ -694,6 +700,18 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 reader.SkipDataItem();
             }
+        }
+
+        private static int CompareMembersForDeterministicOrder(IMemberConverter x, IMemberConverter y)
+        {
+            // IntKeyMap members carry an index; StringKeyMap members carry a name. A mapping uses one
+            // or the other, never both, so whichever is present decides the order.
+            if (x.MemberIndex.HasValue && y.MemberIndex.HasValue)
+            {
+                return CborKeyComparer.CompareIntKeys(x.MemberIndex.Value, y.MemberIndex.Value);
+            }
+
+            return CborKeyComparer.CompareTextKeys(x.MemberName, y.MemberName);
         }
 
         private static bool FindItem(ref CborReader reader, ReadOnlySpan<byte> name)

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -63,6 +63,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         private readonly Dictionary<int, IMemberConverter> _memberConvertersForReadByIndex = new();
         public List<IMemberConverter> _requiredMemberConvertersForRead = new List<IMemberConverter>();
         private readonly List<IMemberConverter> _memberConvertersForWrite;
+        private List<IMemberConverter>? _deterministicMemberConvertersForWrite;
         private readonly CborOptions _options;
         private readonly SerializationRegistry _registry;
         private readonly IObjectMapping _objectMapping;
@@ -71,7 +72,50 @@ namespace Dahomey.Cbor.Serialization.Converters
         private readonly bool _isStruct;
         private readonly IDiscriminatorConvention? _discriminatorConvention = null;
 
-        public IReadOnlyList<IMemberConverter> MemberConvertersForWrite => _memberConvertersForWrite;
+        /// <summary>
+        /// The members to write, in the order to write them: declaration order normally, deterministic
+        /// key order when <see cref="CborOptions.Deterministic"/> is set.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The flag is read here, where the list is consumed, rather than in the constructor where it is
+        /// built. A converter is built once per type and then cached in
+        /// <see cref="CborConverterRegistry"/> for the lifetime of the options, so an order chosen at
+        /// construction would be frozen at whatever the flag happened to be the first time that type was
+        /// serialized -- and silently wrong, not loudly wrong, for every write after the flag changed.
+        /// <see cref="CborOptions.Default"/> being a process-wide singleton makes that ordinary rather
+        /// than exotic. Reading the flag per write costs a branch and keeps the guarantee honest.
+        /// </para>
+        /// <para>
+        /// <see cref="CborObjectFormat.Array"/> is excluded because it writes members positionally and
+        /// emits no keys at all. There is nothing to order, and reordering would move values between
+        /// array positions -- changing what the document means rather than only how it is spelled.
+        /// </para>
+        /// </remarks>
+        public IReadOnlyList<IMemberConverter> MemberConvertersForWrite
+        {
+            get
+            {
+                if (!_options.Deterministic || _objectMapping.ObjectFormat == CborObjectFormat.Array)
+                {
+                    return _memberConvertersForWrite;
+                }
+
+                // The member set itself is fixed at construction, so its sorted permutation is too, and
+                // is computed once. Two threads racing here build identical lists; the reference
+                // assignment is atomic, so the loser's copy is simply dropped.
+                List<IMemberConverter>? sorted = _deterministicMemberConvertersForWrite;
+
+                if (sorted == null)
+                {
+                    sorted = new List<IMemberConverter>(_memberConvertersForWrite);
+                    sorted.Sort(CompareMembersForDeterministicOrder);
+                    _deterministicMemberConvertersForWrite = sorted;
+                }
+
+                return sorted;
+            }
+        }
         public ByteBufferDictionary<IMemberConverter> MemberConvertersForRead => _memberConvertersForRead;
         public Dictionary<int, IMemberConverter> MemberConvertersForReadByIndex => _memberConvertersForReadByIndex;
         public IReadOnlyList<IMemberConverter> RequiredMemberConvertersForRead => _requiredMemberConvertersForRead;
@@ -130,11 +174,6 @@ namespace Dahomey.Cbor.Serialization.Converters
                 {
                     _memberConvertersForWrite.Add(memberConverter);
                 }
-            }
-
-            if (options.Deterministic)
-            {
-                _memberConvertersForWrite.Sort(CompareMembersForDeterministicOrder);
             }
 
             _isInterfaceOrAbstract = typeof(T).IsInterface || typeof(T).IsAbstract;

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -71,6 +71,20 @@ namespace Dahomey.Cbor.Serialization.Converters
             /// every object write, deterministic or not.
             /// </remarks>
             public IReadOnlyList<IMemberConverter> memberConvertersForWrite;
+
+            /// <summary>
+            /// The object format this write runs on, taken from the same converter as
+            /// <see cref="memberConvertersForWrite"/>.
+            /// </summary>
+            /// <remarks>
+            /// In the polymorphic case that converter is the derived type's, so reading the format
+            /// from the declared type's mapping instead would let a base and a derived type that
+            /// disagree on it decide the exclusion of
+            /// <see cref="CborObjectFormat.Array"/> from one mapping and the write from the other:
+            /// members would be written positionally in sorted order, moving values between array
+            /// slots. Both come from one converter, read once.
+            /// </remarks>
+            public CborObjectFormat objectFormat;
             public LengthMode lengthMode;
         }
 
@@ -458,11 +472,12 @@ namespace Dahomey.Cbor.Serialization.Converters
                 context.objectConverter = this;
             }
 
-            // One read, here, now that the converter this write runs on is settled -- see
-            // WriterContext.memberConvertersForWrite.
+            // One read of each, here, now that the converter this write runs on is settled -- see
+            // WriterContext.memberConvertersForWrite and WriterContext.objectFormat.
             context.memberConvertersForWrite = context.objectConverter.MemberConvertersForWrite;
+            context.objectFormat = context.objectConverter.ObjectMapping.ObjectFormat;
 
-            switch (_objectMapping.ObjectFormat)
+            switch (context.objectFormat)
             {
                 case CborObjectFormat.StringKeyMap:
                 case CborObjectFormat.IntKeyMap:
@@ -852,7 +867,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
                     if (typedMemberConverter.ShouldSerialize(ref context.obj, typeof(T)))
                     {
-                        switch (_objectMapping.ObjectFormat)
+                        switch (context.objectFormat)
                         {
                             case CborObjectFormat.StringKeyMap:
                                 writer.WriteString(memberConverter.MemberName);
@@ -874,7 +889,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                 }
                 else if (memberConverter.ShouldSerialize(context.obj!, typeof(T), context.options))
                 {
-                    switch (_objectMapping.ObjectFormat)
+                    switch (context.objectFormat)
                     {
                         case CborObjectFormat.StringKeyMap:
                             writer.WriteString(memberConverter.MemberName);

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -704,8 +704,14 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         private static int CompareMembersForDeterministicOrder(IMemberConverter x, IMemberConverter y)
         {
-            // IntKeyMap members carry an index; StringKeyMap members carry a name. A mapping uses one
-            // or the other, never both, so whichever is present decides the order.
+            // IntKeyMap/Array members carry an index and no name. Ordinary StringKeyMap members carry
+            // a name and no index. But DiscriminatorMemberConverter.MemberIndex is hardcoded to 0 in
+            // every format, so a StringKeyMap type with a discriminator has one entry with BOTH a
+            // MemberIndex and a MemberName. That still routes correctly, because the two-sided
+            // HasValue test below only takes the int branch when *both* sides carry an index -- an
+            // ordinary StringKeyMap member's MemberIndex is null, so comparing it against the
+            // discriminator entry always falls through to CompareTextKeys, which is the comparison
+            // that matches how the whole map is actually keyed.
             if (x.MemberIndex.HasValue && y.MemberIndex.HasValue)
             {
                 return CborKeyComparer.CompareIntKeys(x.MemberIndex.Value, y.MemberIndex.Value);


### PR DESCRIPTION
Closes #148.

Adds `CborOptions.Deterministic`, producing RFC 8949 §4.2.1 canonical output so a document can be hashed for integrity or deduplication.

## What was already true

Three of the four §4.2.1 core requirements are already satisfied by `CborWriter` and needed no change:

- shortest-form arguments for integers, lengths and tags (`WriteInteger`'s 24/25/26/27 ladder)
- preferred float serialization — binary16, then binary32, then binary64, shortest that round-trips exactly
- definite lengths, which are already the default

So this PR adds the fourth — bytewise map-key ordering — plus refusal of any setting that admits more than one encoding of the same value.

## What it does

- Map keys sort bytewise on their **encoded** form. A shorter encoded key therefore always sorts before a longer one (`"z"` before `"aa"`), and negative integer keys sort after every non-negative one because they are major type 1. This is §4.2.1 ordering, not the deprecated §4.2.3 length-first variant.
- Ordering applies wherever a map is written: `StringKeyMap` and `IntKeyMap` objects, `Dictionary<K,V>`, and `CborObject`. `CborObjectFormat.Array` is positional and has no keys, so it is deliberately left untouched.
- An indefinite-length map or array throws a `CborException` at the point its header would be written, whichever of the three sources asked for it: `ArrayLengthMode`, `MapLengthMode`, or a `CborLengthMode` attribute on a type or member, which outranks both options. The refusal is at the writer rather than at the property setters so no configuration order can slip past it.
- Any key kind whose converter can write it is orderable, because each key is encoded through that converter and the encoded bytes are what get compared. That covers text, byte strings, every integral type, `char`, enums, floating point, booleans and `DateTime`, and for `CborObject` also nulls, arrays and nested maps, mixed freely within one map. Mixed kinds order by major type first, matching the bytewise order of the leading byte. A custom key converter participates with nothing added here.

## Cost

Ordering is decided once per write, not per member. Steady-state allocation is unchanged on both paths; a 32-member object write measured 555-661 ns non-deterministic and 582-600 ns deterministic, both at or below the pre-change baseline. Dictionary key bytes are encoded once per key rather than once per comparison — decorate-sort-undecorate — which took a 2000-entry map from 1,048,488 to 144,208 bytes.

Output with `Deterministic = false` is byte-identical to `master`, verified by `DeterministicByteCompatibilityTests`: a seventeen-shape corpus covering all three object formats, nesting, a polymorphic discriminator, dictionaries keyed by string, int, long, char, aliased and flags enums, double, bool and `byte[]`, and mixed-kind `CborObject`s. The expected bytes were captured by running that same corpus on the base commit, not written by hand.

## Public API

`CborOptions.Deterministic`, and nothing else. `CborKeyComparer` is `internal`: comparing encoded bytes left it with two live methods serving `ObjectConverter`'s member sort, and its old cross-kind signature was an artifact of the previous approach rather than something worth freezing.

The test project is signed with the library's own key so it can be an `InternalsVisibleTo` friend — a strong-named assembly can only grant friend access to another strong-named one. Without it the choice would have been between keeping the class public and dropping the direct tests for a 65536-character key and for `int.MinValue`, neither of which the encoded bytes can reach.

## Known limitations, stated rather than implied

- Enum keys are ordered by the bytes `EnumConverter` actually emits, including its existing 32-bit reinterpretation of wider underlying types. An order derived from a value the document does not contain would be a lie about the document — but it means two enum values wider than 32 bits can collide into duplicate keys. The README says so.
- The flag must not be changed while a write using those options is in flight.

## Tests

974 on `origin/master` → 1080 here, 0 failures; all four TFMs build, and CI is green on all three runnable ones. Coverage includes the encoded-size tier boundaries (23/24, 255/256, 65535/65536) for both text and integer keys, `int.MinValue` and `ulong.MaxValue`, negative `IntKeyMap` indices, discriminated hierarchies, mixed-kind `CborObject` maps, a regression test for changing the flag mid-write, nested maps sorted independently of their container, and non-scalar `CborObject` keys ordered rather than rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
