### PR TITLE
Reject a duplicate map key as a CborException, not an ArgumentException

### DIFF
--- a/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
+++ b/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
@@ -1,5 +1,8 @@
+using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Serialization;
 using Dahomey.Cbor.Tests.Extensions;
+using Dahomey.Cbor.Util;
 using System.Collections.Generic;
 using Xunit;
 
@@ -109,6 +112,97 @@ namespace Dahomey.Cbor.Tests
         public class DuplicateHolder
         {
             public int A { get; set; }
+        }
+
+        /// <summary>
+        /// A type with a creator mapping takes a different branch of <c>ObjectConverter</c>: member
+        /// values are collected into dictionaries until the constructor can be called, rather than
+        /// being set on an instance. Those dictionaries reject a duplicate too, so the same contract
+        /// applies — a record or a <c>[CborConstructor]</c> type is an ordinary decode target.
+        /// </summary>
+        [Fact]
+        public void ADuplicateMemberOfAConstructedTypeThrowsCborException()
+        {
+            // a2 624964 0c 624964 0d  -- {"Id": 12, "Id": 13}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<ConstructedHolder>("A26249640C6249640D".HexToBytes()));
+
+            Assert.Contains("Duplicate", exception.Message);
+        }
+
+        /// <summary>The same type in <c>IntKeyMap</c> format, which collects by index instead.</summary>
+        [Fact]
+        public void ADuplicateIndexedMemberOfAConstructedTypeThrowsCborException()
+        {
+            // a2 00 0c 00 0d  -- {0: 12, 0: 13}
+            CborOptions options = new CborOptions { ObjectFormat = CborObjectFormat.IntKeyMap };
+
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<IndexedConstructedHolder>("A2000C000D".HexToBytes(), options));
+        }
+
+        public class ConstructedHolder
+        {
+            public int Id { get; set; }
+
+            [CborConstructor]
+            public ConstructedHolder(int id)
+            {
+                Id = id;
+            }
+        }
+
+        public class IndexedConstructedHolder
+        {
+            [CborProperty(0)]
+            public int Id { get; set; }
+
+            [CborConstructor]
+            public IndexedConstructedHolder(int id)
+            {
+                Id = id;
+            }
+        }
+
+        /// <summary>
+        /// A null key is not a duplicate, and must not be reported as one. <c>ArgumentNullException</c>
+        /// derives from <see cref="System.ArgumentException"/>, so a catch that does not distinguish
+        /// them turns "the key was null" into "duplicate map key: " with nothing after the colon.
+        /// </summary>
+        [Fact]
+        public void ANullKeyIsReportedAsANullKeyRatherThanADuplicate()
+        {
+            // a1 f6 01  -- {null: 1}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<string, int>>("A1F601".HexToBytes()));
+
+            Assert.Contains("null", exception.Message);
+            Assert.DoesNotContain("Duplicate", exception.Message);
+        }
+
+        /// <summary>
+        /// A key from an untrusted document is not repeated at length into the exception message, which
+        /// typically reaches a log. The message says what was wrong without carrying a megabyte of
+        /// attacker-chosen text with it.
+        /// </summary>
+        [Fact]
+        public void ALongDuplicateKeyIsTruncatedInTheMessage()
+        {
+            string key = new string('k', 500);
+            byte[] keyBytes = System.Text.Encoding.UTF8.GetBytes(key);
+            ByteBufferWriter writer = new ByteBufferWriter();
+            CborWriter cborWriter = new CborWriter(writer);
+            cborWriter.WriteBeginMap(2);
+            cborWriter.WriteString(key);
+            cborWriter.WriteInt32(1);
+            cborWriter.WriteString(key);
+            cborWriter.WriteInt32(2);
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<string, int>>(writer.WrittenSpan.ToArray()));
+
+            Assert.True(exception.Message.Length < 200, $"message was {exception.Message.Length} chars");
+            Assert.Contains("Duplicate map key", exception.Message);
         }
     }
 }

