### PR TITLE
Stop the read path's probes from consuming semantic tags (split from #157)

### DIFF
--- a/src/Dahomey.Cbor.Tests/SemanticTagProbeTests.cs
+++ b/src/Dahomey.Cbor.Tests/SemanticTagProbeTests.cs
@@ -1,0 +1,293 @@
+﻿using System;
+using System.Collections.Generic;
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Serialization.Converters;
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// A semantic tag in front of a value must survive the read path's probes and reach the
+    /// converter that owns it.
+    /// </summary>
+    /// <remarks>
+    /// Every <see cref="CborReader"/> read entry point begins with <c>SkipSemanticTag()</c>, so for
+    /// converters that ignore tags a probe consuming one is invisible: the value still decodes. It
+    /// stops being invisible as soon as a converter needs to <em>see</em> its tag, which is what
+    /// <see cref="TagObservingConverter"/> does here — it is the smallest thing that can tell the
+    /// difference, and it stands in for any converter decoded from its tag.
+    /// <para>
+    /// Four probes consumed a tag while only meaning to look at one: the null check in
+    /// <c>MemberConverter</c> and <c>StructMemberConverter</c>, the discriminator test in
+    /// <c>ObjectConverter</c>'s Array format, the break checks in <c>MoveNextMapItem</c>,
+    /// <c>ReadArray</c>, <c>SkipArray</c> and <c>SkipMap</c>, and the same break check across the
+    /// tuple converters.
+    /// </para>
+    /// </remarks>
+    public class SemanticTagProbeTests
+    {
+        [CborConverter(typeof(TagObservingConverter))]
+        public class Tagged
+        {
+            public ulong Tag { get; set; }
+            public int Value { get; set; }
+        }
+
+        /// <summary>
+        /// Reads its own semantic tag instead of letting the reader skip it, so a probe that
+        /// consumed the tag shows up as <c>Tag == 0</c> rather than as a decoding failure.
+        /// </summary>
+        public class TagObservingConverter : CborConverterBase<Tagged>
+        {
+            public override Tagged Read(ref CborReader reader)
+            {
+                ulong tag = reader.TryReadSemanticTag(out ulong semanticTag) ? semanticTag : 0;
+
+                return new Tagged { Tag = tag, Value = reader.ReadInt32() };
+            }
+
+            public override void Write(ref CborWriter writer, Tagged value, LengthMode lengthMode)
+            {
+                writer.WriteSemanticTag(value.Tag);
+                writer.WriteInt32(value.Value);
+            }
+        }
+
+        public class Holder
+        {
+            public Tagged Member { get; set; }
+        }
+
+        public struct StructHolder
+        {
+            public Tagged Member { get; set; }
+        }
+
+        /// <summary>
+        /// A string member, so the null case is about the probe rather than about whether the
+        /// member's converter happens to handle null.
+        /// </summary>
+        public class RequiredHolder
+        {
+            [CborRequired(RequirementPolicy.DisallowNull)]
+            public string Member { get; set; }
+        }
+
+        /// <summary>
+        /// The Array object format keys members by position, so every member needs an explicit index.
+        /// </summary>
+        public class ArrayHolder
+        {
+            [CborProperty(0)]
+            public Tagged Member { get; set; }
+        }
+
+        public class IntHolder
+        {
+            public int Value { get; set; }
+        }
+
+        /// <summary>
+        /// The null probe on a class member. This is every object member in the library, so before
+        /// the fix no tag-decoded value could be read back as a member of anything.
+        /// </summary>
+        [Fact]
+        public void AClassMemberKeepsItsSemanticTag()
+        {
+            // a1                     map(1)
+            //    66 4d656d626572     "Member"
+            //    c1                  tag(1)
+            //    05                  5
+            Holder holder = Helper.Read<Holder>("A1664D656D626572C105");
+
+            Assert.Equal(1UL, holder.Member.Tag);
+            Assert.Equal(5, holder.Member.Value);
+        }
+
+        /// <summary>Same probe, struct member path.</summary>
+        [Fact]
+        public void AStructMemberKeepsItsSemanticTag()
+        {
+            StructHolder holder = Helper.Read<StructHolder>("A1664D656D626572C105");
+
+            Assert.Equal(1UL, holder.Member.Tag);
+            Assert.Equal(5, holder.Member.Value);
+        }
+
+        /// <summary>
+        /// The break probe in <c>ReadArray</c>. A break marker is never tagged, so a tag here belongs
+        /// to the next item and must survive.
+        /// </summary>
+        [Fact]
+        public void AnIndefiniteLengthArrayKeepsItemTags()
+        {
+            // 9f            array(*)
+            //    c1 05      tag(1) 5
+            //    c2 06      tag(2) 6
+            // ff            break
+            List<Tagged> items = Cbor.Deserialize<List<Tagged>>("9FC105C206FF".HexToBytes());
+
+            Assert.Equal(2, items.Count);
+            Assert.Equal(1UL, items[0].Tag);
+            Assert.Equal(5, items[0].Value);
+            Assert.Equal(2UL, items[1].Tag);
+            Assert.Equal(6, items[1].Value);
+        }
+
+        /// <summary>The break probe in <c>MoveNextMapItem</c>, on an indefinite-length map.</summary>
+        [Fact]
+        public void AnIndefiniteLengthMapKeepsValueTags()
+        {
+            // bf                     map(*)
+            //    66 4d656d626572     "Member"
+            //    c1 05               tag(1) 5
+            // ff                     break
+            Holder holder = Helper.Read<Holder>("BF664D656D626572C105FF");
+
+            Assert.Equal(1UL, holder.Member.Tag);
+            Assert.Equal(5, holder.Member.Value);
+        }
+
+        /// <summary>
+        /// A definite-length array of tagged items, so the fix is not only about the break probe.
+        /// </summary>
+        [Fact]
+        public void ADefiniteLengthArrayKeepsItemTags()
+        {
+            List<Tagged> items = Cbor.Deserialize<List<Tagged>>("82C105C206".HexToBytes());
+
+            Assert.Equal(2, items.Count);
+            Assert.Equal(1UL, items[0].Tag);
+            Assert.Equal(2UL, items[1].Tag);
+        }
+
+        /// <summary>
+        /// <c>ObjectConverter</c>'s Array format tested for the discriminator tag and discarded
+        /// whatever it found. A tag that is not the discriminator tag belongs to the first item.
+        /// </summary>
+        [Fact]
+        public void ArrayFormatKeepsATagOnTheFirstItemWhenItIsNotTheDiscriminator()
+        {
+            CborOptions options = new CborOptions { ObjectFormat = CborObjectFormat.Array };
+
+            // 81            array(1)
+            //    c1 05      tag(1) 5      <- tag 1, not the discriminator tag (39)
+            ArrayHolder holder = Helper.Read<ArrayHolder>("81C105", options);
+
+            Assert.Equal(1UL, holder.Member.Tag);
+            Assert.Equal(5, holder.Member.Value);
+        }
+
+        public class TupleHolder
+        {
+            public (int, int) T { get; set; }
+        }
+
+        /// <summary>
+        /// A tagged tuple must stay readable. This one guards against a regression introduced by
+        /// this change rather than a bug on master.
+        /// </summary>
+        /// <remarks>
+        /// <c>TupleConverter</c> is the only converter that reaches the reader below its
+        /// tag-skipping entry points -- <c>Read</c> opens with <c>ReadSize()</c>, which inspects the
+        /// header directly -- so it relied on the member null probe consuming the tag on its behalf.
+        /// Once that probe stopped consuming, the tag byte's low five bits were read as the array
+        /// size and the arity check fired. Each arity now skips its own tag.
+        /// </remarks>
+        [Fact]
+        public void ATaggedTupleIsStillReadable()
+        {
+            // a1              map(1)
+            //    61 54        "T"
+            //    c1           tag(1)
+            //    82 01 02     [1, 2]
+            TupleHolder holder = Helper.Read<TupleHolder>("A16154C1820102");
+
+            Assert.Equal((1, 2), holder.T);
+        }
+
+        /// <summary>
+        /// The tuple converters ran the same break probe once per arity.
+        /// </summary>
+        [Fact]
+        public void ATupleKeepsItemTags()
+        {
+            (Tagged, Tagged) pair = Cbor.Deserialize<(Tagged, Tagged)>("82C105C206".HexToBytes());
+
+            Assert.Equal(1UL, pair.Item1.Tag);
+            Assert.Equal(2UL, pair.Item2.Tag);
+        }
+
+        /// <summary>
+        /// Writing is unchanged: the tag is emitted by the converter exactly as before, and the
+        /// probes were only ever on the read side.
+        /// </summary>
+        [Fact]
+        public void WritingIsUnaffected()
+        {
+            Holder holder = new Holder { Member = new Tagged { Tag = 1, Value = 5 } };
+
+            Helper.TestWrite(holder, "A1664D656D626572C105");
+        }
+
+        /// <summary>
+        /// The one behaviour that does change, pinned deliberately.
+        /// </summary>
+        /// <remarks>
+        /// The null probe inspects the header rather than skipping tags, so a null behind a semantic
+        /// tag no longer reads as null to the probe. The value is unaffected — the member's converter
+        /// calls <c>ReadNull()</c>, which skips the tag and yields null — but
+        /// <see cref="RequirementPolicy.DisallowNull"/> no longer rejects this one shape. The
+        /// alternative is a bookmark copy on every member of every object read, which is a cost paid
+        /// by everyone to reject a value almost nobody writes.
+        /// </remarks>
+        [Fact]
+        public void ATaggedNullIsNotRejectedByDisallowNull()
+        {
+            // a1                     map(1)
+            //    66 4d656d626572     "Member"
+            //    c1                  tag(1)
+            //    f6                  null
+            // a1                     map(1)
+            //    66 4d656d626572     "Member"
+            //    c1                  tag(1)
+            //    f6                  null
+            RequiredHolder holder = Cbor.Deserialize<RequiredHolder>(
+                "A1664D656D626572C1F6".HexToBytes());
+
+            Assert.Null(holder.Member);
+        }
+
+        /// <summary>An untagged null is still rejected, which is the case that matters.</summary>
+        [Fact]
+        public void AnUntaggedNullIsStillRejectedByDisallowNull()
+        {
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<RequiredHolder>("A1664D656D626572F6".HexToBytes()));
+        }
+
+        /// <summary>
+        /// Nested semantic tags do not work, on this branch or on master, and this change neither
+        /// fixes nor worsens them.
+        /// </summary>
+        /// <remarks>
+        /// <c>GetCurrentDataItemType</c>'s <c>case SemanticTag: Advance(1); return
+        /// GetCurrentDataItemType();</c> advances a second time after <c>GetHeader()</c> has already
+        /// consumed the header byte, so the recursion skips the tag byte and the byte after it. The
+        /// case is pinned here so that fixing it later is a deliberate change to a stated
+        /// expectation rather than a silent one.
+        /// </remarks>
+        [Fact]
+        public void NestedSemanticTagsAreNotSupported()
+        {
+            // a1                  map(1)
+            //    65 56616c7565    "Value"
+            //    c1 c0            tag(1) tag(0)
+            //    01               1
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<IntHolder>("A16556616C7565C1C001".HexToBytes()));
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/SemanticTagProbeTests.cs
+++ b/src/Dahomey.Cbor.Tests/SemanticTagProbeTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.ObjectModel;
 using Dahomey.Cbor.Serialization;
 using Dahomey.Cbor.Serialization.Converters;
 using Dahomey.Cbor.Tests.Extensions;
