### PR TITLE
Consume an undefined (0xF7) read into a CborValue, closes #163

### DIFF
--- a/src/Dahomey.Cbor.Tests/Issues/Issue0163.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0163.cs
@@ -1,0 +1,126 @@
+using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Tests.Extensions;
+using System;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #163: an <c>undefined</c> (<c>F7</c>) read into a <see cref="CborValue"/> was reported as
+    /// read without being consumed, so the rest of its container was decoded from a stale header.
+    /// </summary>
+    /// <remarks>
+    /// <c>GetCurrentDataItemType</c> maps both <c>Null</c> and <c>Undefined</c> to
+    /// <see cref="CborDataItemType.Null"/>, but <c>ReadNull()</c> accepts only <c>F6</c>: for <c>F7</c>
+    /// it returns false having advanced nothing, while the header byte has already been read into the
+    /// reader's cache. <c>CborValueConverter</c> returned <see cref="CborValue.Null"/> regardless, so
+    /// the next read was handed that same cached <c>F7</c> header back.
+    /// <para>
+    /// It is invisible when the <c>undefined</c> is its container's last item, which is why the
+    /// existing coverage did not catch it — the container's item count runs out before anything looks
+    /// again. <see cref="AnUndefinedAsTheLastItemWasNeverAffected"/> pins that case so a future change
+    /// cannot quietly break the shape that always worked.
+    /// </para>
+    /// </remarks>
+    public class Issue0163
+    {
+        public class Holder
+        {
+            public CborValue A { get; set; }
+            public int B { get; set; }
+        }
+
+        /// <summary>
+        /// The silent one: no exception, and a document that decodes to something else entirely.
+        /// </summary>
+        [Fact]
+        public void AnUndefinedInAMapDoesNotSwallowTheFollowingPair()
+        {
+            // a2                  map(2)
+            //    61 41            "A"
+            //    f7               undefined
+            //    61 42            "B"
+            //    01               1
+            CborObject obj = Cbor.Deserialize<CborObject>("A26141F7614201".HexToBytes());
+
+            Assert.Equal(2, obj.Count);
+            Assert.Equal(CborValueType.Null, obj["A"].Type);
+            Assert.Equal(1, obj["B"].Value<int>());
+        }
+
+        /// <summary>
+        /// The same document into a POCO, where the stale header reached <c>ReadRawString</c> and threw
+        /// about the member <em>after</em> the undefined one.
+        /// </summary>
+        [Fact]
+        public void AnUndefinedMemberDoesNotBreakTheFollowingMember()
+        {
+            Holder holder = Cbor.Deserialize<Holder>("A26141F7614201".HexToBytes());
+
+            Assert.Equal(CborValueType.Null, holder.A.Type);
+            Assert.Equal(1, holder.B);
+        }
+
+        /// <summary>
+        /// The indefinite-length form failed differently again: the stale header was re-read as another
+        /// null key, and the duplicate collided in the backing dictionary as an
+        /// <see cref="ArgumentException"/> — outside the <see cref="CborException"/> contract a caller
+        /// wraps deserialization in.
+        /// </summary>
+        [Fact]
+        public void AnUndefinedInAnIndefiniteLengthMapDoesNotCollideOnANullKey()
+        {
+            // bf                  map(*)
+            //    61 41 f7         "A": undefined
+            //    61 42 01         "B": 1
+            // ff                  break
+            CborObject obj = Cbor.Deserialize<CborObject>("BF6141F7614201FF".HexToBytes());
+
+            Assert.Equal(2, obj.Count);
+            Assert.Equal(CborValueType.Null, obj["A"].Type);
+            Assert.Equal(1, obj["B"].Value<int>());
+        }
+
+        /// <summary>An array item, which reaches the same converter by a different route.</summary>
+        [Fact]
+        public void AnUndefinedInAnArrayDoesNotSwallowTheFollowingItem()
+        {
+            // 82 f7 01            [undefined, 1]
+            CborArray array = Cbor.Deserialize<CborArray>("82F701".HexToBytes());
+
+            Assert.Equal(2, array.Count);
+            Assert.Equal(CborValueType.Null, array[0].Type);
+            Assert.Equal(1, array[1].Value<int>());
+        }
+
+        /// <summary>
+        /// The shape that always worked, and still reads as null rather than gaining a distinct
+        /// <c>undefined</c> value: <c>CborValueType.Undefined</c> stays the default-struct sentinel it
+        /// has always been, since no concrete <see cref="CborValue"/> reports it.
+        /// </summary>
+        [Fact]
+        public void AnUndefinedAsTheLastItemWasNeverAffected()
+        {
+            // a2 6142 01 6141 f7  -- {"B": 1, "A": undefined}
+            Holder holder = Cbor.Deserialize<Holder>("A26142016141F7".HexToBytes());
+
+            Assert.Equal(CborValueType.Null, holder.A.Type);
+            Assert.Equal(1, holder.B);
+        }
+
+        /// <summary>
+        /// A tagged <c>undefined</c> takes the same path, since <c>ReadNull</c> skips the tag before
+        /// failing to accept the primitive behind it.
+        /// </summary>
+        [Fact]
+        public void ATaggedUndefinedIsAlsoConsumed()
+        {
+            // a2 6141 c1f7 6142 01  -- {"A": tag(1) undefined, "B": 1}
+            CborObject obj = Cbor.Deserialize<CborObject>("A26141C1F7614201".HexToBytes());
+
+            Assert.Equal(2, obj.Count);
+            Assert.Equal(CborValueType.Null, obj["A"].Type);
+            Assert.Equal(1, obj["B"].Value<int>());
+        }
+    }
+}

