### PR TITLE
Build converters for mutually referencing types without overflowing the stack

### DIFF
--- a/src/Dahomey.Cbor.Tests/Issues/Issue0149Cycles.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0149Cycles.cs
@@ -1,0 +1,134 @@
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #149, converter-construction side: two types that reference each other must be
+    /// serializable.
+    /// </summary>
+    /// <remarks>
+    /// A converter resolves its members' converters while it is being constructed, and it is not in
+    /// the registry until its constructor returns. Two mutually referencing types therefore ask the
+    /// registry for each other indefinitely, and the process dies on an uncatchable
+    /// <see cref="System.StackOverflowException"/> before any CBOR is written — a different failure
+    /// from the deep-nesting one <c>CborOptions.MaxDepth</c> bounds, which happens during a write on
+    /// a converter graph that built fine.
+    /// <para>
+    /// The single-type case (<c>A.Property</c> of type <c>A</c>) is covered by
+    /// <see cref="Issue0149"/>; these are the cases that need more than the parent-converter reuse.
+    /// </para>
+    /// </remarks>
+    public class Issue0149Cycles
+    {
+        public class Parent
+        {
+            public string Name { get; set; }
+            public Child Only { get; set; }
+        }
+
+        public class Child
+        {
+            public int Age { get; set; }
+            public Parent Owner { get; set; }
+        }
+
+        public class RingA
+        {
+            public int Id { get; set; }
+            public RingB Next { get; set; }
+        }
+
+        public class RingB
+        {
+            public int Id { get; set; }
+            public RingC Next { get; set; }
+        }
+
+        public class RingC
+        {
+            public int Id { get; set; }
+            public RingA Next { get; set; }
+        }
+
+        /// <summary>
+        /// Two types referencing each other — the back-reference shape that any parent/child model
+        /// has.
+        /// </summary>
+        [Fact]
+        public void MutuallyReferencingTypesCanBeSerialized()
+        {
+            Parent parent = new Parent
+            {
+                Name = "root",
+                Only = new Child { Age = 3 },
+            };
+
+            // a2                        map(2)
+            //    644e616d65             "Name"
+            //    64726f6f74             "root"
+            //    644f6e6c79             "Only"
+            //    a2                     map(2)
+            //       63416765            "Age"
+            //       03                  3
+            //       654f776e6572        "Owner"
+            //       f6                  null
+            Helper.TestWrite(parent, "A2644E616D6564726F6F74644F6E6C79A26341676503654F776E6572F6");
+        }
+
+        [Fact]
+        public void MutuallyReferencingTypesCanBeDeserialized()
+        {
+            const string hexBuffer = "A2644E616D6564726F6F74644F6E6C79A26341676503654F776E6572F6";
+
+            Parent parent = Cbor.Deserialize<Parent>(hexBuffer.HexToBytes());
+
+            Assert.Equal("root", parent.Name);
+            Assert.Equal(3, parent.Only.Age);
+            Assert.Null(parent.Only.Owner);
+        }
+
+        /// <summary>
+        /// A cycle longer than two types: nothing in the break may depend on the pair being adjacent.
+        /// </summary>
+        [Fact]
+        public void ThreeTypeCycleCanBeSerialized()
+        {
+            RingA a = new RingA
+            {
+                Id = 1,
+                Next = new RingB { Id = 2, Next = new RingC { Id = 3 } },
+            };
+
+            // a2                     map(2)
+            //    624964              "Id"
+            //    01                  1
+            //    644e657874          "Next"
+            //    a2                  map(2)
+            //       624964           "Id"
+            //       02               2
+            //       644e657874       "Next"
+            //       a2               map(2)
+            //          624964        "Id"
+            //          03            3
+            //          644e657874    "Next"
+            //          f6            null
+            Helper.TestWrite(a, "A262496401644E657874A262496402644E657874A262496403644E657874F6");
+        }
+
+        /// <summary>
+        /// An actual object graph cycle is still a write-side infinite recursion, bounded by
+        /// <see cref="CborOptions.MaxDepth"/> rather than by anything here. Building the converters
+        /// is what must not overflow; writing a cycle is a caller error and stays a
+        /// <see cref="CborException"/>.
+        /// </summary>
+        [Fact]
+        public void AnActualObjectCycleIsStillBoundedByMaxDepth()
+        {
+            Parent parent = new Parent { Name = "root" };
+            parent.Only = new Child { Age = 3, Owner = parent };
+
+            Assert.Throws<CborException>(() => Helper.Write(parent));
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0149Cycles.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0149Cycles.cs
@@ -1,4 +1,6 @@
 using Dahomey.Cbor.Tests.Extensions;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests.Issues
@@ -49,6 +51,35 @@ namespace Dahomey.Cbor.Tests.Issues
         {
             public int Id { get; set; }
             public RingA Next { get; set; }
+        }
+
+        public class Team
+        {
+            public string Name { get; set; }
+            public List<Member> Members { get; set; }
+        }
+
+        public class Member
+        {
+            public string Name { get; set; }
+            public Team Team { get; set; }
+        }
+
+        public struct Slot
+        {
+            public Node Node { get; set; }
+        }
+
+        public class Boxed
+        {
+            public int Id { get; set; }
+            public ValueTuple<Boxed, int> Pair { get; set; }
+        }
+
+        public class Node
+        {
+            public int Id { get; set; }
+            public Slot Slot { get; set; }
         }
 
         /// <summary>
@@ -114,6 +145,118 @@ namespace Dahomey.Cbor.Tests.Issues
             //          644e657874    "Next"
             //          f6            null
             Helper.TestWrite(a, "A262496401644E657874A262496402644E657874A262496403644E657874F6");
+        }
+
+        [Fact]
+        public void ThreeTypeCycleCanBeDeserialized()
+        {
+            const string hexBuffer = "A262496401644E657874A262496402644E657874A262496403644E657874F6";
+
+            RingA a = Cbor.Deserialize<RingA>(hexBuffer.HexToBytes());
+
+            Assert.Equal(1, a.Id);
+            Assert.Equal(2, a.Next.Id);
+            Assert.Equal(3, a.Next.Next.Id);
+            Assert.Null(a.Next.Next.Next);
+        }
+
+        /// <summary>
+        /// The cycle most real models actually have: the back-reference is reached through a
+        /// collection rather than directly.
+        /// </summary>
+        /// <remarks>
+        /// This shape survives on <c>master</c> already, because <c>AbstractCollectionConverter</c>
+        /// resolves its item converter lazily. Pinning it keeps a future change there from
+        /// reintroducing the overflow through a path nothing else covers.
+        /// </remarks>
+        [Fact]
+        public void CycleThroughACollectionCanBeRoundTripped()
+        {
+            Team team = new Team
+            {
+                Name = "a",
+                Members = new List<Member> { new Member { Name = "b" } },
+            };
+
+            // a2                           map(2)
+            //    644e616d65                "Name"
+            //    6161                      "a"
+            //    674d656d62657273          "Members"
+            //    81                        array(1)
+            //       a2                     map(2)
+            //          644e616d65          "Name"
+            //          6162                "b"
+            //          645465616d          "Team"
+            //          f6                  null
+            const string hexBuffer = "A2644E616D656161674D656D6265727381A2644E616D656162645465616DF6";
+
+            Helper.TestWrite(team, hexBuffer);
+
+            Team read = Cbor.Deserialize<Team>(hexBuffer.HexToBytes());
+
+            Assert.Equal("a", read.Name);
+            Assert.Single(read.Members);
+            Assert.Equal("b", read.Members[0].Name);
+            Assert.Null(read.Members[0].Team);
+        }
+
+        /// <summary>
+        /// A cycle whose second leg goes through <c>StructMemberConverter</c>. Struct-to-struct
+        /// cycles are impossible in C#, but a struct holding a class that holds the struct is a
+        /// genuine mutual reference and is the only shape that reaches that converter.
+        /// </summary>
+        [Fact]
+        public void CycleThroughAStructMemberCanBeRoundTripped()
+        {
+            Node node = new Node { Id = 7 };
+
+            // a2                     map(2)
+            //    624964              "Id"
+            //    07                  7
+            //    64536c6f74          "Slot"
+            //    a1                  map(1)
+            //       644e6f6465       "Node"
+            //       f6               null
+            const string hexBuffer = "A26249640764536C6F74A1644E6F6465F6";
+
+            Helper.TestWrite(node, hexBuffer);
+
+            Node read = Cbor.Deserialize<Node>(hexBuffer.HexToBytes());
+
+            Assert.Equal(7, read.Id);
+            Assert.Null(read.Slot.Node);
+        }
+
+        /// <summary>
+        /// A cycle whose second leg goes through a converter that resolves eagerly.
+        /// </summary>
+        /// <remarks>
+        /// The tuple and nullable converters look their item types up from their own constructors,
+        /// unlike the collection and dictionary converters. That stays safe only because the member
+        /// converter no longer resolves during construction: <c>Boxed</c> reaches the registry before
+        /// its <c>Pair</c> member is looked at, so <c>Tuple2Converter</c>'s eager <c>Lookup</c> finds
+        /// it rather than re-entering its construction. This is the one shape that covers those
+        /// eager lookups, and it overflows the stack without the change.
+        /// </remarks>
+        [Fact]
+        public void CycleThroughATupleCanBeSerialized()
+        {
+            Boxed boxed = new Boxed { Id = 1, Pair = new ValueTuple<Boxed, int>(new Boxed { Id = 2 }, 9) };
+
+            // a2                        map(2)
+            //    624964                 "Id"
+            //    01                     1
+            //    6450616972             "Pair"
+            //    82                     array(2)
+            //       a2                  map(2)
+            //          624964           "Id"
+            //          02               2
+            //          6450616972       "Pair"
+            //          82               array(2)
+            //             f6            null
+            //             00            0
+            //       09                  9
+            Helper.TestWrite(boxed, "A262496401645061697282A262496402645061697282F60009");
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor/Serialization/Converters/CborConverterRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborConverterRegistry.cs
@@ -1,7 +1,6 @@
 ﻿using Dahomey.Cbor.Serialization.Converters.Providers;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace Dahomey.Cbor.Serialization.Converters
@@ -10,27 +9,7 @@ namespace Dahomey.Cbor.Serialization.Converters
     {
         private readonly CborOptions _options;
         private readonly ConcurrentDictionary<Type, ICborConverter> _converters = new ConcurrentDictionary<Type, ICborConverter>();
-        private readonly ConcurrentStack<ICborConverterProvider> _providers = new ConcurrentStack<ICborConverterProvider>();
-
-        /// <summary>
-        /// Types whose converter is being constructed on this thread, right now.
-        /// </summary>
-        /// <remarks>
-        /// A converter resolves its members' converters while it is being constructed, and it is not
-        /// in <c>_converters</c> until that constructor returns. Two types that reference each other
-        /// therefore ask for each other indefinitely: A's construction looks up B, B's construction
-        /// looks up A, and neither is registered yet. The result is an uncatchable
-        /// <see cref="StackOverflowException"/>, not an exception a caller can handle.
-        /// <para>
-        /// Recording what is in flight lets a member mapping recognise the cycle and defer instead —
-        /// see <c>MemberMapping{T}.InitializeConverter</c>. Thread-static because construction is
-        /// re-entrant per thread; two threads building the same graph independently each complete on
-        /// their own, and <see cref="ConcurrentDictionary{TKey, TValue}.GetOrAdd"/> settles which
-        /// instance wins.
-        /// </para>
-        /// </remarks>
-        [ThreadStatic]
-        private static HashSet<(CborConverterRegistry, Type)>? _underConstruction;
+        private readonly ConcurrentStack<ICborConverterProvider> _providers = new ConcurrentStack<ICborConverterProvider>();        
 
         public CborConverterRegistry(CborOptions options)
         {
@@ -110,39 +89,18 @@ namespace Dahomey.Cbor.Serialization.Converters
             _converters.Clear();
         }
 
-        /// <summary>
-        /// Whether a converter for <paramref name="type" /> is already being constructed further up
-        /// this thread's call stack, so asking for it again would recurse rather than return.
-        /// </summary>
-        internal bool IsUnderConstruction(Type type)
-        {
-            return _underConstruction != null && _underConstruction.Contains((this, type));
-        }
-
         private ICborConverter CreateConverter(Type type)
         {
-            HashSet<(CborConverterRegistry, Type)> underConstruction =
-                _underConstruction ??= new HashSet<(CborConverterRegistry, Type)>();
+            ICborConverter? converter = _providers
+                .Select(provider => provider.GetConverter(type, _options))
+                .FirstOrDefault(provider => provider != null);
 
-            underConstruction.Add((this, type));
-
-            try
+            if (converter == null)
             {
-                ICborConverter? converter = _providers
-                    .Select(provider => provider.GetConverter(type, _options))
-                    .FirstOrDefault(provider => provider != null);
-
-                if (converter == null)
-                {
-                    throw new CborException($"No converter found for type {type.FullName}.");
-                }
-
-                return converter;
+                throw new CborException($"No converter found for type {type.FullName}.");
             }
-            finally
-            {
-                underConstruction.Remove((this, type));
-            }
+
+            return converter;
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/CborConverterRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborConverterRegistry.cs
@@ -1,6 +1,7 @@
 ﻿using Dahomey.Cbor.Serialization.Converters.Providers;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Dahomey.Cbor.Serialization.Converters
@@ -9,7 +10,27 @@ namespace Dahomey.Cbor.Serialization.Converters
     {
         private readonly CborOptions _options;
         private readonly ConcurrentDictionary<Type, ICborConverter> _converters = new ConcurrentDictionary<Type, ICborConverter>();
-        private readonly ConcurrentStack<ICborConverterProvider> _providers = new ConcurrentStack<ICborConverterProvider>();        
+        private readonly ConcurrentStack<ICborConverterProvider> _providers = new ConcurrentStack<ICborConverterProvider>();
+
+        /// <summary>
+        /// Types whose converter is being constructed on this thread, right now.
+        /// </summary>
+        /// <remarks>
+        /// A converter resolves its members' converters while it is being constructed, and it is not
+        /// in <c>_converters</c> until that constructor returns. Two types that reference each other
+        /// therefore ask for each other indefinitely: A's construction looks up B, B's construction
+        /// looks up A, and neither is registered yet. The result is an uncatchable
+        /// <see cref="StackOverflowException"/>, not an exception a caller can handle.
+        /// <para>
+        /// Recording what is in flight lets a member mapping recognise the cycle and defer instead —
+        /// see <c>MemberMapping{T}.InitializeConverter</c>. Thread-static because construction is
+        /// re-entrant per thread; two threads building the same graph independently each complete on
+        /// their own, and <see cref="ConcurrentDictionary{TKey, TValue}.GetOrAdd"/> settles which
+        /// instance wins.
+        /// </para>
+        /// </remarks>
+        [ThreadStatic]
+        private static HashSet<(CborConverterRegistry, Type)>? _underConstruction;
 
         public CborConverterRegistry(CborOptions options)
         {
@@ -89,18 +110,39 @@ namespace Dahomey.Cbor.Serialization.Converters
             _converters.Clear();
         }
 
+        /// <summary>
+        /// Whether a converter for <paramref name="type" /> is already being constructed further up
+        /// this thread's call stack, so asking for it again would recurse rather than return.
+        /// </summary>
+        internal bool IsUnderConstruction(Type type)
+        {
+            return _underConstruction != null && _underConstruction.Contains((this, type));
+        }
+
         private ICborConverter CreateConverter(Type type)
         {
-            ICborConverter? converter = _providers
-                .Select(provider => provider.GetConverter(type, _options))
-                .FirstOrDefault(provider => provider != null);
+            HashSet<(CborConverterRegistry, Type)> underConstruction =
+                _underConstruction ??= new HashSet<(CborConverterRegistry, Type)>();
 
-            if (converter == null)
+            underConstruction.Add((this, type));
+
+            try
             {
-                throw new CborException($"No converter found for type {type.FullName}.");
-            }
+                ICborConverter? converter = _providers
+                    .Select(provider => provider.GetConverter(type, _options))
+                    .FirstOrDefault(provider => provider != null);
 
-            return converter;
+                if (converter == null)
+                {
+                    throw new CborException($"No converter found for type {type.FullName}.");
+                }
+
+                return converter;
+            }
+            finally
+            {
+                underConstruction.Remove((this, type));
+            }
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
@@ -9,7 +9,6 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
     public class MemberMapping<T> : IMemberMapping
     {
         private bool _isInitialized = false;
-        private bool _converterDeferred = false;
         private readonly IObjectMapping _objectMapping;
         private readonly CborConverterRegistry _converterRegistry;
         private string? _memberName = null;
@@ -44,13 +43,17 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             {
                 EnsureInitialize();
 
-                // A cycle deferred this resolution during initialization. By the time anyone asks for
-                // the converter the graph is fully built, so the lookup now completes.
-                if (_converter == null && _converterDeferred)
+                // Initialization deliberately leaves the registry lookup undone: a converter resolves
+                // its members while its own constructor is still running, so asking the registry for a
+                // member whose type is part of a cycle would re-enter that construction and recurse
+                // until the stack is gone. By the time anyone reads this the graph is built, so the
+                // lookup now completes.
+                if (_converter == null)
                 {
-                    _converter = _converterRegistry.Lookup(MemberType);
-                    VerifyMemberConverterType(_converter.GetType());
-                    _converterDeferred = false;
+                    lock (this)
+                    {
+                        _converter ??= _converterRegistry.Lookup(MemberType);
+                    }
                 }
 
                 return _converter;
@@ -253,18 +256,8 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                     }
                 }
                 
-                // The member's own type is already being constructed further up the stack — this is a
-                // reference cycle between two or more types. Looking it up here would re-enter its
-                // construction and recurse until the stack is gone, so leave it unresolved; the
-                // `Converter` getter completes it once the graph is built. The direct A -> A case is
-                // handled above by reusing the parent converter, which is cheaper and needs no defer.
-                if (_converterRegistry.IsUnderConstruction(MemberType))
-                {
-                    _converterDeferred = true;
-                    return;
-                }
-
-                _converter = _converterRegistry.Lookup(MemberType);
+                // Nothing else to do here. The registry lookup belongs in the `Converter` getter, not
+                // in construction — see the comment there.
                 return;
             }
             

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
@@ -9,6 +9,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
     public class MemberMapping<T> : IMemberMapping
     {
         private bool _isInitialized = false;
+        private bool _converterDeferred = false;
         private readonly IObjectMapping _objectMapping;
         private readonly CborConverterRegistry _converterRegistry;
         private string? _memberName = null;
@@ -42,6 +43,16 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             get
             {
                 EnsureInitialize();
+
+                // A cycle deferred this resolution during initialization. By the time anyone asks for
+                // the converter the graph is fully built, so the lookup now completes.
+                if (_converter == null && _converterDeferred)
+                {
+                    _converter = _converterRegistry.Lookup(MemberType);
+                    VerifyMemberConverterType(_converter.GetType());
+                    _converterDeferred = false;
+                }
+
                 return _converter;
             }
         }
@@ -242,6 +253,17 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                     }
                 }
                 
+                // The member's own type is already being constructed further up the stack — this is a
+                // reference cycle between two or more types. Looking it up here would re-enter its
+                // construction and recurse until the stack is gone, so leave it unresolved; the
+                // `Converter` getter completes it once the graph is built. The direct A -> A case is
+                // handled above by reusing the parent converter, which is cheaper and needs no defer.
+                if (_converterRegistry.IsUnderConstruction(MemberType))
+                {
+                    _converterDeferred = true;
+                    return;
+                }
+
                 _converter = _converterRegistry.Lookup(MemberType);
                 return;
             }

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
@@ -34,7 +34,19 @@ namespace Dahomey.Cbor.Serialization.Converters
     {
         private readonly Func<T, TM>? _memberGetter;
         private readonly Action<T, TM>? _memberSetter;
-        private readonly ICborConverter<TM> _converter;
+        private readonly IMemberMapping _memberMapping;
+        private ICborConverter<TM>? _converter;
+
+        /// <summary>
+        /// Resolved on first use, not in the constructor.
+        /// </summary>
+        /// <remarks>
+        /// Two types that reference each other cannot both have a converter at the moment either one
+        /// is being constructed. Resolving here instead means the member converter exists before the
+        /// converter it points at, which is what lets a cycle finish building at all.
+        /// </remarks>
+        private ICborConverter<TM> Converter
+            => _converter ??= (ICborConverter<TM>)_memberMapping.Converter!;
         private ReadOnlyMemory<byte> _memberName;
         private int? _memberIndex;
         private readonly TM _defaultValue;
@@ -66,7 +78,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             _memberGetter = GenerateGetter(memberInfo);
             _memberSetter = GenerateSetter(memberInfo);
-            _converter = (ICborConverter<TM>)memberMapping.Converter!;
+            _memberMapping = memberMapping;
             _defaultValue = (TM)memberMapping.DefaultValue!;
             _ignoreIfDefault = memberMapping.IgnoreIfDefault;
             _shouldSerializeMethod = memberMapping.ShouldSerializeMethod;
@@ -89,7 +101,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                 throw new CborException($"No member setter for '{Encoding.UTF8.GetString(_memberName.Span)}'");
             }
 
-            _memberSetter((T)obj, _converter.Read(ref reader));
+            _memberSetter((T)obj, Converter.Read(ref reader));
         }
 
         public void Write(ref CborWriter writer, object obj)