@@ -84,6 +85,46 @@ namespace Dahomey.Cbor.Tests
             public Tagged Member { get; set; }
         }
 
+        /// <summary>
+        /// Array format again, but part of a discriminated hierarchy, which is what actually reaches
+        /// the bookmark in <c>ObjectConverter</c>: its Array case runs only when
+        /// <c>DiscriminatorConventionRegistry.GetConvention</c> returns a convention for the type
+        /// being read, and it returns null for a type with no discriminator.
+        /// </summary>
+        /// <remarks>
+        /// Member indexes start at 1 because index 0 is the discriminator's slot.
+        /// </remarks>
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class TaggedArrayBase
+        {
+            [CborProperty(1)]
+            public Tagged Member { get; set; }
+        }
+
+        [CborDiscriminator("derived")]
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class TaggedArrayDerived : TaggedArrayBase
+        {
+            [CborProperty(2)]
+            public int Extra { get; set; }
+        }
+
+        /// <summary>
+        /// A <see cref="CborValue"/> member, which is the shape that makes the <c>undefined</c> probe
+        /// observable: its converter accepts the primitive, so nothing downstream re-raises the
+        /// requirement. A member typed <c>string</c> would fail in its own converter either way.
+        /// </summary>
+        public class RequiredValueHolder
+        {
+            [CborRequired(RequirementPolicy.DisallowNull)]
+            public CborValue Member { get; set; }
+        }
+
+        public class ValueHolder
+        {
+            public CborValue Member { get; set; }
+        }
+
         public class IntHolder
         {
             public int Value { get; set; }
@@ -164,11 +205,11 @@ namespace Dahomey.Cbor.Tests
         }
 
         /// <summary>
