### PR TITLE
Read RFC 8949 indefinite-length byte and text strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ High-performance [CBOR](https://cbor.io/) serialization framework for .Net (C#)
 * Support for RFC 8746 typed arrays, opt-in per direction (CborOptions.TypedArrayMode)
 * Support for RFC 8949 §3.4.3 bignums (tags 2 and 3) as System.Numerics.BigInteger
 * Duplicate map keys rejected on every decode target, with a last-wins opt-out (CborOptions.DuplicateKeyMode)
+* Reads RFC 8949 indefinite-length (chunked) byte and text strings; writes definite-length only
 
 ## Installation
 ### NuGet
@@ -206,11 +207,28 @@ definite-length byte string, so there is no array header to make indefinite. It 
 array not written as one.
 
 The object model does not model typed arrays. A `CborValue` holding one is a `ByteString` with the tag in
-`CborValue.SemanticTag`, so DOM code sees opaque bytes rather than numbers. Note that
-`CborValueConverter` does not write `SemanticTag` back — reading a document into a `CborValue` and
-serializing it again drops the tag, turning the typed array into a plain byte string. That is true of
-every semantic tag, not just these, but typed arrays are the easiest way to meet it. Tracked as
-https://github.com/dahomey-technologies/Dahomey.Cbor/issues/162.
+`CborValue.SemanticTag`, so DOM code sees opaque bytes rather than numbers. The tag itself survives a
+read-then-write, so the document still describes a typed array afterwards.
+
+### Indefinite-length strings (RFC 8949 §3.2.3)
+
+A byte or text string may arrive as a series of chunks terminated by a break, which is what a producer
+emits when it does not know the length in advance:
+
+```
+7F 62 7374 64 7265616D FF     reads as "stream"
+5F 42 0102 43 030405 FF       reads as the five bytes 01 02 03 04 05
+```
+
+An indefinite-length string denotes exactly the concatenation of its chunks, so it is indistinguishable
+from the definite-length string of the same content once read — there is nothing to configure and
+nothing to opt into.
+
+**Reading only.** Nothing is ever written in this form: `LengthMode.IndefiniteLength` applies to arrays
+and maps, not to strings, so what this library emits is unchanged.
+
+A chunk whose major type differs from the enclosing string, and a nested indefinite-length string, are
+both malformed and raise a `CborException`.
 
 ### Bignums (RFC 8949 §3.4.3)
 

--- a/src/Dahomey.Cbor.Tests/ChunkedStringTests.cs
+++ b/src/Dahomey.Cbor.Tests/ChunkedStringTests.cs
@@ -46,9 +46,15 @@ namespace Dahomey.Cbor.Tests
         [InlineData("5F42010243030405FF", new byte[] { 1, 2, 3, 4, 5 })]
         // 5f ff -- zero chunks
         [InlineData("5FFF", new byte[0])]
+        // 5f 40 42 0102 ff -- an empty chunk, which is the one shape that copies zero bytes
+        [InlineData("5F40420102FF", new byte[] { 1, 2 })]
         public void AChunkedByteStringReadsAsItsConcatenation(string hexBuffer, byte[] expected)
         {
-            Assert.Equal(expected, Cbor.Deserialize<byte[]>(hexBuffer.HexToBytes()));
+            // Helper.Read rather than Cbor.Deserialize: it runs the same bytes through the span reader,
+            // a single-segment sequence and a one-byte-per-segment sequence. The last is what matters
+            // here -- the scratch buffer only exists in sequence mode, so it is the only shape that
+            // would catch ReadChunk asking for it and one chunk overwriting the previous.
+            Assert.Equal(expected, Helper.Read<byte[]>(hexBuffer));
         }
 
         /// <summary>
@@ -69,12 +75,23 @@ namespace Dahomey.Cbor.Tests
         }
 
         /// <summary>
-        /// A multi-byte character split across a chunk boundary. This is the case that makes joining
-        /// the bytes before decoding necessary rather than merely tidy: decoding each chunk on its own
-        /// would see two invalid fragments.
+        /// A multi-byte character split across a chunk boundary is <em>accepted</em>, not refused.
         /// </summary>