@@ -107,12 +119,12 @@ namespace Dahomey.Cbor.Serialization.Converters
                 throw new CborException($"Property '{Encoding.UTF8.GetString(_memberName.Span)}' cannot be null.");
             }
 
-            _converter.Write(ref writer, value, _lengthMode);
+            Converter.Write(ref writer, value, _lengthMode);
         }
 
         public object Read(ref CborReader reader)
         {
-            return _converter.Read(ref reader)!;
+            return Converter.Read(ref reader)!;
         }
 
         public void Set(object obj, object value)
@@ -206,7 +218,19 @@ namespace Dahomey.Cbor.Serialization.Converters
     {
         private readonly StructMemberGetterDelegate<T, TM>? _memberGetter;
         private readonly StructMemberSetterDelegate<T, TM>? _memberSetter;
-        private readonly ICborConverter<TM> _converter;
+        private readonly IMemberMapping _memberMapping;
+        private ICborConverter<TM>? _converter;
+
+        /// <summary>
+        /// Resolved on first use, not in the constructor.
+        /// </summary>
+        /// <remarks>
+        /// Two types that reference each other cannot both have a converter at the moment either one
+        /// is being constructed. Resolving here instead means the member converter exists before the
+        /// converter it points at, which is what lets a cycle finish building at all.
+        /// </remarks>
+        private ICborConverter<TM> Converter
+            => _converter ??= (ICborConverter<TM>)_memberMapping.Converter!;
         private readonly ReadOnlyMemory<byte> _memberName;
         private readonly TM _defaultValue;
         private readonly bool _ignoreIfDefault;
@@ -233,7 +257,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             MemberIndex = memberMapping.MemberIndex;
             _memberGetter = GenerateGetter(memberInfo);
             _memberSetter = GenerateSetter(memberInfo);
-            _converter = (ICborConverter<TM>)memberMapping.Converter!;
+            _memberMapping = memberMapping;
             _defaultValue = (TM)memberMapping.DefaultValue!;
             _ignoreIfDefault = memberMapping.IgnoreIfDefault;
             _requirementPolicy = memberMapping.RequirementPolicy;
@@ -251,7 +275,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public object Read(ref CborReader reader)
         {
-            return _converter.Read(ref reader)!;
+            return Converter.Read(ref reader)!;
         }
 
         public void Set(object obj, object value)
@@ -279,7 +303,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                 throw new CborException($"No member setter for '{MemberNameAsString}'");
             }
 