-        /// <c>ObjectConverter</c>'s Array format tested for the discriminator tag and discarded
-        /// whatever it found. A tag that is not the discriminator tag belongs to the first item.
+        /// Array format with no discriminator anywhere, which leaves <c>ObjectConverter</c>'s Array
+        /// case unentered and so covers the member probe alone.
         /// </summary>
         [Fact]
-        public void ArrayFormatKeepsATagOnTheFirstItemWhenItIsNotTheDiscriminator()
+        public void ArrayFormatKeepsAFirstItemTagWithoutADiscriminator()
         {
             CborOptions options = new CborOptions { ObjectFormat = CborObjectFormat.Array };
 
@@ -178,6 +219,32 @@ namespace Dahomey.Cbor.Tests
 
             Assert.Equal(1UL, holder.Member.Tag);
             Assert.Equal(5, holder.Member.Value);
+        }
+
+        /// <summary>
+        /// <c>ObjectConverter</c>'s Array format tests for the discriminator tag and previously
+        /// discarded whatever it found. A tag that is not the discriminator tag belongs to the first
+        /// item, so it is returned to the reader.
+        /// </summary>
+        /// <remarks>
+        /// Registering the discriminator is what makes this test bind: it is the condition on the
+        /// whole <c>case CborObjectFormat.Array:</c> block. The document then deliberately carries no
+        /// discriminator, so the tag the block finds is the member's.
+        /// </remarks>
+        [Fact]
+        public void ArrayFormatKeepsAFirstItemTagWhenADiscriminatorIsExpected()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<TaggedArrayDerived>();
+
+            // 82            array(2)
+            //    c1 05      tag(1) 5      <- tag 1, not the discriminator tag (39)
+            //    07         7
+            TaggedArrayDerived holder = Helper.Read<TaggedArrayDerived>("82C10507", options);
+
+            Assert.Equal(1UL, holder.Member.Tag);
+            Assert.Equal(5, holder.Member.Value);
+            Assert.Equal(7, holder.Extra);
         }
 
         public class TupleHolder