--- a/src/Dahomey.Cbor/ObjectModel/CborValueType.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborValueType.cs
@@ -2,6 +2,14 @@
 {
     public enum CborValueType
     {
+        /// <summary>
+        /// The zero sentinel, not a value any <see cref="CborValue"/> reports. In particular it is not
+        /// CBOR's <c>undefined</c> (<c>F7</c>): that decodes to <see cref="CborValue.Null"/> and so
+        /// reports <see cref="Null"/>, which makes <c>undefined</c> and <c>null</c> indistinguishable
+        /// after a round trip. Giving <c>F7</c> a value of its own would be a modelling change rather
+        /// than a fix, and would need a matching case in <c>CborValueConverter.Write</c>, whose switch
+        /// has no default and would otherwise write nothing at all for it.
+        /// </summary>
         Undefined =  0,
         Object,
         Array,

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -65,7 +65,14 @@ namespace Dahomey.Cbor.Serialization.Converters
                     return reader.ReadBoolean();
 
                 case CborDataItemType.Null:
-                    reader.ReadNull();
+                    // Null covers `undefined` as well as `null`, but ReadNull accepts only the latter:
+                    // for F7 it returns false having consumed nothing, and the item still has to be
+                    // taken or the next read is handed the same header back.
+                    if (!reader.ReadNull())
+                    {
+                        reader.SkipDataItem();
+                    }
+
                     return CborValue.Null;
 
                 case CborDataItemType.Signed:


### PR DESCRIPTION
Fixes #163, which you filed out of the #161 review. Taking **option 1** from the issue — consuming the primitive in `CborValueConverter` — as offered there; say so if you would rather have option 2 and I will swap it.

## The defect

`GetCurrentDataItemType()` maps both `Null` and `Undefined` to `CborDataItemType.Null`, but `ReadNull()` accepts only `F6`. For `F7` it returns false having advanced nothing, while `GetHeader()` has already read the header byte into the reader's cache. `CborValueConverter` returned `CborValue.Null` regardless, so the item was reported as read without being consumed and the next read was handed that same stale header back.

Your two traces both reproduce exactly. Running them produced three distinct failures, none a clean error:

| Shape | Before |
|---|---|
| `A2 6141 F7 6142 01` into `CborObject` | `{"A": null, null: null}` — the trailing `6142 01` never consumed, no exception |
| the same into a POCO | `CborException: [4] Expected major type TextString` — naming the member *after* the undefined one |
| `BF 6141 F7 6142 01 FF` (indefinite) | `ArgumentException: An item with the same key has already been added. Key: null` |

Two details worth adding to the issue. The definite-length re-read is **bounded** by the declared item count rather than endless, so it terminates and returns a plausible-looking document — worse than a hang in the way that matters. And the indefinite-length form escapes as an `ArgumentException` from the backing dictionary, outside the `CborException` contract a caller wraps deserialization in.

## The fix

One branch:

```csharp
case CborDataItemType.Null:
    if (!reader.ReadNull())
    {
        reader.SkipDataItem();
    }

    return CborValue.Null;
```

`SkipDataItem()`'s `Primitive` case already handles `Undefined` by settling the reader state, so it is the existing mechanism rather than a new one.

## Why not option 2

`grep` says `CborValueConverter.cs:68` was the **only** site in the library that ignored `ReadNull()`'s result — every other caller branches on it. So the blast radius of option 1 is exactly the defect. Widening `ReadNull()` to accept `F7` would instead change `ReadString`, `ReadRawString`, `NullableConverter`, `ArrayConverter`, `ObjectConverter`, `AbstractCollectionConverter` and `AbstractDictionaryConverter` into treating `undefined` as null — a wire-contract change rather than a fix.

## On the modelling question

`CborValueType.Undefined` is currently unreachable: `CborValue` is `abstract`, no concrete subclass reports it, and `grep` finds no other use of the member in `ObjectModel/`. So it is the default-struct sentinel that `= 0` implies, and this PR keeps it that way — `undefined` still reads as `CborValue.Null`, and `undefined` and `null` stay indistinguishable after a round trip.

I documented that on the enum rather than changing it, including the part that would bite whoever revisits it: `CborValueConverter.Write` switches on `value.Type` with **no `default:`**, so a `CborValue` reporting `Undefined` would write *zero bytes* rather than `F7` or an error. Giving `F7` its own value needs that case too.

## Tests

`Issues/Issue0163.cs`, six cases: the map, the POCO, the indefinite-length map, an array item (a different route to the same converter), a tagged `undefined`, and the undefined-as-last-item shape.

**Five of the six fail without the source change.** The sixth is the one that always worked — the `undefined` is its container's last item, so the count runs out before anything looks again — which is exactly why the existing suite never caught this, and it is pinned so a future change cannot quietly break it.

1110 tests pass on net10.0, up from 1104. All four TFMs build.