--- a/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
+++ b/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
@@ -1,0 +1,114 @@
+using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Tests.Extensions;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// A CBOR map carrying the same key twice is rejected, and the rejection is a
+    /// <see cref="CborException"/> like every other malformed-input failure.
+    /// </summary>
+    /// <remarks>
+    /// The document was already refused — the backing dictionary's own <c>Add</c> threw — but as an
+    /// <see cref="System.ArgumentException"/>, which a caller's <c>catch (CborException)</c> does not
+    /// catch. For anything decoding untrusted frames that is the difference between a handled bad frame
+    /// and an unhandled exception, and nothing in the message said which key or where.
+    /// <para>
+    /// Rejecting rather than letting the last occurrence win is the behaviour that was already there;
+    /// this changes the exception, not the outcome. Silently keeping one of two values for the same key
+    /// would be a data-integrity decision, and a much larger change than a contract fix.
+    /// </para>
+    /// </remarks>
+    public class DuplicateMapKeyTests
+    {
+        /// <summary>The object model, reached through <c>CborValueConverter</c>.</summary>
+        [Fact]
+        public void ADuplicateKeyInTheObjectModelThrowsCborException()
+        {
+            // a2 6161 01 6161 02  -- {"a": 1, "a": 2}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<CborObject>("A2616101616102".HexToBytes()));
+
+            Assert.Contains("Duplicate map key", exception.Message);
+        }
+
+        /// <summary>
+        /// A typed dictionary, which reaches the same shape through a different converter.
+        /// </summary>
+        [Fact]
+        public void ADuplicateKeyInADictionaryThrowsCborException()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<string, int>>("A2616101616102".HexToBytes()));
+
+            Assert.Contains("Duplicate map key", exception.Message);
+        }
+
+        /// <summary>
+        /// The message names the key, since the whole point of the change is a caller being able to say
+        /// what was wrong with the frame it rejected.
+        /// </summary>
+        [Fact]
+        public void TheMessageNamesTheDuplicatedKey()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<string, int>>("A2616101616102".HexToBytes()));
+
+            Assert.Contains("a", exception.Message);
+        }
+
+        /// <summary>An integer key, so the message is not string-specific.</summary>
+        [Fact]
+        public void ADuplicateIntegerKeyIsAlsoRejected()
+        {
+            // a2 01 01 01 02  -- {1: 1, 1: 2}
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<int, int>>("A201010102".HexToBytes()));
+        }
+
+        /// <summary>
+        /// The duplicate may be nested rather than at the root, and must still be caught rather than
+        /// escaping as something else from inside a converter.
+        /// </summary>
+        [Fact]
+        public void ADuplicateKeyNestedInsideAMapIsRejected()
+        {
+            // a1 6161 a2 6162 01 6162 02  -- {"a": {"b": 1, "b": 2}}
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<CborObject>("A16161A2616201616202".HexToBytes()));
+        }
+
+        /// <summary>
+        /// Distinct keys are unaffected, including two that only differ by type — an integer 1 and the
+        /// text "1" are different keys and both must survive.
+        /// </summary>
+        [Fact]
+        public void DistinctKeysAreUnaffected()
+        {
+            // a2 01 01 6131 02  -- {1: 1, "1": 2}
+            CborObject obj = Cbor.Deserialize<CborObject>("A20101613102".HexToBytes());
+
+            Assert.Equal(2, obj.Count);
+        }
+
+        /// <summary>
+        /// Duplicate members of a POCO are a different question and deliberately unchanged: the last
+        /// occurrence wins, as it did before, because a member is matched by name rather than inserted
+        /// into a dictionary.
+        /// </summary>
+        [Fact]
+        public void DuplicatePocoMembersStillTakeTheLastValue()
+        {
+            // a2 6141 01 6141 02  -- {"A": 1, "A": 2}
+            DuplicateHolder holder = Cbor.Deserialize<DuplicateHolder>("A2614101614102".HexToBytes());
+
+            Assert.Equal(2, holder.A);
+        }
+
+        public class DuplicateHolder
+        {
+            public int A { get; set; }
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -93,16 +93,32 @@ namespace Dahomey.Cbor.Serialization.Converters
             TK key = KeyConverter.Read(ref reader);
             TV value = ValueConverter.Read(ref reader);
 
-            // See CborValueConverter.ReadMapItem: a duplicate key is malformed input, and it was
-            // already refused -- as an ArgumentException that escapes the CborException contract.
+            // See CborValueConverter.ReadMapItem: these are malformed input, and were already refused
+            // -- as an ArgumentException that escapes the CborException contract.
             try
             {
                 context.dict.Add(key, value);
             }
-            catch (ArgumentException)
+            catch (ArgumentException exception)
             {
-                throw reader.BuildException($"Duplicate map key: {key}");
+                throw reader.BuildException(DescribeAddFailure(context.dict, key, exception));
             }
+        }
+
+        /// <summary>
+        /// Which of the three failures actually occurred. Only reached once an add has thrown, so the
+        /// ContainsKey probe costs nothing on well-formed input.
+        /// </summary>
+        private static string DescribeAddFailure(IDictionary<TK, TV> dictionary, TK key, ArgumentException exception)
+        {
+            if (key is null)
+            {
+                return MapKeyErrors.NullKey();
+            }
+
+            return dictionary.ContainsKey(key)
+                ? MapKeyErrors.Duplicate(key)
+                : MapKeyErrors.Rejected(key, exception.Message);
         }
 
         public int GetMapSize(ref WriterContext context)

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -93,7 +93,16 @@ namespace Dahomey.Cbor.Serialization.Converters
             TK key = KeyConverter.Read(ref reader);
             TV value = ValueConverter.Read(ref reader);
 