@@ -250,10 +317,6 @@ namespace Dahomey.Cbor.Tests
             //    66 4d656d626572     "Member"
             //    c1                  tag(1)
             //    f6                  null
-            // a1                     map(1)
-            //    66 4d656d626572     "Member"
-            //    c1                  tag(1)
-            //    f6                  null
             RequiredHolder holder = Cbor.Deserialize<RequiredHolder>(
                 "A1664D656D626572C1F6".HexToBytes());
 
@@ -269,15 +332,63 @@ namespace Dahomey.Cbor.Tests
         }
 
         /// <summary>
+        /// <c>undefined</c> is rejected by the same policy, because
+        /// <see cref="CborReader.GetCurrentDataItemType"/> reports both <c>Null</c> and
+        /// <c>Undefined</c> as <see cref="CborDataItemType.Null"/> and the probe replacing it has to
+        /// agree.
+        /// </summary>
+        /// <remarks>
+        /// Matching only <c>Null</c> would not reword this failure but remove it:
+        /// <c>CborValueConverter</c> maps <c>F7</c> to <c>CborValue.Null</c>, which is a non-null
+        /// reference, so no later check re-raises the requirement.
+        /// </remarks>
+        [Fact]
+        public void AnUndefinedMemberIsRejectedByDisallowNull()
+        {
+            // a1                     map(1)
+            //    66 4d656d626572     "Member"
+            //    f7                  undefined
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<RequiredValueHolder>("A1664D656D626572F7".HexToBytes()));
+
+            Assert.Equal("Property 'Member' cannot be null.", exception.Message);
+        }
+
+        /// <summary>The same byte without the policy reads as before.</summary>
+        [Fact]
+        public void AnUndefinedMemberReadsWhenThePolicyAllowsIt()
+        {
+            ValueHolder holder = Helper.Read<ValueHolder>("A1664D656D626572F7");
+
+            Assert.Equal(CborValueType.Null, holder.Member.Type);
+        }
+
+        /// <summary>
+        /// Behind a tag, <c>undefined</c> is exempt for exactly the reason a tagged null is: the probe
+        /// sees the tag's header, not the primitive behind it.
+        /// </summary>
+        [Fact]
+        public void ATaggedUndefinedIsNotRejectedByDisallowNull()
+        {
+            // a1                     map(1)
+            //    66 4d656d626572     "Member"
+            //    c1                  tag(1)
+            //    f7                  undefined
+            RequiredValueHolder holder = Cbor.Deserialize<RequiredValueHolder>(
+                "A1664D656D626572C1F7".HexToBytes());
+
+            Assert.Equal(CborValueType.Null, holder.Member.Type);
+        }
+
+        /// <summary>
         /// Nested semantic tags do not work, on this branch or on master, and this change neither
         /// fixes nor worsens them.
         /// </summary>
         /// <remarks>
-        /// <c>GetCurrentDataItemType</c>'s <c>case SemanticTag: Advance(1); return
-        /// GetCurrentDataItemType();</c> advances a second time after <c>GetHeader()</c> has already
-        /// consumed the header byte, so the recursion skips the tag byte and the byte after it. The
-        /// case is pinned here so that fixing it later is a deliberate change to a stated
-        /// expectation rather than a silent one.
+        /// A read entry point opens with a single <c>SkipSemanticTag()</c>, so the second tag arrives
+        /// where a data item is expected. The message is asserted rather than just the type: it is
+        /// what says the failure is the second tag being met as a value, so a future change that makes
+        /// nested tags work, or that breaks the first tag instead, cannot leave this test green.
         /// </remarks>
         [Fact]
         public void NestedSemanticTagsAreNotSupported()
@@ -286,8 +397,10 @@ namespace Dahomey.Cbor.Tests
             //    65 56616c7565    "Value"
             //    c1 c0            tag(1) tag(0)
             //    01               1
-            Assert.Throws<CborException>(
+            CborException exception = Assert.Throws<CborException>(
                 () => Cbor.Deserialize<IntHolder>("A16556616C7565C1C001".HexToBytes()));
+
+            Assert.Equal("[9] Invalid major type SemanticTag", exception.Message);
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -251,7 +251,8 @@ namespace Dahomey.Cbor.Serialization
         }
 
         /// <summary>
-        /// Reports whether the next data item is the null primitive.
+        /// Reports whether the next data item is the null primitive, or <c>undefined</c>, which
+        /// <see cref="GetCurrentDataItemType"/> also reports as <see cref="CborDataItemType.Null"/>.
         /// </summary>
         /// <remarks>
         /// Like <see cref="IsBreak"/>, this inspects the header and skips nothing:
@@ -269,7 +270,8 @@ namespace Dahomey.Cbor.Serialization
         /// semantic tag reads as a tag rather than as null, so the probe does not see it. The value's
         /// converter still calls <c>ReadNull()</c>, which skips the tag and yields null, so the value
         /// is unaffected -- but <see cref="RequirementPolicy.DisallowNull"/> no longer rejects that
