### PR TITLE
Emit semantic tags when writing the object model, closes #162

### DIFF
--- a/src/Dahomey.Cbor.Tests/Issues/Issue0162.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0162.cs
@@ -5,23 +5,170 @@ using Xunit;
 namespace Dahomey.Cbor.Tests.Issues
 {
     /// <summary>
-    /// Issue #162, first half: a semantic tag captured on read must not attach itself to every other
-    /// occurrence of that value in the process.
+    /// Issue #162: reading a document into the object model and writing it back dropped every semantic
+    /// tag it carried.
     /// </summary>
     /// <remarks>
-    /// <see cref="CborPositive"/> and <see cref="CborNegative"/> hand out shared instances for small
-    /// integers, as <see cref="CborSingle"/>, <see cref="CborDouble"/> and <see cref="CborDecimal"/> do
-    /// for small whole numbers, <see cref="CborBoolean"/> for both values and
-    /// <see cref="CborValue.Null"/> for null. Assigning <c>SemanticTag</c> to one of those attaches the
-    /// tag to that value everywhere — in documents that never carried a tag, and in values built in
-    /// code that were never read at all.
+    /// <c>CborValueConverter.Read</c> captures the tag into <see cref="CborValue.SemanticTag"/>, but
+    /// the write path switched on <see cref="CborValue.Type"/> and never read it back, so the tag was
+    /// silently lost. The tag is often what carries the meaning — tag 1 makes an integer an epoch
+    /// datetime, tag 2 makes a byte string a bignum, tag 39 carries a discriminator — so dropping it
+    /// changed what the document said rather than merely losing an annotation, and raised no error.
     /// <para>
-    /// This is observable today through the property, and it is what would turn emitting tags on write
-    /// into wrong bytes rather than a fix.
+    /// Tags are re-emitted unconditionally, which is what makes a read-then-write lossless. A caller
+    /// that reads a tag-1 value and replaces it with a string does get a document whose tag no longer
+    /// matches its content, but that is the caller describing their own value: the alternative,
+    /// dropping tags whose content changed, cannot be distinguished from the round trip this fixes.
     /// </para>
     /// </remarks>
     public class Issue0162
     {
+        /// <summary>The repro from the issue: a tagged epoch datetime.</summary>
+        [Fact]
+        public void ATaggedValueSurvivesARoundTrip()
+        {
+            // c1                  tag(1)
+            //    1a 514b67b0      1363896240
+            const string hexBuffer = "C11A514B67B0";
+
+            CborValue value = Cbor.Deserialize<CborValue>(hexBuffer.HexToBytes());
+
+            Assert.Equal(1UL, value.SemanticTag);
+            Helper.TestWrite(value, hexBuffer);
+        }
+
+        /// <summary>
+        /// A tag on a value nested inside a map, which reaches the write path through
+        /// <c>WriteMapItem</c> rather than the top-level call.
+        /// </summary>
+        [Fact]
+        public void ATagOnAMapValueSurvives()
+        {
+            // a1                  map(1)
+            //    61 61            "a"
+            //    c1 1a 514b67b0   tag(1) 1363896240
+            const string hexBuffer = "A16161C11A514B67B0";
+
+            CborObject obj = Cbor.Deserialize<CborObject>(hexBuffer.HexToBytes());
+
+            Assert.Equal(1UL, obj["a"].SemanticTag);
+            Helper.TestWrite(obj, hexBuffer);
+        }
+
+        /// <summary>A tag on a map <em>key</em>, which is written by the same call as the value.</summary>
+        [Fact]
+        public void ATagOnAMapKeySurvives()
+        {
+            // a1                  map(1)
+            //    c1 01            tag(1) 1
+            //    02               2
+            const string hexBuffer = "A1C10102";
+
+            CborObject obj = Cbor.Deserialize<CborObject>(hexBuffer.HexToBytes());
+
+            Helper.TestWrite(obj, hexBuffer);
+        }
+
+        /// <summary>A tag on an array item, reached through <c>WriteArrayItem</c>.</summary>
+        [Fact]
+        public void ATagOnAnArrayItemSurvives()
+        {
+            // 82                  array(2)
+            //    c1 01            tag(1) 1
+            //    02               2
+            const string hexBuffer = "82C10102";
+
+            CborArray array = Cbor.Deserialize<CborArray>(hexBuffer.HexToBytes());
+
+            Assert.Equal(1UL, array[0].SemanticTag);
+            Helper.TestWrite(array, hexBuffer);
+        }
+
+        /// <summary>
+        /// A tag on the container itself. The map and array writers are reachable directly — a member
+        /// declared <see cref="CborObject"/> does not go through the <see cref="CborValue"/> switch —
+        /// so they have to emit the tag themselves rather than rely on their caller.
+        /// </summary>
+        [Fact]
+        public void ATagOnAMapItselfSurvives()
+        {
+            // c1                  tag(1)
+            //    a1 6161 01       {"a": 1}
+            const string hexBuffer = "C1A1616101";
+
+            CborObject obj = Cbor.Deserialize<CborObject>(hexBuffer.HexToBytes());
+
+            Assert.Equal(1UL, obj.SemanticTag);
+            Helper.TestWrite(obj, hexBuffer);
+        }
+
+        /// <summary>The same for an array, written through the array converter directly.</summary>
+        [Fact]
+        public void ATagOnAnArrayItselfSurvives()
+        {
+            // c1                  tag(1)
+            //    82 01 02         [1, 2]
+            const string hexBuffer = "C1820102";
+
+            CborArray array = Cbor.Deserialize<CborArray>(hexBuffer.HexToBytes());
+
+            Assert.Equal(1UL, array.SemanticTag);
+            Helper.TestWrite(array, hexBuffer);
+        }
+
+        /// <summary>
+        /// A tag deeper than one level, so nesting is asserted rather than assumed: the tagged value
+        /// sits inside an array inside a map.
+        /// </summary>
+        [Fact]
+        public void ATagNestedTwoLevelsDeepSurvives()
+        {
+            // a1                  map(1)
+            //    61 61            "a"
+            //    81               array(1)
+            //       c2 41 01      tag(2) bytes(1) 01     -- a bignum
+            const string hexBuffer = "A1616181C24101";
+
+            CborObject obj = Cbor.Deserialize<CborObject>(hexBuffer.HexToBytes());
+
+            Assert.Equal(2UL, ((CborArray)obj["a"])[0].SemanticTag);
+            Helper.TestWrite(obj, hexBuffer);
+        }
+
+        /// <summary>
+        /// Every tagged shape the issue lists, so the fix is not specific to the one it repros with.
+        /// </summary>
+        [Theory]
+        [InlineData("C07818323031332D30332D32315432303A30343A30302E353A3030")] // tag 0, RFC 3339 string
+        [InlineData("C11A514B67B0")]                                          // tag 1, epoch datetime
+        [InlineData("C249010000000000000000")]                                // tag 2, positive bignum
+        [InlineData("C349010000000000000000")]                                // tag 3, negative bignum
+        [InlineData("D8206A687474703A2F2F612E62")]                            // tag 32, URI
+        [InlineData("D82763666F6F")]                                          // tag 39, discriminator
+        [InlineData("D855480000C03F00002040")]                                // tag 85, float32 typed array
+        public void EveryTaggedShapeSurvives(string hexBuffer)
+        {
+            CborValue value = Cbor.Deserialize<CborValue>(hexBuffer.HexToBytes());
+
+            Helper.TestWrite(value, hexBuffer);
+        }
+
+        /// <summary>
+        /// A tag must not escape the document it came from.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="CborPositive"/> and <see cref="CborNegative"/> hand out shared instances for
+        /// small integers, as <see cref="CborSingle"/>, <see cref="CborDouble"/> and
+        /// <see cref="CborDecimal"/> do for small whole numbers, <see cref="CborBoolean"/> for both
+        /// values and <see cref="CborValue.Null"/> for null. Assigning <c>SemanticTag</c> to one of
+        /// those attaches the tag to every occurrence of that value in the process — including
+        /// documents that never carried a tag, and values built in code that were never read at all.
+        /// <para>
+        /// Reading captures the tag onto a copy for exactly this reason. Without that, emitting tags on
+        /// write turns a latent mutation into wrong bytes: this test's second document would serialize
+        /// as <c>82 C101 02</c>.
+        /// </para>
+        /// </remarks>
         [Fact]
         public void ATagOnOneDocumentDoesNotLeakIntoAnother()
         {
@@ -30,12 +177,14 @@ namespace Dahomey.Cbor.Tests.Issues
 
             // A different document, carrying no tag, whose items are the same integers.
             CborArray other = Cbor.Deserialize<CborArray>("820102".HexToBytes());
-
             Assert.Null(other[0].SemanticTag);
-            Assert.Null(other[1].SemanticTag);
+            Helper.TestWrite(other, "820102");
+
+            // And a value built in code, which was never read from anything.
+            Helper.TestWrite(new CborArray { 1, 2 }, "820102");
         }
 
-        /// <summary>The same for the shared null, which is one instance for the whole process.</summary>
+        /// <summary>The same for the shared null, which is a single instance for the whole process.</summary>
         [Fact]
         public void ATagOnANullDoesNotLeakIntoTheSharedNull()
         {
@@ -43,20 +192,23 @@ namespace Dahomey.Cbor.Tests.Issues
 
             Assert.Equal(2UL, tagged.SemanticTag);
             Assert.Null(CborValue.Null.SemanticTag);
+            Helper.TestWrite<CborValue>(CborValue.Null, "F6");
         }
 
         /// <summary>
-        /// A value built in code, never read from anything, must not acquire a tag either — the shared
-        /// instance a literal resolves to is the same one a document would have tagged.
+        /// An untagged document is byte-identical to what it was before, which is the guarantee that
+        /// matters to every caller who never meets a tag.
         /// </summary>
         [Fact]
-        public void AValueBuiltInCodeNeverAcquiresATag()
+        public void AnUntaggedDocumentIsUnchanged()
         {
-            Cbor.Deserialize<CborValue>("C101".HexToBytes());
+            // a2 6161 01 6162 82 02 03  -- {"a": 1, "b": [2, 3]}
+            const string hexBuffer = "A26161016162820203";
 
-            CborArray built = new CborArray { 1, 2 };
+            CborObject obj = Cbor.Deserialize<CborObject>(hexBuffer.HexToBytes());
 
-            Assert.Null(built[0].SemanticTag);
+            Assert.Null(obj.SemanticTag);
+            Helper.TestWrite(obj, hexBuffer);
         }
     }
 }

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0162.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0162.cs
@@ -196,6 +196,25 @@ namespace Dahomey.Cbor.Tests.Issues
         }
 
         /// <summary>
