### PR TITLE
Remove CborValue.SetValue<T>, closes #168

### DIFF
--- a/src/Dahomey.Cbor/ObjectModel/CborBoolean.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborBoolean.cs
@@ -7,7 +7,7 @@ namespace Dahomey.Cbor.ObjectModel
         private readonly static CborBoolean _false = new CborBoolean(false);
         private readonly static CborBoolean _true = new CborBoolean(true);
 
-        private bool _value;
+        private readonly bool _value;
 
         public override CborValueType Type { get { return CborValueType.Boolean; } }
 
@@ -31,10 +31,6 @@ namespace Dahomey.Cbor.ObjectModel
             return Primitive<bool, T>.Converter(_value);
         }
 
-        public void SetValue<T>(T value)
-        {
-            _value = Primitive<T, bool>.Converter(value);
-        }
 
         public static implicit operator CborBoolean(bool value)
         {

--- a/src/Dahomey.Cbor/ObjectModel/CborDecimal.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborDecimal.cs
@@ -16,7 +16,7 @@ namespace Dahomey.Cbor.ObjectModel
                 .Select(i => new CborDecimal(i))
                 .ToArray();
 
-        private decimal _value;
+        private readonly decimal _value;
 
         public override CborValueType Type { get { return CborValueType.Decimal; } }
 
@@ -40,10 +40,6 @@ namespace Dahomey.Cbor.ObjectModel
             return Primitive<decimal, T>.Converter(_value);
         }
 
-        public void SetValue<T>(T value)
-        {
-            _value = Primitive<T, decimal>.Converter(value);
-        }
 
         public static implicit operator CborDecimal(decimal value)
         {

--- a/src/Dahomey.Cbor/ObjectModel/CborDouble.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborDouble.cs
@@ -16,7 +16,7 @@ namespace Dahomey.Cbor.ObjectModel
                 .Select(i => new CborDouble(i))
                 .ToArray();
 
-        private double _value;
+        private readonly double _value;
 
         public override CborValueType Type { get { return CborValueType.Double; } }
 
@@ -40,10 +40,6 @@ namespace Dahomey.Cbor.ObjectModel
             return Primitive<double, T>.Converter(_value);
         }
 
-        public void SetValue<T>(T value)
-        {
-            _value = Primitive<T, double>.Converter(value);
-        }
 
         public static implicit operator CborDouble(double value)
         {

--- a/src/Dahomey.Cbor/ObjectModel/CborNegative.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborNegative.cs
@@ -15,7 +15,7 @@ namespace Dahomey.Cbor.ObjectModel
                 .Select(i => new CborNegative(i))
                 .ToArray();
 
-        private long _value;
+        private readonly long _value;
 
         public override CborValueType Type => CborValueType.Negative;
 
@@ -44,10 +44,6 @@ namespace Dahomey.Cbor.ObjectModel
             return Primitive<long, T>.Converter(_value);
         }
 
-        public void SetValue<T>(T value)
-        {
-            _value = Primitive<T, long>.Converter(value);
-        }
 
         public static implicit operator CborNegative(long value)
         {

--- a/src/Dahomey.Cbor/ObjectModel/CborPositive.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborPositive.cs
@@ -15,7 +15,7 @@ namespace Dahomey.Cbor.ObjectModel
                 .Select(i => new CborPositive((ulong)i))
                 .ToArray();
 
-        private ulong _value;
+        private readonly ulong _value;
 
         public override CborValueType Type { get { return CborValueType.Positive; } }
 
@@ -39,10 +39,6 @@ namespace Dahomey.Cbor.ObjectModel
             return Primitive<ulong, T>.Converter(_value);
         }
 
-        public void SetValue<T>(T value)
-        {
-            _value = Primitive<T, ulong>.Converter(value);
-        }
 
         public static implicit operator CborPositive(ulong value)
         {

--- a/src/Dahomey.Cbor/ObjectModel/CborSingle.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborSingle.cs
@@ -16,7 +16,7 @@ namespace Dahomey.Cbor.ObjectModel
                 .Select(i => new CborSingle(i))
                 .ToArray();
 
-        private float _value;
+        private readonly float _value;
 
         public override CborValueType Type { get { return CborValueType.Single; } }
 
@@ -40,10 +40,6 @@ namespace Dahomey.Cbor.ObjectModel
             return Primitive<float, T>.Converter(_value);
         }
 
-        public void SetValue<T>(T value)
-        {
-            _value = Primitive<T, float>.Converter(value);
-        }
 
         public static implicit operator CborSingle(float value)
         {

--- a/src/Dahomey.Cbor/ObjectModel/CborString.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborString.cs
@@ -6,7 +6,7 @@ namespace Dahomey.Cbor.ObjectModel
     {
         private readonly static CborString _empty = new CborString(string.Empty);
 
-        private string _value;
+        private readonly string _value;
 
         public override CborValueType Type { get { return CborValueType.String; } }
 
@@ -20,10 +20,6 @@ namespace Dahomey.Cbor.ObjectModel
             return Primitive<string, T>.Converter(_value);
         }
 
-        public void SetValue<T>(T value)
-        {
-            _value = Primitive<T, string>.Converter(value);
-        }
 
         public static implicit operator CborString(string value)
         {


### PR DESCRIPTION
Closes #168, taking option 1 as agreed there, and both of your corrections to the issue.

## What it removes

`SetValue<T>` from all **seven** types that declare it — you were right that `CborString` has one too, and right that removing six of seven would leave a worse surface than either choice. Verified: zero call sites anywhere in `src/`, library and tests both, so nothing needed migrating and no test changed.

The bug it removes, for the record:

```csharp
((CborPositive)five).SetValue(999);

(CborValue)5                     ->  1903E7        // 999, a literal never deserialized
Cbor.Deserialize<CborValue>(05)  ->  1903E7
new CborArray { 5, 6 }           ->  821903E706
```

Six of the seven hand out shared instances — `CborPositive`/`CborNegative` for 0–100, `CborSingle`/`CborDouble`/`CborDecimal` for small whole numbers, `CborBoolean` for both values.

## Why removal rather than the alternatives

Your reasoning, which I agree with and will not restate at length: a working replacement already exists in the settable indexers on `CborObject` and `CborArray`, so this takes away no capability; documenting cannot work when correctness depends on whether the value happens to sit in a cache table; throwing on a cached instance would freeze the cache ranges as observable behaviour; and copy-on-write is a break too, without shrinking the surface.

## One thing beyond the removal

The backing fields are now `readonly`. Nothing else assigned them — each had exactly one assignment, in its constructor — so this is what makes the immutability real rather than a convention, and it means a future `SetValue` cannot be added back without the compiler objecting first.

## Versioning

Agreed this is a binary break on a public method of a public type and wants **1.27.0** with a release note rather than a patch. I have not touched the version in the csproj, since that is yours to set at release time — say if you would rather it were in this PR.

Not staged through `[Obsolete]`, for the reason you gave: with no known callers and silent process-wide corruption as the failure mode, keeping it alive while telling people not to call it is worse than removing it.

**1254 library tests and 35 generator tests pass on net10.0**; all four TFMs build.