-        /// one exotic shape. Pinned by <c>ATaggedNullIsNotRejectedByDisallowNull</c>.
+        /// one exotic shape. Pinned by <c>ATaggedNullIsNotRejectedByDisallowNull</c> and
+        /// <c>ATaggedUndefinedIsNotRejectedByDisallowNull</c>.
         /// </para>
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -277,7 +279,8 @@ namespace Dahomey.Cbor.Serialization
         {
             CborReaderHeader header = GetHeader();
 
-            return header.MajorType == CborMajorType.Primitive && header.Primitive == CborPrimitive.Null;
+            return header.MajorType == CborMajorType.Primitive
+                && (header.Primitive == CborPrimitive.Null || header.Primitive == CborPrimitive.Undefined);
         }
 
         public CborReaderBookmark GetBookmark()

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -232,6 +232,54 @@ namespace Dahomey.Cbor.Serialization
             }
         }
 
+        /// <summary>
+        /// Reports whether the next data item is the break marker that terminates an
+        /// indefinite-length array or map.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately does not skip a semantic tag: a break marker is never tagged, so a tag here
+        /// belongs to the next item and has to survive for that item's converter. A typed array is
+        /// decoded from its RFC 8746 tag, so consuming it would make an indefinite-length container
+        /// of typed arrays unreadable.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool IsBreak()
+        {
+            CborReaderHeader header = GetHeader();
+
+            return header.MajorType == CborMajorType.Primitive && header.Primitive == CborPrimitive.Break;
+        }
+
+        /// <summary>
+        /// Reports whether the next data item is the null primitive.
+        /// </summary>
+        /// <remarks>
+        /// Like <see cref="IsBreak"/>, this inspects the header and skips nothing:
+        /// <see cref="GetCurrentDataItemType"/> begins with <c>SkipSemanticTag()</c>, so a caller that
+        /// only wants to look - a member probing for null - would consume a tag the value's own
+        /// converter still needs.
+        /// <para>
+        /// It is deliberately not a bookmark-and-rewind. This runs once per member of every object
+        /// read, and <see cref="CborReaderBookmark"/> carries a span, a sequence and a
+        /// <c>SequenceReader</c>: copying that twice per member is a cost paid by every caller,
+        /// including those who never encounter a semantic tag.
+        /// </para>
+        /// <para>
+        /// One consequence, which is the reason this is not simply equivalent: a null behind a
+        /// semantic tag reads as a tag rather than as null, so the probe does not see it. The value's
+        /// converter still calls <c>ReadNull()</c>, which skips the tag and yields null, so the value
+        /// is unaffected -- but <see cref="RequirementPolicy.DisallowNull"/> no longer rejects that
+        /// one exotic shape. Pinned by <c>ATaggedNullIsNotRejectedByDisallowNull</c>.
+        /// </para>
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool IsNull()
+        {
+            CborReaderHeader header = GetHeader();
+
+            return header.MajorType == CborMajorType.Primitive && header.Primitive == CborPrimitive.Null;
+        }
+
         public CborReaderBookmark GetBookmark()
         {
             CborReaderBookmark bookmark;
@@ -643,7 +691,7 @@ namespace Dahomey.Cbor.Serialization
 
         public bool MoveNextMapItem(ref int remainingItemCount)
         {
-            if (remainingItemCount == 0 || remainingItemCount < 0 && GetCurrentDataItemType() == CborDataItemType.Break)
+            if (remainingItemCount == 0 || remainingItemCount < 0 && IsBreak())
             {
                 return false;
             }
@@ -662,7 +710,7 @@ namespace Dahomey.Cbor.Serialization
 
             arrayReader.ReadBeginArray(size, ref context);
 
-            while (size > 0 || size < 0 && GetCurrentDataItemType() != CborDataItemType.Break)
+            while (size > 0 || size < 0 && !IsBreak())
             {
                 arrayReader.ReadArrayItem(ref this, ref context);
                 size--;
@@ -1049,7 +1097,7 @@ namespace Dahomey.Cbor.Serialization
         {
             int size = ReadSize();
 
-            while (size > 0 || size < 0 && GetCurrentDataItemType() != CborDataItemType.Break)
+            while (size > 0 || size < 0 && !IsBreak())
             {
                 SkipDataItem();
                 size--;
@@ -1063,7 +1111,7 @@ namespace Dahomey.Cbor.Serialization
         {
             int size = ReadSize();
 
-            while (size > 0 || size < 0 && GetCurrentDataItemType() != CborDataItemType.Break)
+            while (size > 0 || size < 0 && !IsBreak())
             {
                 SkipDataItem();
                 SkipDataItem();

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
@@ -88,7 +88,9 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public void Read(ref CborReader reader, object obj)
         {
-            if (reader.GetCurrentDataItemType() == CborDataItemType.Null)
+            // Inspect rather than read: this only asks whether the member is null, and the member's
+            // own converter may still need the semantic tag that sits in front of the value.
+            if (reader.IsNull())
             {
                 if (_requirementPolicy == RequirementPolicy.DisallowNull || _requirementPolicy == RequirementPolicy.Always)
                 {
@@ -290,7 +292,9 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public void Read(ref CborReader reader, ref T instance)
         {
-            if (reader.GetCurrentDataItemType() == CborDataItemType.Null)
+            // Inspect rather than read: this only asks whether the member is null, and the member's
+            // own converter may still need the semantic tag that sits in front of the value.
+            if (reader.IsNull())
             {
                 if (_requirementPolicy == RequirementPolicy.DisallowNull || _requirementPolicy == RequirementPolicy.Always)
                 {

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -598,30 +598,38 @@ namespace Dahomey.Cbor.Serialization.Converters
                                 break;
                             case CborObjectFormat.Array:
                             default:
-                                // discriminator is always the first item
-                                // we need a Semantic Tag to check if the discriminator is present
-                                if (reader.TryReadSemanticTag(out ulong semanticTag) && semanticTag == _options.DiscriminatorSemanticTag)
                                 {
-                                    // discriminator value
-                                    Type actualType = _discriminatorConvention.ReadDiscriminator(ref reader);
+                                    // discriminator is always the first item
+                                    // we need a Semantic Tag to check if the discriminator is present
+                                    CborReaderBookmark bookmark = reader.GetBookmark();
 
-                                    if (!_objectMapping.ObjectType.IsAssignableFrom(actualType))
+                                    if (reader.TryReadSemanticTag(out ulong semanticTag) && semanticTag == _options.DiscriminatorSemanticTag)
                                     {
-                                        throw new CborException($"expected type {_objectMapping.ObjectType} is not assignable from actual type {actualType}");
+                                        // discriminator value
+                                        Type actualType = _discriminatorConvention.ReadDiscriminator(ref reader);
+
+                                        if (!_objectMapping.ObjectType.IsAssignableFrom(actualType))
+                                        {
+                                            throw new CborException($"expected type {_objectMapping.ObjectType} is not assignable from actual type {actualType}");
+                                        }
+
+                                        context.converter = (IObjectConverter<T>)_registry.ConverterRegistry.Lookup(actualType);
+                                        ICreatorMapping? creatorMapping = context.converter.ObjectMapping.CreatorMapping;
+                                        context.creatorValuesByIndex = creatorMapping != null ? new() : null;
+                                        context.regularValuesByIndex = creatorMapping != null ? new() : null;
+                                    }
+                                    else
+                                    {
+                                        // Any tag read here was not the discriminator tag, so it belongs to the
+                                        // first item and must survive for that item's own converter — an RFC 8746
+                                        // typed array is decoded from its tag.
+                                        reader.ReturnToBookmark(bookmark);
+                                        context.converter = this;
                                     }
 
-                                    context.converter = (IObjectConverter<T>)_registry.ConverterRegistry.Lookup(actualType);
-                                    ICreatorMapping? creatorMapping = context.converter.ObjectMapping.CreatorMapping;
-                                    context.creatorValuesByIndex = creatorMapping != null ? new() : null;
-                                    context.regularValuesByIndex = creatorMapping != null ? new() : null;
+                                    // increment to skip discriminator index even when the semantic tag is not present
+                                    context.memberIndex++;
                                 }
-                                else
-                                {
-                                    context.converter = this;
-                                }
-
-                                // increment to skip discriminator index even when the semantic tag is not present
-                                context.memberIndex++;
                                 break;
                         }
                     }

--- a/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
@@ -331,7 +331,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             if (size == -1 && reader.IsBreak())
             {
-                throw new CborException("Expected CBOR Array of size 5");
+                throw new CborException("Expected CBOR Array of size 6");
             }
             T5 item5 = _item5Converter.Read(ref reader);
 

--- a/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
@@ -15,6 +15,11 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public override (T1, T2) Read(ref CborReader reader)
         {
+            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
+            // the reader below its tag-skipping entry points. Skip it here so a tagged tuple
+            // stays readable; the tag itself carries no information this converter needs.
+            reader.TryReadSemanticTag(out _);
+
             int size = reader.ReadSize();
 
             if (size != -1 && size != 2)
@@ -22,13 +27,13 @@ namespace Dahomey.Cbor.Serialization.Converters
                 throw new CborException("Expected CBOR Array of size 2");
             }
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 2");
             }
             T1 item1 = _item1Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 2");
             }
@@ -66,6 +71,11 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public override (T1, T2, T3) Read(ref CborReader reader)
         {
+            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
+            // the reader below its tag-skipping entry points. Skip it here so a tagged tuple
+            // stays readable; the tag itself carries no information this converter needs.
+            reader.TryReadSemanticTag(out _);
+
             int size = reader.ReadSize();
 
             if (size != -1 && size != 3)
@@ -73,19 +83,19 @@ namespace Dahomey.Cbor.Serialization.Converters
                 throw new CborException("Expected CBOR Array of size 3");
             }
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 3");
             }
             T1 item1 = _item1Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 3");
             }
             T2 item2 = _item2Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 3");
             }
@@ -126,6 +136,11 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public override (T1, T2, T3, T4) Read(ref CborReader reader)
         {
+            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
+            // the reader below its tag-skipping entry points. Skip it here so a tagged tuple
+            // stays readable; the tag itself carries no information this converter needs.
+            reader.TryReadSemanticTag(out _);
+
             int size = reader.ReadSize();
 
             if (size != -1 && size != 4)
@@ -133,25 +148,25 @@ namespace Dahomey.Cbor.Serialization.Converters
                 throw new CborException("Expected CBOR Array of size 4");
             }
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 4");
             }
             T1 item1 = _item1Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 4");
             }
             T2 item2 = _item2Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 4");
             }
             T3 item3 = _item3Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 4");
             }
@@ -195,6 +210,11 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public override (T1, T2, T3, T4, T5) Read(ref CborReader reader)
         {
+            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
+            // the reader below its tag-skipping entry points. Skip it here so a tagged tuple
+            // stays readable; the tag itself carries no information this converter needs.
+            reader.TryReadSemanticTag(out _);
+
             int size = reader.ReadSize();
 
             if (size != -1 && size != 5)
@@ -202,31 +222,31 @@ namespace Dahomey.Cbor.Serialization.Converters
                 throw new CborException("Expected CBOR Array of size 5");
             }
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 5");
             }
             T1 item1 = _item1Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 5");
             }
             T2 item2 = _item2Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 5");
             }
             T3 item3 = _item3Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 5");
             }
             T4 item4 = _item4Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 5");
             }