+        /// The round trip carries one tag, not a chain: <see cref="CborValue.SemanticTag"/> is a single
+        /// <c>ulong?</c>, so the object model structurally cannot hold nested tags.
+        /// </summary>
+        /// <remarks>
+        /// The outer tag survives and the inner is dropped, which is an improvement on losing both but
+        /// is not lossless, and is a limit of the model rather than of this change. Pinned so the
+        /// distinction is stated rather than discovered.
+        /// </remarks>
+        [Fact]
+        public void ANestedTagKeepsOnlyTheOuterOne()
+        {
+            // c1 c2 01  -- tag(1) tag(2) 1
+            CborValue value = Cbor.Deserialize<CborValue>("C1C201".HexToBytes());
+
+            Assert.Equal(1UL, value.SemanticTag);
+            Helper.TestWrite(value, "C101");
+        }
+
+        /// <summary>
         /// An untagged document is byte-identical to what it was before, which is the guarantee that
         /// matters to every caller who never meets a tag.
         /// </summary>

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0162.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0162.cs
@@ -1,0 +1,62 @@
+using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #162, first half: a semantic tag captured on read must not attach itself to every other
+    /// occurrence of that value in the process.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CborPositive"/> and <see cref="CborNegative"/> hand out shared instances for small
+    /// integers, as <see cref="CborSingle"/>, <see cref="CborDouble"/> and <see cref="CborDecimal"/> do
+    /// for small whole numbers, <see cref="CborBoolean"/> for both values and
+    /// <see cref="CborValue.Null"/> for null. Assigning <c>SemanticTag</c> to one of those attaches the
+    /// tag to that value everywhere — in documents that never carried a tag, and in values built in
+    /// code that were never read at all.
+    /// <para>
+    /// This is observable today through the property, and it is what would turn emitting tags on write
+    /// into wrong bytes rather than a fix.
+    /// </para>
+    /// </remarks>
+    public class Issue0162
+    {
+        [Fact]
+        public void ATagOnOneDocumentDoesNotLeakIntoAnother()
+        {
+            CborValue tagged = Cbor.Deserialize<CborValue>("C101".HexToBytes());
+            Assert.Equal(1UL, tagged.SemanticTag);
+
+            // A different document, carrying no tag, whose items are the same integers.
+            CborArray other = Cbor.Deserialize<CborArray>("820102".HexToBytes());
+
+            Assert.Null(other[0].SemanticTag);
+            Assert.Null(other[1].SemanticTag);
+        }
+
+        /// <summary>The same for the shared null, which is one instance for the whole process.</summary>
+        [Fact]
+        public void ATagOnANullDoesNotLeakIntoTheSharedNull()
+        {
+            CborValue tagged = Cbor.Deserialize<CborValue>("C2F6".HexToBytes());
+
+            Assert.Equal(2UL, tagged.SemanticTag);
+            Assert.Null(CborValue.Null.SemanticTag);
+        }
+
+        /// <summary>
+        /// A value built in code, never read from anything, must not acquire a tag either — the shared
+        /// instance a literal resolves to is the same one a document would have tagged.
+        /// </summary>
+        [Fact]
+        public void AValueBuiltInCodeNeverAcquiresATag()
+        {
+            Cbor.Deserialize<CborValue>("C101".HexToBytes());
+
+            CborArray built = new CborArray { 1, 2 };
+
+            Assert.Null(built[0].SemanticTag);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
+++ b/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
@@ -773,27 +773,26 @@ namespace Dahomey.Cbor.Tests
         }
 
         [Fact]
-        public void TheObjectModelSeesATypedArrayAsAByteStringAndDropsItsTag()
+        public void TheObjectModelSeesATypedArrayAsATaggedByteString()
         {
             // CborValue has no typed array node, so a typed array arrives as a byte string with the tag
             // parked in CborValue.SemanticTag. Two consequences for a DOM consumer:
             //
-            //   * code that inspects or compares the value sees opaque bytes, not numbers;
-            //   * CborValueConverter never writes SemanticTag back, so reading a document and writing
-            //     it out again turns the typed array into an ordinary byte string.
+            // DOM code that inspects or compares the value therefore sees opaque bytes rather than
+            // numbers, which is the part typed arrays make easy to reach.
             //
-            // The second is a general property of the object model rather than anything typed arrays
-            // introduce -- every semantic tag is dropped this way -- but typed arrays are what make it
-            // easy to reach. It is pinned here so that changing it is a deliberate act.
+            // The tag itself survives a read-then-write, so the document still describes a typed array
+            // afterwards. That is a property of the object model rather than of typed arrays: it holds
+            // for every semantic tag.
             // D855 tag(85) 48 bytes(8) -> 1.5f, 2.5f little endian
+            const string hexBuffer = "D855480000C03F00002040";
             CborOptions options = TypedArrayOptions();
-            CborValue value = Cbor.Deserialize<CborValue>("D855480000C03F00002040".HexToBytes(), options);
+            CborValue value = Cbor.Deserialize<CborValue>(hexBuffer.HexToBytes(), options);
 
             Assert.Equal(CborValueType.ByteString, value.Type);
             Assert.Equal(85ul, value.SemanticTag);
 
-            // 48 bytes(8) -- written back without D855, so the reader no longer sees a typed array
-            Helper.TestWrite(value, "480000C03F00002040", null, options);
+            Helper.TestWrite(value, hexBuffer, null, options);
         }
 
         private static float[] ReadFloatsWith(TypedArrayConverter<float> converter, string hexBuffer)

--- a/src/Dahomey.Cbor/ObjectModel/CborBoolean.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborBoolean.cs
@@ -16,6 +16,16 @@ namespace Dahomey.Cbor.ObjectModel
             _value = value;
         }
 