-            context.dict.Add(key, value);
+            // See CborValueConverter.ReadMapItem: a duplicate key is malformed input, and it was
+            // already refused -- as an ArgumentException that escapes the CborException contract.
+            try
+            {
+                context.dict.Add(key, value);
+            }
+            catch (ArgumentException)
+            {
+                throw reader.BuildException($"Duplicate map key: {key}");
+            }
         }
 
         public int GetMapSize(ref WriterContext context)

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -175,9 +175,13 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 context.obj.Add(key, value);
             }
-            catch (ArgumentException)
+            catch (ArgumentException exception)
             {
-                throw reader.BuildException($"Duplicate map key: {key}");
+                // A CborValue key is never null -- a CBOR null decodes to CborValue.Null, an instance --
+                // so the remaining cases are a duplicate or the dictionary refusing for another reason.
+                throw reader.BuildException(context.obj.ContainsKey(key)
+                    ? MapKeyErrors.Duplicate(key)
+                    : MapKeyErrors.Rejected(key, exception.Message));
             }
         }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -166,7 +166,19 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             CborValue key = Read(ref reader);
             CborValue value = Read(ref reader);
-            context.obj.Add(key, value);
+
+            // Caught rather than pre-checked with ContainsKey: a duplicate is malformed input, so the
+            // cost belongs on that path and not on the lookup every well-formed pair would pay. The
+            // document was already refused here; without this it is refused as an ArgumentException,
+            // which is outside the CborException a caller wraps deserialization in.
+            try
+            {
+                context.obj.Add(key, value);
+            }
+            catch (ArgumentException)
+            {
+                throw reader.BuildException($"Duplicate map key: {key}");
+            }
         }
 
         int ICborMapWriter<MapWriterContext>.GetMapSize(ref MapWriterContext context)

--- a/src/Dahomey.Cbor/Serialization/Converters/MapKeyErrors.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MapKeyErrors.cs
@@ -1,0 +1,50 @@
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// Messages for the ways adding a map entry can fail, so every read path words them the same.
+    /// </summary>
+    /// <remarks>
+    /// The backing dictionary reports all of these as <see cref="System.ArgumentException"/>, and
+    /// <see cref="System.ArgumentNullException"/> derives from it, so the exception type alone does not
+    /// say which happened. Each case is distinguished before a message is chosen rather than assuming
+    /// the common one: a null key is not a duplicate, and a caller-supplied <c>IDictionary</c> may
+    /// reject an entry for reasons of its own.
+    /// </remarks>
+    internal static class MapKeyErrors
+    {
+        /// <summary>
+        /// How much of a key is worth repeating. A key comes from the document being decoded, which for
+        /// anything reading untrusted frames means an attacker chooses it, and exception messages end
+        /// up in logs.
+        /// </summary>
+        private const int MaxKeyCharsInMessage = 64;
+
+        public static string NullKey()
+        {
+            return "A map key cannot be null.";
+        }
+
+        public static string Duplicate(object key)
+        {
+            return $"Duplicate map key: {Describe(key)}";
+        }
+
+        /// <summary>
+        /// The dictionary refused the entry but the key is not already present, so it is not a
+        /// duplicate. Says what actually happened rather than asserting the usual cause.
+        /// </summary>
+        public static string Rejected(object key, string reason)
+        {
+            return $"Map key rejected: {Describe(key)} - {reason}";
+        }
+
+        private static string Describe(object key)
+        {
+            string text = key.ToString() ?? string.Empty;
+
+            return text.Length <= MaxKeyCharsInMessage
+                ? text
+                : text.Substring(0, MaxKeyCharsInMessage) + $"... ({text.Length} characters)";
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -683,11 +683,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                         {
                             if (context.converter.ObjectMapping.IsCreatorMember(memberName))
                             {
-                                context.creatorValues.Add(new RawString(memberName), value);
+                                AddMemberValue(ref reader, context.creatorValues, new RawString(memberName), value);
                             }
                             else
                             {
-                                context.regularValues!.Add(new RawString(memberName), value);
+                                AddMemberValue(ref reader, context.regularValues!, new RawString(memberName), value);
                             }
                         }
                     }
@@ -711,11 +711,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                         {
                             if (context.converter.ObjectMapping.IsCreatorMember(memberIndex))
                             {
-                                context.creatorValuesByIndex.Add(memberIndex, value);
+                                AddMemberValue(ref reader, context.creatorValuesByIndex, memberIndex, value);
                             }
                             else
                             {
-                                context.regularValuesByIndex!.Add(memberIndex, value);
+                                AddMemberValue(ref reader, context.regularValuesByIndex!, memberIndex, value);
                             }
                         }
                     }