@@ -273,6 +293,11 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public override (T1, T2, T3, T4, T5, T6) Read(ref CborReader reader)
         {
+            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
+            // the reader below its tag-skipping entry points. Skip it here so a tagged tuple
+            // stays readable; the tag itself carries no information this converter needs.
+            reader.TryReadSemanticTag(out _);
+
             int size = reader.ReadSize();
 
             if (size != -1 && size != 6)
@@ -280,37 +305,37 @@ namespace Dahomey.Cbor.Serialization.Converters
                 throw new CborException("Expected CBOR Array of size 6");
             }
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 6");
             }
             T1 item1 = _item1Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 6");
             }
             T2 item2 = _item2Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 6");
             }
             T3 item3 = _item3Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 6");
             }
             T4 item4 = _item4Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 5");
             }
             T5 item5 = _item5Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 6");
             }
@@ -360,6 +385,11 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public override (T1, T2, T3, T4, T5, T6, T7) Read(ref CborReader reader)
         {
+            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
+            // the reader below its tag-skipping entry points. Skip it here so a tagged tuple
+            // stays readable; the tag itself carries no information this converter needs.
+            reader.TryReadSemanticTag(out _);
+
             int size = reader.ReadSize();
 
             if (size != -1 && size != 7)
@@ -367,43 +397,43 @@ namespace Dahomey.Cbor.Serialization.Converters
                 throw new CborException("Expected CBOR Array of size 7");
             }
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
             T1 item1 = _item1Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
             T2 item2 = _item2Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
             T3 item3 = _item3Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
             T4 item4 = _item4Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
             T5 item5 = _item5Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
             T6 item6 = _item6Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