+        /// <summary>
+        /// Copies before tagging: CborBoolean hands out shared instances for common values, so
+        /// tagging in place would attach the tag to every occurrence of that value in the
+        /// process. See <see cref="CborValue.WithSemanticTag"/>.
+        /// </summary>
+        internal override CborValue WithSemanticTag(ulong semanticTag)
+        {
+            return new CborBoolean(_value) { SemanticTag = semanticTag };
+        }
+
         public override T Value<T>()
         {
             return Primitive<bool, T>.Converter(_value);

--- a/src/Dahomey.Cbor/ObjectModel/CborDecimal.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborDecimal.cs
@@ -25,6 +25,16 @@ namespace Dahomey.Cbor.ObjectModel
             _value = value;
         }
 
+        /// <summary>
+        /// Copies before tagging: CborDecimal hands out shared instances for common values, so
+        /// tagging in place would attach the tag to every occurrence of that value in the
+        /// process. See <see cref="CborValue.WithSemanticTag"/>.
+        /// </summary>
+        internal override CborValue WithSemanticTag(ulong semanticTag)
+        {
+            return new CborDecimal(_value) { SemanticTag = semanticTag };
+        }
+
         public override T Value<T>()
         {
             return Primitive<decimal, T>.Converter(_value);

--- a/src/Dahomey.Cbor/ObjectModel/CborDouble.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborDouble.cs
@@ -25,6 +25,16 @@ namespace Dahomey.Cbor.ObjectModel
             _value = value;
         }
 