-            _memberSetter(ref instance, _converter.Read(ref reader));
+            _memberSetter(ref instance, Converter.Read(ref reader));
         }
 
         public void Write(ref CborWriter writer, ref T instance)
@@ -297,7 +321,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                 throw new CborException($"Property '{MemberNameAsString}' cannot be null.");
             }
 
-            _converter.Write(ref writer, value);
+            Converter.Write(ref writer, value);
         }
 
         public bool ShouldSerialize(ref T instance, Type declaredType)


### PR DESCRIPTION
Two types that reference each other cannot be serialized at all today — the process dies on an uncatchable `StackOverflowException` before any CBOR is written:

```csharp
public class Parent { public string Name { get; set; } public Child Only { get; set; } }
public class Child  { public int Age { get; set; }     public Parent Owner { get; set; } }

Cbor.Serialize(new Parent { Name = "root", Only = new Child { Age = 3 } }, buffer);
```

No cycle in the *data* is needed — `Only.Owner` is null above. The recursion is in building the converter graph, and a plain parent/child model with a back-reference is enough to trigger it.

## Why it happens

A converter resolves its members' converters while it is being constructed, and it is not in `CborConverterRegistry._converters` until that constructor returns. So `Lookup(Parent)` starts building `ObjectConverter<Parent>`, which looks up `Child`, which starts building `ObjectConverter<Child>`, which looks up `Parent` — not registered yet, because its constructor has not returned — and around it goes. `ConcurrentDictionary.GetOrAdd` runs its factory outside the lock, so nothing intervenes.