+        /// <remarks>
+        /// RFC 8949 section 3.2.3 tells producers not to do this — a chunk boundary is supposed to fall
+        /// on a character boundary — so accepting it is a lenient reading rather than a conformance
+        /// requirement. It is deliberate, and consistent with the leniency already in the reader:
+        /// <c>Encoding.UTF8.GetString</c> substitutes U+FFFD for invalid sequences rather than
+        /// throwing, so refusing this particular malformation while silently repairing others would be
+        /// arbitrary. <c>System.Formats.Cbor</c> in strict mode rejects it.
+        /// <para>
+        /// Joining the bytes before decoding is right either way: it is what makes the chunked and
+        /// definite-length forms of the same value indistinguishable, which is what section 3.2.3
+        /// requires of a reader whoever emitted the document.
+        /// </para>
+        /// </remarks>
         [Fact]
-        public void AUtf8CharacterMaySpanAChunkBoundary()
+        public void AUtf8CharacterSplitAcrossChunksIsAccepted()
         {
             // 7f 61 e2      -- first byte of U+20AC EURO SIGN, alone in its chunk
             //    62 82ac    -- its remaining two bytes

--- a/src/Dahomey.Cbor.Tests/ChunkedStringTests.cs
+++ b/src/Dahomey.Cbor.Tests/ChunkedStringTests.cs
@@ -62,16 +62,30 @@ namespace Dahomey.Cbor.Tests
         /// the encoding, and the only one that hands back a <see cref="ReadOnlySequence{T}"/>. The
         /// chunks are not contiguous in the input, so it returns the joined copy rather than a slice.
         /// </summary>
-        [Fact]
-        public void AChunkedByteStringReadsAsASequence()
+        /// <remarks>
+        /// Run over a span reader and over a fragmented one. There is no converter registered for
+        /// <see cref="ReadOnlySequence{T}"/>, so <c>Helper.Read</c> cannot reach this entry point and
+        /// the reader has to be built directly; a sequence-backed reader is the only shape in which
+        /// the scratch buffer this path declines exists at all.
+        /// <para>
+        /// The three-single-byte-chunk case is the one that binds the window: the accumulator grows by
+        /// doubling, so three bytes arrive in a four-byte array, and handing the array back whole would
+        /// append a trailing zero.
+        /// </para>
+        /// </remarks>
+        [Theory]
+        // 5f 42 0102 43 030405 ff -- two chunks, and the accumulator happens to end up exactly sized
+        [InlineData("5F42010243030405FF", new byte[] { 1, 2, 3, 4, 5 })]
+        // 5f 41 01 41 02 41 03 ff -- three one-byte chunks: 1 -> 2 -> 4, so the last resize overshoots
+        [InlineData("5F410141024103FF", new byte[] { 1, 2, 3 })]
+        // 5f ff -- zero chunks
+        [InlineData("5FFF", new byte[0])]
+        public void AChunkedByteStringReadsAsASequence(string hexBuffer, byte[] expected)
         {
-            // 5f 42 0102 43 030405 ff
-            byte[] buffer = "5F42010243030405FF".HexToBytes();
-            CborReader reader = new CborReader(buffer);
+            byte[] buffer = hexBuffer.HexToBytes();
 
-            ReadOnlySequence<byte> sequence = reader.ReadByteStringSequence();
-
-            Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, sequence.ToArray());
+            Assert.Equal(expected, new CborReader(buffer).ReadByteStringSequence().ToArray());
+            Assert.Equal(expected, new CborReader(Helper.Fragmentize(buffer)).ReadByteStringSequence().ToArray());
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/ChunkedStringTests.cs
+++ b/src/Dahomey.Cbor.Tests/ChunkedStringTests.cs
@@ -1,0 +1,196 @@
+using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// RFC 8949 section 3.2.3 indefinite-length strings: a byte or text string encoded as zero or more
+    /// definite-length chunks terminated by a break.
+    /// </summary>
+    /// <remarks>
+    /// This is core format rather than an extension — any encoder may emit it, and it is what a producer
+    /// streaming a value whose length it does not yet know will emit. An indefinite-length string
+    /// denotes exactly the concatenation of its chunks, so the chunk boundaries carry no meaning and a
+    /// reader cannot distinguish one from the definite-length string of the same content.
+    /// <para>
+    /// <c>CborDataItemScanner</c> already walked this shape, so before this the scanner would report a
+    /// document <c>Complete</c> that <c>Cbor.Deserialize</c> then refused.
+    /// </para>
+    /// </remarks>
+    public class ChunkedStringTests
+    {
+        /// <summary>
+        /// The chunked form and the definite-length form of the same value must be indistinguishable.
+        /// </summary>
+        [Theory]
+        // 7f 62"st" 64"ream" ff              -> "stream"
+        [InlineData("7F627374647265616DFF", "stream")]
+        // 7f 61"a" 61"b" 61"c" ff            -> "abc", three chunks
+        [InlineData("7F616161626163FF", "abc")]
+        // 7f 66"stream" ff                   -> a single chunk
+        [InlineData("7F6673747265616DFF", "stream")]
+        // 7f ff                              -> zero chunks, the empty string
+        [InlineData("7FFF", "")]
+        public void AChunkedTextStringReadsAsItsConcatenation(string hexBuffer, string expected)
+        {
+            Assert.Equal(expected, Helper.Read<string>(hexBuffer.Replace(" ", string.Empty)));
+        }
+
+        [Theory]
+        // 5f 42 0102 43 030405 ff
+        [InlineData("5F42010243030405FF", new byte[] { 1, 2, 3, 4, 5 })]
+        // 5f ff -- zero chunks
+        [InlineData("5FFF", new byte[0])]
+        public void AChunkedByteStringReadsAsItsConcatenation(string hexBuffer, byte[] expected)
+        {
+            Assert.Equal(expected, Cbor.Deserialize<byte[]>(hexBuffer.HexToBytes()));
+        }
+
+        /// <summary>
+        /// <see cref="CborReader.ReadByteStringSequence"/> is the third entry point that had to learn
+        /// the encoding, and the only one that hands back a <see cref="ReadOnlySequence{T}"/>. The
+        /// chunks are not contiguous in the input, so it returns the joined copy rather than a slice.
+        /// </summary>
+        [Fact]
+        public void AChunkedByteStringReadsAsASequence()
+        {
+            // 5f 42 0102 43 030405 ff
+            byte[] buffer = "5F42010243030405FF".HexToBytes();
+            CborReader reader = new CborReader(buffer);
+
+            ReadOnlySequence<byte> sequence = reader.ReadByteStringSequence();
+
+            Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, sequence.ToArray());
+        }
+
+        /// <summary>
+        /// A multi-byte character split across a chunk boundary. This is the case that makes joining
+        /// the bytes before decoding necessary rather than merely tidy: decoding each chunk on its own
+        /// would see two invalid fragments.
+        /// </summary>
+        [Fact]
+        public void AUtf8CharacterMaySpanAChunkBoundary()
+        {
+            // 7f 61 e2      -- first byte of U+20AC EURO SIGN, alone in its chunk
+            //    62 82ac    -- its remaining two bytes
+            // ff
+            Assert.Equal("\u20ac", Helper.Read<string>("7F61E2628 2ACFF".Replace(" ", string.Empty)));
+        }
+
+        /// <summary>The chunked form reaches an object member like any other string.</summary>
+        [Fact]
+        public void AChunkedStringReadsIntoAMember()
+        {
+            // a1 6141 7f 62"st" 64"ream" ff
+            ChunkedHolder holder = Helper.Read<ChunkedHolder>("A161417F627374647265616DFF");
+
+            Assert.Equal("stream", holder.A);
+        }
+
+        public class ChunkedHolder
+        {
+            [Attributes.CborProperty("A")]
+            public string A { get; set; }
+        }
+
+        /// <summary>And into the object model, where it is an ordinary string afterwards.</summary>
+        [Fact]
+        public void AChunkedStringReadsIntoTheObjectModel()
+        {
+            CborValue value = Cbor.Deserialize<CborValue>("7F627374647265616DFF".HexToBytes());
+
+            Assert.Equal(CborValueType.String, value.Type);
+            Assert.Equal("stream", value.Value<string>());
+        }
+
+        /// <summary>
+        /// Skipping a chunked string still walks it. An unmatched member is skipped rather than read, so
+        /// without this a chunked value would derail the rest of the map.
+        /// </summary>
+        [Fact]
+        public void AChunkedStringIsSkippedCorrectly()
+        {
+            // a2 6142 7f 62"st" 64"ream" ff   -- "B" is not a member of ChunkedHolder, so it is skipped
+            //    6141 6161                    -- and "A" after it must still be found
+            ChunkedHolder holder = Helper.Read<ChunkedHolder>(
+                "A261427F627374647265616DFF61416161");
+
+            Assert.Equal("a", holder.A);
+        }
+
+        /// <summary>
+        /// A chunk of the wrong major type is malformed rather than something to coerce: a byte string
+        /// chunk inside a text string would otherwise become text nobody wrote.
+        /// </summary>
+        [Fact]
+        public void AChunkOfTheWrongMajorTypeIsRejected()
+        {
+            // 7f 62"st" 42 0102 ff  -- a byte string chunk inside an indefinite-length text string
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<string>("7F627374420102FF".HexToBytes()));
+
+            Assert.Contains("indefinite-length string chunk", exception.Message);
+        }
+
+        /// <summary>Nesting is not permitted, and is refused rather than flattened.</summary>
+        [Fact]
+        public void ANestedIndefiniteLengthStringIsRejected()
+        {
+            // 7f 7f 61"a" ff ff
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<string>("7F7F6161FFFF".HexToBytes()));
+
+            Assert.Contains("cannot contain another indefinite-length string", exception.Message);
+        }
+
+        /// <summary>
+        /// Both malformed shapes fail as <see cref="CborException"/> rather than as something a caller's
+        /// <c>catch (CborException)</c> would miss, which is what the refusal they replace did.
+        /// </summary>
+        [Theory]
+        [InlineData("7F627374420102FF")]
+        [InlineData("7F7F6161FFFF")]
+        public void MalformedChunksThrowCborException(string hexBuffer)
+        {
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<string>(hexBuffer.Replace(" ", string.Empty).HexToBytes()));
+        }
+
+        /// <summary>
+        /// The chunked form is accepted everywhere the scanner already said it would be — which is the
+        /// inconsistency this closes, since the scanner reported such a document complete while the
+        /// reader refused it.
+        /// </summary>
+        [Fact]
+        public void TheScannerAndTheReaderAgreeOnAChunkedString()
+        {
+            byte[] buffer = "7F627374647265616DFF".HexToBytes();
+
+            Assert.True(CborDataItemScanner.TryGetDataItemLength(buffer, out int length));
+            Assert.Equal(buffer.Length, length);
+            Assert.Equal("stream", Cbor.Deserialize<string>(buffer));
+        }
+
+        /// <summary>
+        /// A chunked string inside an indefinite-length array, so the two indefinite encodings do not
+        /// interfere: the string's break must not be taken for the array's.
+        /// </summary>
+        [Fact]
+        public void AChunkedStringInsideAnIndefiniteLengthArray()
+        {
+            // 9f                              array(*)
+            //    7f 62"st" 64"ream" ff        "stream"
+            //    61 61                        "a"
+            // ff
+            List<string> items = Cbor.Deserialize<List<string>>(
+                "9F7F627374647265616DFF6161FF".HexToBytes());
+
+            Assert.Equal(new[] { "stream", "a" }, items);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
+++ b/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
@@ -722,17 +722,17 @@ namespace Dahomey.Cbor.Tests
         }
 
         [Fact]