+        /// <summary>
+        /// Copies before tagging: CborDouble hands out shared instances for common values, so
+        /// tagging in place would attach the tag to every occurrence of that value in the
+        /// process. See <see cref="CborValue.WithSemanticTag"/>.
+        /// </summary>
+        internal override CborValue WithSemanticTag(ulong semanticTag)
+        {
+            return new CborDouble(_value) { SemanticTag = semanticTag };
+        }
+
         public override T Value<T>()
         {
             return Primitive<double, T>.Converter(_value);

--- a/src/Dahomey.Cbor/ObjectModel/CborNegative.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborNegative.cs
@@ -29,6 +29,16 @@ namespace Dahomey.Cbor.ObjectModel
             _value = value;
         }
 
+        /// <summary>
+        /// Copies before tagging: CborNegative hands out shared instances for common values, so
+        /// tagging in place would attach the tag to every occurrence of that value in the
+        /// process. See <see cref="CborValue.WithSemanticTag"/>.
+        /// </summary>
+        internal override CborValue WithSemanticTag(ulong semanticTag)
+        {
+            return new CborNegative(_value) { SemanticTag = semanticTag };
+        }
+
         public override T Value<T>()
         {
             return Primitive<long, T>.Converter(_value);

--- a/src/Dahomey.Cbor/ObjectModel/CborNull.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborNull.cs
@@ -10,6 +10,16 @@ namespace Dahomey.Cbor.ObjectModel
         {
         }
 
+        /// <summary>
+        /// Copies before tagging: <see cref="CborValue.Null"/> is a single instance shared by the whole
+        /// process, so tagging in place would give every null everywhere that tag. See
+        /// <see cref="CborValue.WithSemanticTag"/>.
+        /// </summary>
+        internal override CborValue WithSemanticTag(ulong semanticTag)
+        {
+            return new CborNull { SemanticTag = semanticTag };
+        }
+
         public override string ToString()
         {
             return "null";

--- a/src/Dahomey.Cbor/ObjectModel/CborPositive.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborPositive.cs
@@ -24,6 +24,16 @@ namespace Dahomey.Cbor.ObjectModel
             _value = value;
         }
 
+        /// <summary>
+        /// Copies before tagging: CborPositive hands out shared instances for common values, so
+        /// tagging in place would attach the tag to every occurrence of that value in the
+        /// process. See <see cref="CborValue.WithSemanticTag"/>.
+        /// </summary>
+        internal override CborValue WithSemanticTag(ulong semanticTag)
+        {
+            return new CborPositive(_value) { SemanticTag = semanticTag };
+        }
+
         public override T Value<T>()
         {
             return Primitive<ulong, T>.Converter(_value);

--- a/src/Dahomey.Cbor/ObjectModel/CborSingle.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborSingle.cs
@@ -25,6 +25,16 @@ namespace Dahomey.Cbor.ObjectModel
             _value = value;
         }
 
+        /// <summary>
+        /// Copies before tagging: CborSingle hands out shared instances for common values, so
+        /// tagging in place would attach the tag to every occurrence of that value in the
+        /// process. See <see cref="CborValue.WithSemanticTag"/>.
+        /// </summary>
+        internal override CborValue WithSemanticTag(ulong semanticTag)
+        {
+            return new CborSingle(_value) { SemanticTag = semanticTag };
+        }
+
         public override T Value<T>()
         {
             return Primitive<float, T>.Converter(_value);

--- a/src/Dahomey.Cbor/ObjectModel/CborValue.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborValue.cs
@@ -15,6 +15,26 @@ namespace Dahomey.Cbor.ObjectModel
         private static readonly CborNull s_Null = new CborNull();
         public static CborNull Null { get; } = s_Null;
 
+        /// <summary>
+        /// Returns this value carrying <paramref name="semanticTag"/>, without ever writing the tag to
+        /// an instance somebody else holds.
+        /// </summary>
+        /// <remarks>
+        /// Several value types hand out shared instances — <see cref="CborPositive"/> and
+        /// <see cref="CborNegative"/> for small integers, <see cref="CborSingle"/>,
+        /// <see cref="CborDouble"/> and <see cref="CborDecimal"/> for small whole numbers,
+        /// <see cref="CborBoolean"/> for both values, and <see cref="Null"/>. Assigning
+        /// <see cref="SemanticTag"/> to one of those would attach the tag to every occurrence of that
+        /// value in the process, in documents that never carried it and in values built in code. Those
+        /// types override this to copy first; the rest, which are constructed fresh per value, tag in
+        /// place.
+        /// </remarks>
+        internal virtual CborValue WithSemanticTag(ulong semanticTag)
+        {
+            SemanticTag = semanticTag;
+            return this;
+        }
+
         public virtual T Value<T>()
         {
             throw new NotSupportedException(

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -108,6 +108,14 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public override void Write(ref CborWriter writer, CborValue value, LengthMode lengthMode)
         {
+            // Containers emit their own tag: the map and array writers are reachable without passing
+            // through here at all - a member declared CborObject resolves straight to them - so
+            // emitting it for them here as well would double the tag on that route.
+            if (value.Type != CborValueType.Object && value.Type != CborValueType.Array)
+            {
+                WriteSemanticTag(ref writer, value);
+            }
+
             switch (value.Type)
             {
                 case CborValueType.Object:
@@ -153,6 +161,26 @@ namespace Dahomey.Cbor.Serialization.Converters
                 case CborValueType.ByteString:
                     writer.WriteByteString(value.Value<ReadOnlyMemory<byte>>().Span);
                     break;
+            }
+        }
+
+        /// <summary>
+        /// Re-emits the semantic tag <c>Read</c> captured, so a document read into the object model and
+        /// written back says what it said. The tag is often the meaning rather than an annotation - tag
+        /// 1 makes an integer a datetime, tag 39 carries a discriminator - so losing it changed the
+        /// document silently.
+        /// </summary>
+        /// <remarks>
+        /// Unconditional, which is what makes the round trip lossless. A caller that reads a tag-1 value
+        /// and replaces it with a string does get a tag that no longer matches its content, but that is
+        /// the caller describing their own value: there is no way to tell an edited value from an
+        /// untouched one, so dropping the tag on suspicion would break the round trip this exists for.
+        /// </remarks>
+        private static void WriteSemanticTag(ref CborWriter writer, CborValue value)
+        {
+            if (value.SemanticTag.HasValue)
+            {
+                writer.WriteSemanticTag(value.SemanticTag.Value);
             }
         }
 
@@ -221,6 +249,12 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         CborObject? ICborConverter<CborObject?>.Read(ref CborReader reader)
         {
+            // Before ReadNull, which skips a semantic tag as every read entry point does. Reaching the
+            // container converter directly - Cbor.Deserialize<CborObject> - bypasses Read(CborValue),
+            // so without this the tag is consumed and lost on the way in and there is nothing left for
+            // the write path to re-emit.
+            bool hasSemanticTag = reader.TryReadSemanticTag(out ulong semanticTag);
+
             if (reader.ReadNull())
             {
                 return null;
@@ -228,6 +262,12 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             MapReaderContext mapContext = new MapReaderContext();
             reader.ReadMap(this, ref mapContext);
+
+            if (hasSemanticTag)
+            {
+                mapContext.obj.SemanticTag = semanticTag;
+            }
+
             return mapContext.obj;
         }
 
@@ -249,6 +289,8 @@ namespace Dahomey.Cbor.Serialization.Converters
                 writer.WriteNull();
                 return;
             }
+
+            WriteSemanticTag(ref writer, value);
 
             MapWriterContext mapWriterContext = new MapWriterContext
             {
@@ -277,6 +319,8 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         CborArray? ICborConverter<CborArray?>.Read(ref CborReader reader)
         {
+            bool hasSemanticTag = reader.TryReadSemanticTag(out ulong semanticTag);
+
             if (reader.ReadNull())
             {
                 return null;
@@ -284,6 +328,12 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             ArrayReaderContext arrayContext = new ArrayReaderContext();
             reader.ReadArray(this, ref arrayContext);
+
+            if (hasSemanticTag)
+            {
+                arrayContext.array.SemanticTag = semanticTag;
+            }
+
             return arrayContext.array;
         }
 
@@ -305,6 +355,8 @@ namespace Dahomey.Cbor.Serialization.Converters
                 writer.WriteNull();
                 return;
             }
+
+            WriteSemanticTag(ref writer, value);
 
             ArrayWriterContext arrayWriterContext = new ArrayWriterContext
             {

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -48,13 +48,12 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             bool hasSemanticTag = reader.TryReadSemanticTag(out ulong semanticTag);
 
-            var cborValue = ReadCborValue(ref reader);
-            if (hasSemanticTag)
-            {
-                cborValue.SemanticTag = semanticTag;
-            }
+            CborValue cborValue = ReadCborValue(ref reader);
 
-            return cborValue;
+            // WithSemanticTag rather than assigning SemanticTag: small integers, common floats, both
+            // booleans and null are shared instances, and stamping a tag on one of those would tag
+            // every occurrence of that value in the process.
+            return hasSemanticTag ? cborValue.WithSemanticTag(semanticTag) : cborValue;
         }
 
         private CborValue ReadCborValue(ref CborReader reader)

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -171,7 +171,10 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// document silently.
         /// </summary>
         /// <remarks>
-        /// Unconditional, which is what makes the round trip lossless. A caller that reads a tag-1 value
+        /// Unconditional, which is what makes the round trip carry the tag rather than lose it. One tag,
+        /// not a chain: <see cref="CborValue.SemanticTag"/> is a single <c>ulong?</c>, so a nested
+        /// <c>C1 C2 01</c> keeps the outer tag and drops the inner -- a limit of the model rather than
+        /// of this method. A caller that reads a tag-1 value
         /// and replaces it with a string does get a tag that no longer matches its content, but that is
         /// the caller describing their own value: there is no way to tell an edited value from an
         /// untouched one, so dropping the tag on suspicion would break the round trip this exists for.


### PR DESCRIPTION
Fixes #162. Two commits, because fixing what the issue describes turned up a defect underneath it that had to be fixed first.

## The one underneath — please read this part first

**Reading a tagged value mutates an instance shared by the whole process.** `CborValueConverter.Read` assigned the captured tag straight onto whatever `ReadCborValue` returned, and several value types hand out shared instances: `CborPositive` and `CborNegative` for integers 0–100, `CborSingle`/`CborDouble`/`CborDecimal` for small whole numbers, `CborBoolean` for both of its values, and `CborValue.Null`, which is one instance for the process.

Run against `master`:

```
Cbor.Deserialize<CborValue>("C101".HexToBytes());          // tag(1) 1, in some document

Cbor.Deserialize<CborArray>("820102".HexToBytes())         // another document, no tags at all
new CborArray { 1, 2 }                                     // built in code, never read
CborValue.Null.SemanticTag                                 // whatever a tagged null last set
```

the second and third both come back with `SemanticTag == 1` on their first item, and `CborValue.Null.SemanticTag` is `2` after anything anywhere reads a tag-2 null.

This is live on `master` today — anyone inspecting `SemanticTag` already gets another document's answer. It is invisible only because nothing reads it back. **Emitting tags on write is what turns it into wrong bytes**, and it would have done so for the most common values there are: with only the second commit, that unrelated `820102` document serializes as `82 C101 02`.

`649b4db` fixes it with an internal `CborValue.WithSemanticTag`, virtual, tagging in place for the types constructed fresh per value and overridden by the seven with shared instances to copy first. No public API change. Three tests, each failing without it.

If you would rather have that as its own PR against `master` I will split it out — it stands alone, and #162's fix should not merge without it.

## The issue itself

`fb8a562`. `Read` captured the tag, `Write` switched on `Type` and never read it back, so a DOM read-then-write dropped every tag: tag 0/1 a datetime became a bare string or integer, 2/3 a bignum became a byte string, 32 a URI became text, 39 a polymorphic document lost its type, 64–87 a typed array became opaque bytes.

**The read side had a matching gap**, which the issue does not mention: reaching the container converters directly — `Cbor.Deserialize<CborObject>(…)`, which is what the README shows — bypasses `Read(CborValue)` entirely, and their own `Read` never captured a tag. So a tagged map or array lost it on the way *in* as well as out, and the round trip needed both halves.

On your two open decisions:

1. **Where the tag is written** — by whoever writes the value, exactly once. Containers emit their own rather than having it emitted for them, because those writers are reachable without passing through the `CborValue` switch; doing both would double the tag on that route. Nested values are asserted rather than assumed — `ATagNestedTwoLevelsDeepSurvives` puts a bignum inside an array inside a map.
2. **Round-trip fidelity vs. correctness on edit** — re-emitted unconditionally, which is what makes the round trip lossless. A caller who reads a tag-1 value and replaces it with a string does get a tag that no longer matches, but an edited value is indistinguishable from an untouched one, so dropping tags on suspicion would break the case this exists for. The reasoning is on the method rather than left to be re-derived.

I did **not** touch `SemanticTag`'s `internal set`. Opening it is a public API decision and it is separable from the round-trip bug now that the round trip works.

## Tests

Twelve for the write fix, three for the sharing fix. Every tagged shape the issue lists is a theory case, and `AnUntaggedDocumentIsUnchanged` pins byte-identity for callers who never meet a tag.

1121 tests pass on net10.0, up from 1104. All four TFMs build.

## Note for #157

That PR pins the current behaviour with `TheObjectModelSeesATypedArrayAsAByteStringAndDropsItsTag`. Whichever of these merges second needs that test updated — it is a one-line expectation change, and I will do it on whichever side is still open.