The existing break covers only the direct `A -> A` case: `MemberMapping<T>.InitializeConverter` reuses the parent converter when a member's type is the type being built. A back-reference through a second type is not covered, and neither is any longer cycle.

This is a different failure from the one bounded by `CborOptions.MaxDepth` in https://github.com/dahomey-technologies/Dahomey.Cbor/pull/155. That one is a write-side recursion over the *data*, on a converter graph that built fine. This one never gets as far as looking at a value.

## What this changes

* `CborConverterRegistry` records which types are being constructed on the current thread, and exposes `IsUnderConstruction`. Thread-static and keyed by `(registry, type)` so two registries do not interfere; the set is empty except while a converter is being built.
* `MemberMapping<T>.InitializeConverter` consults it. If the member's own type is already in flight, it leaves the converter unresolved rather than recursing, and the `Converter` getter completes the lookup on first use — by which time the graph is built.
* `MemberConverter<T, TM>` and `StructMemberConverter<T, TM>` resolve their converter on first use instead of in their constructor. This is the part that actually lets a cycle close: a member converter has to be able to exist before the converter it points at does.

## What it deliberately does not change

* **An actual object-graph cycle (`obj.Property = obj`) still throws.** That is a write-side recursion over the data, bounded by `MaxDepth`, and it stays a `CborException`. Pinned as a test here so the two failure modes do not get conflated later.
* **No wire-format change.** The same converters are chosen for the same types; only the moment of resolution moves.
* **Error timing for a bad `[CborConverter]` on a deferred member.** `VerifyMemberConverterType` still runs, but for a member whose resolution was deferred it runs on first use rather than during construction. This is reachable only in the cycle case — which previously could not be reached at all — so no currently-working code changes behaviour.
* **Nothing about registry thread safety.** Two threads building the same graph still each complete independently, and `GetOrAdd` settles which instance wins, exactly as before.