-        public void AChunkedTypedArrayPayloadIsACborException()
+        public void AChunkedTypedArrayPayloadIsRead()
         {
             // RFC 8746 does not forbid an indefinite-length byte string as the tag content, and a
-            // producer streaming a large array is exactly where one shows up. The reader does not
-            // support chunked strings, but it has to say so as a CborException like every other
-            // unreadable-input error, or it escapes the handler a caller has written.
+            // producer streaming a large array is exactly where one shows up. An indefinite-length
+            // string denotes the concatenation of its chunks, so the payload is the same eight bytes
+            // it would have been in one piece and the array decodes identically.
             // D855 tag(85) 5F bytes(*) 44 0000C03F 44 00002040 FF
-            CborException exception = AssertThrowsCborException(
-                () => Cbor.Deserialize<float[]>("D8555F440000C03F4400002040FF".HexToBytes(), TypedArrayOptions()));
+            float[] value = Cbor.Deserialize<float[]>(
+                "D8555F440000C03F4400002040FF".HexToBytes(), TypedArrayOptions());
 
-            Assert.Contains("Indefinite-length", exception.Message);
+            Assert.Equal(new[] { 1.5f, 2.5f }, value);
         }
 
         [Fact]

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -1038,20 +1038,28 @@ namespace Dahomey.Cbor.Serialization
         /// </remarks>
         private ReadOnlySpan<byte> ReadChunks(CborMajorType majorType)
         {
-            return ReadChunksArray(majorType);
+            byte[] joined = ReadChunksArray(majorType, out int length);
+
+            return new ReadOnlySpan<byte>(joined, 0, length);
         }
 
         /// <inheritdoc cref="ReadChunks"/>
         /// <remarks>