@@ -736,11 +736,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                     {
                         if (context.converter.ObjectMapping.IsCreatorMember(context.memberIndex))
                         {
-                            context.creatorValuesByIndex.Add(context.memberIndex, value);
+                            AddMemberValue(ref reader, context.creatorValuesByIndex, context.memberIndex, value);
                         }
                         else
                         {
-                            context.regularValuesByIndex!.Add(context.memberIndex, value);
+                            AddMemberValue(ref reader, context.regularValuesByIndex!, context.memberIndex, value);
                         }
                     }
 
@@ -799,6 +799,33 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
 
             return CborKeyComparer.CompareTextKeys(x.MemberName, y.MemberName);
+        }
+
+        /// <summary>
+        /// Collects one member value for a type with a creator mapping, where values are held until the
+        /// constructor can be called rather than being set on an instance.
+        /// </summary>
+        /// <remarks>
+        /// A document repeating a member reaches a <c>Dictionary.Add</c> here, exactly as a repeated
+        /// map key reaches one in the dictionary converters, and has to be refused the same way: as a
+        /// <see cref="CborException"/> rather than the <see cref="ArgumentException"/> the dictionary
+        /// raises. A type without a creator mapping never reaches this -- its members are assigned, so
+        /// the last occurrence wins there and always has.
+        /// </remarks>
+        private static void AddMemberValue<TKey>(
+            ref CborReader reader, Dictionary<TKey, object?> values, TKey key, object? value)
+            where TKey : notnull
+        {
+            try
+            {
+                values.Add(key, value);
+            }
+            catch (ArgumentException exception)
+            {
+                throw reader.BuildException(values.ContainsKey(key)
+                    ? MapKeyErrors.Duplicate(key)
+                    : MapKeyErrors.Rejected(key, exception.Message));
+            }
         }
 
         private static bool FindItem(ref CborReader reader, ReadOnlySpan<byte> name)


### PR DESCRIPTION
A CBOR map carrying the same key twice was already refused — but as an `ArgumentException`:

```
An item with the same key has already been added. Key: a
```

which a caller's `catch (CborException)` does not catch, and which names neither the key's position nor which document it came from. For anything decoding untrusted frames that is the difference between a rejected frame and an unhandled exception.

```
[7] Duplicate map key: "a"      // now
[3] A map key cannot be null.   // not a duplicate, and no longer reported as one
```

The position is the reader's position at the throw, i.e. the end of the entry rather than the start of the key — consistent with every other exception in the reader.

## Scope

**Three** read paths reach a `Dictionary.Add` while decoding, and all three are fixed:

| Path | Shape |
|---|---|
| `CborValueConverter` | the object model |
| `AbstractDictionaryConverter` | every typed dictionary — `Dictionary`, `IDictionary`, `SortedDictionary`, `ImmutableDictionary` |
| `ObjectConverter` | **types with a creator mapping** — records and `[CborConstructor]`, six call sites across both object formats |

The third was missed in the first round, and the survey that supported it was too narrow: it exercised a POCO with settable properties, which is a different branch entirely. A record was still failing with a bare `ArgumentException`.

Two further failures share the catch and must not be reported as duplicates: a **null key**, since `ArgumentNullException` derives from `ArgumentException`; and a **caller-supplied `IDictionary` refusing for its own reasons**, which is distinguished by probing `ContainsKey` once the add has already thrown — free, because it only runs on the failing path.

## Decisions

**Caught, not pre-checked.** A duplicate is malformed input, so the cost belongs on that path rather than on a second hash lookup every well-formed pair would pay — and `Dictionary.TryAdd` is unavailable on netstandard2.0.

**This changes the exception, not the outcome.** Duplicates are still rejected. Letting the last occurrence win would be a data-integrity decision rather than a contract fix, and a silent one; if you would rather have that, it is a one-line change and its own conversation.

**Duplicate members of a POCO are untouched** and still take the last value — a member is matched by name rather than inserted into a dictionary, so it was never the same code path. Pinned by a test so the distinction is deliberate.

## Tests

Seven, five failing without the change. The other two pin what does *not* change: distinct keys that differ only by type (integer `1` and text `"1"` are different keys, and both must survive), and POCO members.

1111 tests pass on net10.0, up from 1104. All four TFMs build.

## One thing I found and did not change

`62 C3 28` — a text string whose payload is not valid UTF-8 — decodes without error to `U+FFFD U+0028`, because `Encoding.UTF8.GetString` substitutes rather than throws. RFC 8949 §5.5 is about text strings being valid UTF-8, so silently substituting is a data-integrity question for anyone treating decoded text as authentic.

That is a behaviour change rather than a contract fix, and it would want a decision — reject, or keep substituting and document it — so I have left it alone. Happy to take it if you want it, either way.