## Tests

Four new cases in `src/Dahomey.Cbor.Tests/Issues/Issue0149Cycles.cs`: a two-type cycle written and read back, a three-type cycle (nothing in the break may depend on the participants being adjacent), and the object-graph cycle that must still throw.

**All four crash the test host without this change.** That is also why they could not have been added alongside https://github.com/dahomey-technologies/Dahomey.Cbor/pull/152 — a `StackOverflowException` cannot be caught or asserted on, it takes the process with it. It is the same reason https://github.com/dahomey-technologies/Dahomey.Cbor/issues/149 went so long without a test for the case it was originally reported for.

Full suite: 978 passing, green on .NET 8, 9 and 10 — https://github.com/Rafael-SOWNet/Dahomey.Cbor/actions/runs/30959882309

GitHub is holding this PR's own `Build and Test` run for approval (first-time contributor), so that run is from my fork. The branch behind it, `ci-check/cycle-safe-converters`, differs from this PR's head by exactly one commit adding `workflow_dispatch:` to the workflow file; `src/` is byte-identical.

## How I found it

Writing a test for point 4 of your review on https://github.com/dahomey-technologies/Dahomey.Cbor/pull/156 — you asked for defects to be confirmed with a failing test before being acted on, which was good advice. The test did not show the silent mis-binding described there; it took the test host down instead, and the same shape turned out to fail on `master` with no context and no generator anywhere near it.

Cut from `master`, independent of every other open PR.