+        /// The buffer grows by doubling, so it is usually longer than the value; the caller is handed
+        /// the length and takes a window over it rather than an exactly sized array. Trimming here
+        /// instead would copy the whole value again on every overshoot, on the two paths that read a
+        /// string rather than the one that reads a sequence.
+        /// <para>
         /// A plain array rather than <c>ByteBufferWriter</c>, which is the obvious tool and the wrong
         /// one: it rents from <see cref="System.Buffers.ArrayPool{T}"/>, and the result outlives this
         /// call, so a pooled buffer would be returned and handed to another caller underneath the one
         /// holding it.
+        /// </para>
         /// </remarks>
-        private byte[] ReadChunksArray(CborMajorType majorType)
+        private byte[] ReadChunksArray(CborMajorType majorType, out int length)
         {
             byte[] joined = Array.Empty<byte>();
-            int length = 0;
+            length = 0;
 
             while (!IsBreak())
             {
@@ -1068,14 +1076,7 @@ namespace Dahomey.Cbor.Serialization
 
             ConsumeBreak();
 
-            return length == joined.Length ? joined : Trim(joined, length);
-        }
-
-        private static byte[] Trim(byte[] buffer, int length)
-        {
-            byte[] exact = new byte[length];
-            Array.Copy(buffer, exact, length);
-            return exact;
+            return joined;
         }
 
         /// <summary>
@@ -1151,8 +1152,10 @@ namespace Dahomey.Cbor.Serialization
             if (size == -1)
             {
                 // The chunks are not contiguous in the input, so there is no slice of it to hand back;
-                // the joined copy becomes the sequence.
-                return new ReadOnlySequence<byte>(ReadChunksArray(majorType));
+                // the joined copy becomes the sequence, windowed to the length actually read.
+                byte[] joined = ReadChunksArray(majorType, out int length);
+
+                return new ReadOnlySequence<byte>(joined, 0, length);
             }
 
             ExpectLength(size);

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -1010,14 +1010,89 @@ namespace Dahomey.Cbor.Serialization
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ReadOnlySpan<byte> ReadSizeAndBytes(bool allowScratchBuffer)
         {
+            CborMajorType majorType = GetHeader().MajorType;
             int size = ReadSize();
 
             if (size == -1)
             {
-                ThrowIndefiniteLengthString();
+                return ReadChunks(majorType);
             }
 
             return ReadBytes(size, allowScratchBuffer);
+        }
+
+        /// <summary>
+        /// Reads an RFC 8949 section 3.2.3 indefinite-length string: zero or more definite-length
+        /// chunks of <paramref name="majorType"/>, terminated by a break, concatenated into one value.
+        /// </summary>
+        /// <remarks>
+        /// The chunk boundaries carry no meaning — an indefinite-length string denotes exactly the
+        /// concatenation of its chunks, so a caller cannot tell one from the definite-length string of
+        /// the same content, and neither can a UTF-8 decode: a multi-byte character may straddle a
+        /// chunk boundary, which is why the bytes are joined before decoding rather than per chunk.
+        /// <para>
+        /// The result is a freshly allocated array rather than a slice of the input or the scratch
+        /// buffer, because the pieces are not contiguous in either. That allocation is confined to
+        /// documents that actually use the encoding; a definite-length string does not reach here.
+        /// </para>
+        /// </remarks>
+        private ReadOnlySpan<byte> ReadChunks(CborMajorType majorType)
+        {
+            byte[] joined = Array.Empty<byte>();
+            int length = 0;
+
+            while (!IsBreak())
+            {
+                ReadOnlySpan<byte> chunk = ReadChunk(majorType);
+
+                if (length + chunk.Length > joined.Length)
+                {
+                    Array.Resize(ref joined, Math.Max(length + chunk.Length, joined.Length * 2));
+                }
+
+                chunk.CopyTo(joined.AsSpan(length));
+                length += chunk.Length;
+            }
+
+            ConsumeBreak();
+
+            return new ReadOnlySpan<byte>(joined, 0, length);
+        }
+
+        /// <summary>
+        /// One chunk of an indefinite-length string. A chunk must be a definite-length string of the
+        /// same major type: anything else, including a nested indefinite-length string, is malformed
+        /// rather than something to interpret.
+        /// </summary>
+        private ReadOnlySpan<byte> ReadChunk(CborMajorType majorType)
+        {
+            CborReaderHeader header = GetHeader();
+
+            if (header.MajorType != majorType)
+            {
+                ThrowCbor($"Expected major type {majorType} in an indefinite-length string chunk, found {header.MajorType}");
+            }
+
+            int size = ReadSize();
+
+            if (size == -1)
+            {
+                ThrowCbor("An indefinite-length string cannot contain another indefinite-length string");
+            }
+
+            // Never the scratch buffer: it is a single shared buffer, so the next chunk would overwrite
+            // this one before it has been copied out.
+            return ReadBytes(size, allowScratchBuffer: false);
+        }
+
+        /// <summary>
+        /// Settles the reader past a break whose header <see cref="IsBreak"/> has already read.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ConsumeBreak()
+        {
+            GetHeader();
+            _state = CborReaderState.Data;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1045,11 +1120,14 @@ namespace Dahomey.Cbor.Serialization
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ReadOnlySequence<byte> ReadSizeAndSequence()
         {
+            CborMajorType majorType = GetHeader().MajorType;
             int size = ReadSize();
 
             if (size == -1)
             {
-                ThrowIndefiniteLengthString();
+                // The chunks are not contiguous in the input, so there is no slice of it to hand back;
+                // the joined copy becomes the sequence.
+                return new ReadOnlySequence<byte>(ReadChunks(majorType).ToArray());
             }
 
             ExpectLength(size);
@@ -1218,11 +1296,20 @@ namespace Dahomey.Cbor.Serialization
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SkipSizeAndBytes()
         {
+            CborMajorType majorType = GetHeader().MajorType;
             int size = ReadSize();
 
             if (size == -1)
             {
-                ThrowIndefiniteLengthString();
+                // Skipping still validates the chunks: a malformed indefinite-length string must not
+                // pass unnoticed just because its value was not wanted.
+                while (!IsBreak())
+                {
+                    ReadChunk(majorType);
+                }
+
+                ConsumeBreak();
+                return;
             }
 
             ExpectLength(size);
@@ -1357,21 +1444,5 @@ namespace Dahomey.Cbor.Serialization
             throw BuildException(message);
         }
 
-        /// <summary>
-        /// Indefinite-length byte and text strings - RFC 8949 §3.2.3, a chunked string terminated by a
-        /// break marker - are not supported by this reader.
-        /// </summary>
-        /// <remarks>
-        /// This is a <see cref="CborException"/> rather than a <see cref="NotSupportedException"/> so
-        /// that it is caught by the same handler as every other malformed- or unreadable-input error.
-        /// A caller has no way to tell the two apart at the point of the read, and a chunked string is
-        /// a property of the document, not of the API being misused.
-        /// </remarks>
-        private void ThrowIndefiniteLengthString()
-        {
-            throw BuildException(
-                "Indefinite-length byte and text strings are not supported. "
-                + "Re-encode the value as a single definite-length string.");
-        }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -1038,6 +1038,18 @@ namespace Dahomey.Cbor.Serialization
         /// </remarks>
         private ReadOnlySpan<byte> ReadChunks(CborMajorType majorType)
         {
+            return ReadChunksArray(majorType);
+        }
+
+        /// <inheritdoc cref="ReadChunks"/>
+        /// <remarks>
+        /// A plain array rather than <c>ByteBufferWriter</c>, which is the obvious tool and the wrong
+        /// one: it rents from <see cref="System.Buffers.ArrayPool{T}"/>, and the result outlives this
+        /// call, so a pooled buffer would be returned and handed to another caller underneath the one
+        /// holding it.
+        /// </remarks>
+        private byte[] ReadChunksArray(CborMajorType majorType)
+        {
             byte[] joined = Array.Empty<byte>();
             int length = 0;
 
@@ -1056,7 +1068,14 @@ namespace Dahomey.Cbor.Serialization
 
             ConsumeBreak();
 
-            return new ReadOnlySpan<byte>(joined, 0, length);
+            return length == joined.Length ? joined : Trim(joined, length);
+        }
+
+        private static byte[] Trim(byte[] buffer, int length)
+        {
+            byte[] exact = new byte[length];
+            Array.Copy(buffer, exact, length);
+            return exact;
         }
 
         /// <summary>
@@ -1088,6 +1107,12 @@ namespace Dahomey.Cbor.Serialization
         /// <summary>
         /// Settles the reader past a break whose header <see cref="IsBreak"/> has already read.
         /// </summary>
+        /// <remarks>
+        /// Settles to <see cref="CborReaderState.Data"/> where <c>SkipArray</c> and <c>SkipMap</c>
+        /// settle to <see cref="CborReaderState.Start"/>. Equivalent in effect: only <c>Header</c> is
+        /// ever tested for, by <see cref="GetHeader"/>, and both values mean "the cached header has
+        /// been consumed". <c>Data</c> matches what <see cref="SkipDataItem"/> does for a break.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ConsumeBreak()
         {
@@ -1127,7 +1152,7 @@ namespace Dahomey.Cbor.Serialization
             {
                 // The chunks are not contiguous in the input, so there is no slice of it to hand back;
                 // the joined copy becomes the sequence.
-                return new ReadOnlySequence<byte>(ReadChunks(majorType).ToArray());
+                return new ReadOnlySequence<byte>(ReadChunksArray(majorType));
             }
 
             ExpectLength(size);


### PR DESCRIPTION
Reads RFC 8949 §3.2.3 indefinite-length byte and text strings, which the reader refused.

```csharp
Cbor.Deserialize<string>("7F 62'st' 64'ream' FF")   // was: NotSupportedException
                                                     // now: "stream"
```

This is core format rather than an extension — any encoder may emit it, and it is what a producer that does not yet know a value's length emits. `ReadSizeAndBytes`, `ReadSizeAndSequence` and `SkipSizeAndBytes` all called `ThrowNotSupported()` on a size of `-1`, which surfaced as a bare `NotSupportedException` that a caller's `catch (CborException)` does not catch.

## The library already disagreed with itself

`CborDataItemScanner` walks this shape correctly — it has since #154. So the scanner reported a document **`Complete`** that `Cbor.Deserialize` then threw on. `TheScannerAndTheReaderAgreeOnAChunkedString` pins that they no longer do, and it matters for #134: anything built on the scanner, which is the streaming primitive #139 asked for, meets this immediately.

## Decisions worth stating

**The chunks are joined before decoding, not decoded per chunk.** A multi-byte character may straddle a boundary — `7F 61E2 6282AC FF` is one EURO SIGN, and two invalid fragments to anything that decodes each chunk on its own. `AUtf8CharacterMaySpanAChunkBoundary` is that case.

**The result is a fresh array, not a slice.** The pieces are contiguous in neither the input nor the scratch buffer, and the scratch buffer is a single shared one the next chunk would overwrite. The allocation is confined to documents that use the encoding — a definite-length string does not reach the code, and `ReadSizeAndBytes` still returns a slice for it.

**Two shapes are malformed and refused rather than interpreted**, both as `CborException`: a chunk whose major type differs from the enclosing string, which would otherwise turn bytes into text nobody wrote, and a nested indefinite-length string. **Skipping validates them too** — a chunked value in a member nobody asked for must not pass unnoticed and derail the rest of the map, which `AChunkedStringIsSkippedCorrectly` pins.

**Read only.** Writing indefinite-length strings is a separate question — `LengthMode.IndefiniteLength` applies to arrays and maps, and nothing here changes what is written.

## Relationship to #157

#157's first commit makes these three sites throw a `CborException` instead of a `NotSupportedException`. This supersedes it: the sites no longer throw at all. If this lands first I will drop that commit from #157; if #157 lands first this rebases over it cleanly, since it replaces the same three bodies.

## Tests

`ChunkedStringTests.cs`, 17 cases: both major types, one, three and zero chunks, a character spanning a boundary, into a member and into the object model, skipped, as a `ReadOnlySequence`, inside an indefinite-length array so the string's break is not taken for the array's, both malformed shapes, and the scanner/reader agreement. `Helper.Read` runs the text cases through the span, sequence and fragmented readers, so the segmented path is covered rather than assumed.

1121 tests pass on net10.0, up from 1104. All four TFMs build.

## What this does not close

Two further gaps I confirmed by running them against `master`, neither touched here:

* **Duplicate map keys** (§5.6) throw `ArgumentException` from the backing dictionary — again outside the `CborException` contract.
* Tags 2–5 decode structurally (a bignum arrives as a byte string, a decimal fraction as an array) rather than semantically. That is permitted, but it is where `System.Formats.Cbor` is ahead.

Happy to take either if you want them.