@@ -455,6 +485,11 @@ namespace Dahomey.Cbor.Serialization.Converters
         }
         public override (T1, T2, T3, T4, T5, T6, T7, T8) Read(ref CborReader reader)
         {
+            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
+            // the reader below its tag-skipping entry points. Skip it here so a tagged tuple
+            // stays readable; the tag itself carries no information this converter needs.
+            reader.TryReadSemanticTag(out _);
+
             int size = reader.ReadSize();
 
             if (size != -1 && size != 8)
@@ -462,50 +497,50 @@ namespace Dahomey.Cbor.Serialization.Converters
                 throw new CborException("Expected CBOR Array of size 8");
             }
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
             T1 item1 = _item1Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
             T2 item2 = _item2Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
             T3 item3 = _item3Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
             T4 item4 = _item4Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
             T5 item5 = _item5Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
             T6 item6 = _item6Converter.Read(ref reader);
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
             T7 item7 = _item7Converter.Read(ref reader);
 
 
-            if (size == -1 && reader.GetCurrentDataItemType() == CborDataItemType.Break)
+            if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }


### PR DESCRIPTION
This is the read-path half of #157, split out as you asked, with the B4 fix included. It stands on its own: no typed arrays, no new public API, no change to written bytes in any configuration.

## What it claims

Four probes in the read path call a *read* entry point to decide what comes next. Every read entry point begins with `SkipSemanticTag()`, so each of those probes consumes a tag that belongs to the value behind it. This stops that.

It does **not** change nested-tag behaviour, in either direction. Nested semantic tags are unsupported before and after; `NestedSemanticTagsAreNotSupported` records that rather than leaving it undiscovered.

Nothing in the library depended on the old behaviour, because the invariant that hides it is real: a tag left in front of a value is harmless, since each converter skips its own. It only becomes a bug once a converter must *see* its own tag — which is what #157 needs, and why this is separable from it.

| Probe | Was | Now |
|---|---|---|
| `MemberConverter.Read`, `StructMemberConverter.Read` — null check | `GetCurrentDataItemType()` | `IsNull()` |
| `MoveNextMapItem`, `ReadArray`, `SkipArray`, `SkipMap`, and 35 sites in `TupleConverter` — break check | `GetCurrentDataItemType()` | `IsBreak()` |
| `ObjectConverter`, `CborObjectFormat.Array` — discriminator tag test | `TryReadSemanticTag`, result discarded | non-discriminator tag returned to the reader |
| `TupleConverter` — a tuple's own tag | failed on it | skips it |

`IsNull()` and `IsBreak()` are `internal` header inspections that skip nothing. `IsNull()` matches `undefined` as well as `null`, because `GetCurrentDataItemType()` reports both as `CborDataItemType.Null` and the probe replacing it has to agree.

## B4 — measured

You asked for a number rather than an assurance, and it turned out to matter more than I expected.

`IsNull()` is deliberately not a bookmark-and-rewind. It runs once per member of every object read, and `CborReaderBookmark` carries a `ReadOnlySpan<byte>`, a `ReadOnlySequence<byte>?` and a `SequenceReader<byte>` — copying that twice per member is a cost every caller pays, including those who never meet a semantic tag.

net10.0 Release, 1M deserializations of a six-member class, minimum of seven measured passes after a 200k warmup (CoreCLR tier-0 code is unoptimised, so a short warmup measures the wrong thing):

| Member null probe | ns/object | ns/member | vs. `master` |
|---|--:|--:|--:|
| `master`, `GetCurrentDataItemType()` | 324–330 | ~54 | — |
| bookmark-and-rewind | 464–467 | ~77 | **+43%** |
| `IsNull()`, as written here | 315–316 | ~53 | **−3%** |

The bookmark costs ~43% of object deserialization. `IsNull()` removes it and lands marginally *under* `master`, because it also skips the `SkipSemanticTag()` call that `GetCurrentDataItemType()` performs.

The one remaining bookmark is `ObjectConverter`'s discriminator probe, which is once per object and only in `CborObjectFormat.Array` — not a per-member cost.

## What changes behaviour

**One value shape.** A null or `undefined` behind a semantic tag no longer registers with the member probe, so `RequirementPolicy.DisallowNull` does not reject that shape. The value is unaffected: the member's own converter calls `ReadNull()`, which skips the tag and yields null. Pinned by `ATaggedNullIsNotRejectedByDisallowNull` and `ATaggedUndefinedIsNotRejectedByDisallowNull`, with `AnUntaggedNullIsStillRejectedByDisallowNull` and `AnUndefinedMemberIsRejectedByDisallowNull` alongside them for the ordinary cases.

**Malformed input inside an indefinite-length container fails later, and differently.** `GetCurrentDataItemType()` throws `Primitive not supported` for primitives it has no mapping for, such as a bare `SimpleValue`; `IsBreak()` returns false and defers to the item's own converter. The document is still rejected, but by a different call and with a different message. Probably an improvement — the error now names what the converter expected — but it is a change, not a no-op.

**`MoveNextMapItem` is `public`.** Its tag-consumption behaviour changes for external callers who drive the reader themselves, not only for the library's own converters. Nothing else on the public surface moves.

## Tests

`SemanticTagProbeTests.cs`, 16 cases: class and struct members, definite- and indefinite-length arrays and maps, `Array` object format with a non-discriminator tag on the first item both with and without a discriminator registered, tagged tuples, tuple item tags, all four `DisallowNull` shapes (`null` and `undefined`, tagged and not), nested tags, and that writing is unaffected. 1088 → 1104 on net10.0; all four TFMs build.

Two of them fail without the source change and would not have without care:

* `ArrayFormatKeepsAFirstItemTagWhenADiscriminatorIsExpected` is the one that reaches the `ObjectConverter` bookmark. The whole `case CborObjectFormat.Array:` block runs only when `DiscriminatorConventionRegistry.GetConvention` returns a convention for the type being read, so `ArrayFormatKeepsAFirstItemTagWithoutADiscriminator` — which is the same shape on an undiscriminated type — passes with that hunk reverted, on the `MemberConverter` fix alone. Both are kept, and the names now say which path each covers.
* `AnUndefinedMemberIsRejectedByDisallowNull` fails if `IsNull()` matches only `Null`. That is a lost check rather than a changed message: `CborValueConverter` maps `F7` to `CborValue.Null`, a non-null reference, so `MemberConverter.Write`'s later null check never sees it either.

`NestedSemanticTagsAreNotSupported` now asserts the message, not just the exception type — otherwise any unrelated regression that throws keeps it green.

Also included, since it is on lines this touches: `Tuple6Converter`'s T5 break check said `Expected CBOR Array of size 5`, the one arity message in that file naming the wrong size. Pre-existing on `master`.

## CI

Green on this head, upstream, on .NET 8, 9 and 10 — 1104 tests on each:

https://github.com/dahomey-technologies/Dahomey.Cbor/actions/runs/31081457392

Rebased onto `master` at `563273f`, so that run is against the tree with #158 and #160 in it. No conflicts.

---

Once this lands I'll rebase #157 on top; what remains there is B1 and B5, plus the B2 README item.
