### PR TITLE
Report where in the model a read failed, closes #135

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Every failure raised while deserializing has a path, down to ``$`` for a documen
 requested type outright — so ``Path`` being ``null`` means the exception did not come from a read at
 all, such as a serialization failure or a mapping the registry refused to build.
 
+The path grows as the exception travels back up the stack, so read it once the read has failed rather
+than part of the way out of it: an intercepting ``catch`` that logs ``Message`` and rethrows sees only
+the path as far as it is known at that point.
+
 A path is as precise as the converters it passed through. A converter you register yourself is already
 named by the object holding it, and one that delegates to other converters inherits whatever they
 contribute — so most custom converters need do nothing. A converter that decodes a structure of its
@@ -105,7 +109,7 @@ public override Payload Read(ref CborReader reader)
     catch (CborException exception)
     {
         exception.PrependPathMember("Body");   // or PrependPathIndex(i) inside a sequence
-        throw;                                 // bare throw, so the stack trace survives
+        throw;                                 // rethrow the same exception, do not wrap it
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A read that fails throws a ``CborException`` naming both the offending byte offs
 the model it was reached from:
 
 ```
-[129] Expected major type TextString (3) Failed to deserialize from "$.Items[7].Name".
+[129] Expected major type TextString (3). Failed to deserialize from "$.Items[7].Name".
 ```
 
 The same path is available on its own, in the notation ``System.Text.Json`` uses, for code that needs
@@ -86,13 +86,18 @@ catch (CborException exception)
 }
 ```
 
-``$`` alone means the root value itself was wrong — the document contradicts the requested type
-outright. ``Path`` is ``null`` when no position could be determined, which is what a failure raised
-inside a converter you registered yourself looks like: custom converters contribute no segments, so a
-path stops at the member holding them.
+Every failure raised while deserializing has a path, down to ``$`` for a document that contradicts the
+requested type outright — so ``Path`` being ``null`` means the exception did not come from a read at
+all, such as a serialization failure or a mapping the registry refused to build.
 
-Text taken from the document — map keys and member names — is truncated in both the message and the
-path, so a message's length follows the shape of the document rather than the size of the values in it.
+A path is as precise as the converters it passed through. Converters you register yourself contribute
+no segment of their own, so a failure inside one is reported against the member that holds it rather
+than against anything within.
+
+Member names and map keys read the same way — ``$.Map.key`` — and are bracketed and escaped when they
+would otherwise be ambiguous: a member genuinely named ``a.b`` is written ``$['a.b']``. Text taken from
+the document is also truncated, so a message's length follows the shape of a document rather than the
+size of the values in it.
 
 ### Serialization
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,28 @@ Every failure raised while deserializing has a path, down to ``$`` for a documen
 requested type outright — so ``Path`` being ``null`` means the exception did not come from a read at
 all, such as a serialization failure or a mapping the registry refused to build.
 
-A path is as precise as the converters it passed through. Converters you register yourself contribute
-no segment of their own, so a failure inside one is reported against the member that holds it rather
-than against anything within.
+A path is as precise as the converters it passed through. A converter you register yourself is already
+named by the object holding it, and one that delegates to other converters inherits whatever they
+contribute — so most custom converters need do nothing. A converter that decodes a structure of its
+own can name positions inside it by adding a segment on the way out:
+
+```csharp
+public override Payload Read(ref CborReader reader)
+{
+    try
+    {
+        return ReadBody(ref reader);
+    }
+    catch (CborException exception)
+    {
+        exception.PrependPathMember("Body");   // or PrependPathIndex(i) inside a sequence
+        throw;                                 // bare throw, so the stack trace survives
+    }
+}
+```
+
+Each frame adds only its own segment, outermost last, and nothing is built until something has
+actually failed.
 
 Member names and map keys read the same way — ``$.Map.key`` — and are bracketed and escaped when they
 would otherwise be ambiguous: a member genuinely named ``a.b`` is written ``$['a.b']``. Text taken from

--- a/README.md
+++ b/README.md
@@ -62,6 +62,38 @@ Another option consists in using Dahomey.Cbor object model to deserialize the bu
 CborObject cborObject = await Cbor.DeserializeAsync<CborObject>(stream);
 ```
 
+#### Where a read failed
+
+A read that fails throws a ``CborException`` naming both the offending byte offset and the position in
+the model it was reached from:
+
+```
+[129] Expected major type TextString (3) Failed to deserialize from "$.Items[7].Name".
+```
+
+The same path is available on its own, in the notation ``System.Text.Json`` uses, for code that needs
+to act on it rather than log it:
+
+```csharp
+try
+{
+    return Cbor.Deserialize<CustomObject>(buffer);
+}
+catch (CborException exception)
+{
+    logger.LogWarning("rejected at {Path}", exception.Path);   // $.Items[7].Name
+    throw;
+}
+```
+
+``$`` alone means the root value itself was wrong — the document contradicts the requested type
+outright. ``Path`` is ``null`` when no position could be determined, which is what a failure raised
+inside a converter you registered yourself looks like: custom converters contribute no segments, so a
+path stops at the member holding them.
+
+Text taken from the document — map keys and member names — is truncated in both the message and the
+path, so a message's length follows the shape of the document rather than the size of the values in it.
+
 ### Serialization
 
 Any C# class can be serialized to CBOR buffer Stream:

--- a/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
+++ b/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
@@ -201,8 +201,12 @@ namespace Dahomey.Cbor.Tests
             CborException exception = Assert.Throws<CborException>(
                 () => Cbor.Deserialize<Dictionary<string, int>>(writer.WrittenSpan.ToArray()));
 
-            Assert.True(exception.Message.Length < 200, $"message was {exception.Message.Length} chars");
+            // Two bounded quotations of the key now, not one: the description of what went wrong and
+            // the path saying where. Both are truncated on the same terms, so the message stays a
+            // function of the document's shape rather than of the length of the key it carries.
+            Assert.True(exception.Message.Length < 300, $"message was {exception.Message.Length} chars");
             Assert.Contains("Duplicate map key", exception.Message);
+            Assert.DoesNotContain(key, exception.Message);
         }
     }
 }

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0135.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0135.cs
@@ -1,0 +1,232 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using Dahomey.Cbor.Util;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #135: a read failure reported the offending byte but not where in the model it was
+    /// reached, leaving the caller to map an offset back onto a POCO graph by hand.
+    /// </summary>
+    /// <remarks>
+    /// The path is assembled as the exception unwinds rather than tracked as the reader descends: the
+    /// reader is a <c>ref struct</c> that knows major types, not members, and the hot structural reads
+    /// are deliberately inlineable. Each converter names its own position on the way out, so
+    /// well-formed data pays nothing.
+    /// <para>
+    /// A path of <c>$</c> means the root value itself was wrong; a null <see cref="CborException.Path"/>
+    /// means no converter on the way up could name a position at all, which is what a failure inside a
+    /// caller-supplied converter looks like. Those are different answers and are kept apart.
+    /// </para>
+    /// </remarks>
+    public class Issue0135
+    {
+        private class Child
+        {
+            public string Name { get; set; }
+        }
+
+        private class Root
+        {
+            public Child Child { get; set; }
+            public List<Child> Items { get; set; }
+            public Dictionary<string, int> Map { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        private class IntKeyed
+        {
+            [CborProperty(1)]
+            public int Value { get; set; }
+        }
+
+        /// <summary>
+        /// The failure the issue opened with: the document contradicts the requested type outright.
+        /// There is no member to name, but "at the root" is itself the answer.
+        /// </summary>
+        [Fact]
+        public void ARootLevelFailureIsReportedAsTheRoot()
+        {
+            // 01   1, where a map was required
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>("01".HexToBytes()));
+
+            Assert.Equal("$", exception.Path);
+            Assert.Contains("Failed to deserialize from \"$\".", exception.Message);
+        }
+
+        [Fact]
+        public void AMemberIsNamedByItsPath()
+        {
+            // a1                  map(1)
+            //    64 4e616d65      "Name"
+            //    01               1, where a text string was required
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>("A1644E616D6501".HexToBytes()));
+
+            Assert.Equal("$.Name", exception.Path);
+        }
+
+        /// <summary>The byte offset the reader already reported is kept, not replaced.</summary>
+        [Fact]
+        public void ThePathIsAddedToTheExistingMessageRatherThanReplacingIt()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>("A1644E616D6501".HexToBytes()));
+
+            Assert.StartsWith("[", exception.Message);
+            Assert.EndsWith(" Failed to deserialize from \"$.Name\".", exception.Message);
+        }
+
+        [Fact]
+        public void NestedObjectsCompose()
+        {
+            // a1                  map(1)
+            //    65 4368696c64    "Child"
+            //    a1               map(1)
+            //       64 4e616d65   "Name"
+            //       01            1
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Root>("A1654368696C64A1644E616D6501".HexToBytes()));
+
+            Assert.Equal("$.Child.Name", exception.Path);
+        }
+
+        /// <summary>
+        /// A member whose value is the wrong shape entirely fails before any of its own members are
+        /// reached, so the innermost thing that can be named is the member itself.
+        /// </summary>
+        [Fact]
+        public void AMemberOfTheWrongShapeIsNamedWithoutAnInnerSegment()
+        {
+            // a1                  map(1)
+            //    65 4368696c64    "Child"
+            //    01               1, where a map was required
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Root>("A1654368696C6401".HexToBytes()));
+
+            Assert.Equal("$.Child", exception.Path);
+        }
+
+        [Fact]
+        public void CollectionItemsAreNamedByIndex()
+        {
+            // a1                     map(1)
+            //    65 4974656d73       "Items"
+            //    82                  array(2)
+            //       a1 644e616d65 63 616263    {"Name": "abc"}
+            //       a1 644e616d65 01           {"Name": 1}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Root>("A1654974656D7382A1644E616D6563616263A1644E616D6501".HexToBytes()));
+
+            Assert.Equal("$.Items[1].Name", exception.Path);
+        }
+
+        /// <summary>
+        /// The index is the failing item's own, not the count of items read so far, and a root
+        /// collection needs no member to hang off.
+        /// </summary>
+        [Fact]
+        public void ARootCollectionNamesTheFailingIndex()
+        {
+            // 82            array(2)
+            //    01         1
+            //    63 616263  "abc", where an integer was required
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<List<int>>("820163616263".HexToBytes()));
+
+            Assert.Equal("$[1]", exception.Path);
+        }
+
+        /// <summary>A failure on the array header is not attributed to its first item.</summary>
+        [Fact]
+        public void ACollectionOfTheWrongShapeIsNotAttributedToItemZero()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<List<int>>("01".HexToBytes()));
+
+            Assert.Equal("$", exception.Path);
+        }
+
+        [Fact]
+        public void DictionaryEntriesAreNamedByKey()
+        {
+            // a1                  map(1)
+            //    63 4d6170        "Map"
+            //    a2               map(2)
+            //       61 61 01      "a": 1
+            //       61 62 63616263  "b": "abc", where an integer was required
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Root>("A1634D6170A2616101616263616263".HexToBytes()));
+
+            Assert.Equal("$.Map['b']", exception.Path);
+        }
+
+        [Fact]
+        public void TupleItemsAreNamedByIndex()
+        {
+            // 82      array(2)
+            //    01   1
+            //    02   2, where a text string was required
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<(int, string)>("820102".HexToBytes()));
+
+            Assert.Equal("$[1]", exception.Path);
+        }
+
+        /// <summary>
+        /// An integer-keyed member is worth naming by the name it has on the type: the index is what
+        /// the document said, but the name is what the caller is looking for.
+        /// </summary>
+        [Fact]
+        public void AnIntegerKeyedMemberIsNamedByItsMemberName()
+        {
+            // a1      map(1)
+            //    01   1
+            //    63 616263  "abc", where an integer was required
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<IntKeyed>("A10163616263".HexToBytes()));
+
+            Assert.Equal("$.Value", exception.Path);
+        }
+
+        /// <summary>
+        /// A member name comes from the document, so a hostile one is quoted on the same terms as any
+        /// other document text rather than copied into the path whole.
+        /// </summary>
+        [Fact]
+        public void ALongMemberNameIsTruncatedInThePath()
+        {
+            string name = new string('n', 500);
+            CborOptions options = new CborOptions { UnhandledNameMode = UnhandledNameMode.ThrowException };
+
+            ByteBufferWriter writer = new ByteBufferWriter();
+            CborWriter cborWriter = new CborWriter(writer);
+            cborWriter.WriteBeginMap(1);
+            cborWriter.WriteString(name);
+            cborWriter.WriteInt32(1);
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>(writer.WrittenSpan.ToArray(), options));
+
+            Assert.DoesNotContain(name, exception.Message);
+            Assert.True(exception.Message.Length < 300, $"message was {exception.Message.Length} chars");
+        }
+
+        /// <summary>
+        /// Nothing is appended when a read succeeds, and the property stays null for an exception that
+        /// never passed through a converter.
+        /// </summary>
+        [Fact]
+        public void AnExceptionRaisedOutsideAnyConverterHasNoPath()
+        {
+            CborException exception = new CborException("boom");
+
+            Assert.Null(exception.Path);
+            Assert.Equal("boom", exception.Message);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0135.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0135.cs
@@ -1,4 +1,5 @@
 using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.ObjectModel;
 using Dahomey.Cbor.Serialization;
 using Dahomey.Cbor.Tests.Extensions;
 using Dahomey.Cbor.Util;
@@ -18,9 +19,9 @@ namespace Dahomey.Cbor.Tests.Issues
     /// successful read allocates nothing for it - it only keeps enough state to answer where it was,
     /// which is an index and, for a map, the current key.
     /// <para>
-    /// A path of <c>$</c> means the root value itself was wrong; a null <see cref="CborException.Path"/>
-    /// means no converter on the way up could name a position at all, which is what a failure inside a
-    /// caller-supplied converter looks like. Those are different answers and are kept apart.
+    /// A path of <c>$</c> means the root value itself was wrong. Every read has at least that much, so
+    /// a null <see cref="CborException.Path"/> means the exception did not come from a read at all -
+    /// and those two answers are worth telling apart.
     /// </para>
     /// </remarks>
     public class Issue0135
@@ -372,6 +373,86 @@ namespace Dahomey.Cbor.Tests.Issues
                 () => Cbor.Deserialize<Child>("A1644E616D65F6".HexToBytes(), options));
 
             Assert.Equal("Property 'Name' cannot be null. Failed to deserialize from \"$.Name\".", fullStop.Message);
+        }
+
+        /// <summary>
+        /// The object model reaches the same converters by a different door, so it has to mark the
+        /// root as well - otherwise a scalar conversion is exactly the case that reports nothing,
+        /// which is what <see cref="CborException.Path"/> now promises cannot happen.
+        /// </summary>
+        [Fact]
+        public void ConvertingFromTheObjectModelReportsTheRootToo()
+        {
+            CborObject source = new CborObject { ["Name"] = "abc" };
+
+            CborException scalar = Assert.Throws<CborException>(() => source.ToObject<int>());
+            CborException collection = Assert.Throws<CborException>(() => source.ToObject<List<int>>());
+            CborException array = Assert.Throws<CborException>(
+                () => new CborArray(1, "abc").ToCollection<List<int>>());
+
+            Assert.Equal("$", scalar.Path);
+            Assert.Equal("$", collection.Path);
+            Assert.Equal("$[1]", array.Path);
+        }
+
+        /// <summary>
+        /// The budget is spent on the rendered result, not on the source. Counting the source would
+        /// let a name of control characters - each of which renders as six - past a bound that looks
+        /// like 64 and is really 384.
+        /// </summary>
+        [Fact]
+        public void TheLengthBoundHoldsAgainstTextChosenToDefeatIt()
+        {
+            CborOptions options = new CborOptions { UnhandledNameMode = UnhandledNameMode.ThrowException };
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>(WriteSingleMemberMap(new string('\n', 300)), options));
+
+            Assert.True(exception.Message.Length < 300, $"message was {exception.Message.Length} chars");
+            Assert.Contains("(300 characters)", exception.Path);
+        }
+
+        /// <summary>
+        /// Truncation lands between characters, never inside one: half a surrogate pair is not valid
+        /// UTF-16 and can break whatever the message is written to.
+        /// </summary>
+        [Fact]
+        public void TruncationDoesNotSplitASurrogatePair()
+        {
+            CborOptions options = new CborOptions { UnhandledNameMode = UnhandledNameMode.ThrowException };
+            string name = new string('a', 63) + "\U0001F600" + new string('a', 40);
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>(WriteSingleMemberMap(name), options));
+
+            string path = Assert.IsType<string>(exception.Path);
+
+            for (int i = 0; i < path.Length; i++)
+            {
+                if (char.IsHighSurrogate(path[i]))
+                {
+                    Assert.True(i + 1 < path.Length && char.IsLowSurrogate(path[i + 1]), "high surrogate left unpaired");
+                }
+                else
+                {
+                    Assert.False(char.IsLowSurrogate(path[i]), "low surrogate left unpaired");
+                }
+            }
+        }
+
+        /// <summary>
+        /// A non-ASCII member name survives the round trip into the message it is rejected with.
+        /// </summary>
+        [Fact]
+        public void AnUnhandledNameIsDecodedAsUtf8()
+        {
+            CborOptions options = new CborOptions { UnhandledNameMode = UnhandledNameMode.ThrowException };
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>(WriteSingleMemberMap("naïve"), options));
+
+            Assert.Contains("naïve", exception.Message);
+            Assert.Equal("$.naïve", exception.Path);
         }
 
         private static byte[] WriteSingleMemberMap(string memberName)

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0135.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0135.cs
@@ -545,6 +545,40 @@ namespace Dahomey.Cbor.Tests.Issues
             }
         }
 
+        /// <summary>
+        /// Building a <see cref="CborObject"/> from a value reads it back, so it is a read like any
+        /// other and reports like one.
+        /// </summary>
+        [Fact]
+        public void BuildingAnObjectFromANonObjectReportsTheRoot()
+        {
+            CborException exception = Assert.Throws<CborException>(() => CborObject.FromObject(1));
+
+            Assert.Equal("$", exception.Path);
+        }
+
+        /// <summary>
+        /// The public seam runs inside a caller's <c>catch</c>, so it answers nonsense with something
+        /// harmless rather than with a second exception over the top of the first.
+        /// </summary>
+        [Fact]
+        public void TheSeamRefusesToInventAPositionItWasNotGiven()
+        {
+            CborException negative = new CborException("boom");
+            negative.PrependPathIndex(-1);
+
+            CborException huge = new CborException("boom");
+            huge.PrependPathMember(new string('\n', 500));
+
+            // A negative index is not a position, so it names none - but the failure is still marked
+            // as having been seen.
+            Assert.Equal("$", negative.Path);
+
+            // A caller-supplied name is bounded and escaped on the same terms as document text.
+            Assert.True(huge.Path!.Length < 100, $"path was {huge.Path.Length} chars");
+            Assert.DoesNotContain("\n", huge.Path);
+        }
+
         private static byte[] WriteSingleMemberMap(string memberName)
         {
             ByteBufferWriter writer = new ByteBufferWriter();

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0135.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0135.cs
@@ -14,8 +14,9 @@ namespace Dahomey.Cbor.Tests.Issues
     /// <remarks>
     /// The path is assembled as the exception unwinds rather than tracked as the reader descends: the
     /// reader is a <c>ref struct</c> that knows major types, not members, and the hot structural reads
-    /// are deliberately inlineable. Each converter names its own position on the way out, so
-    /// well-formed data pays nothing.
+    /// are deliberately inlineable. Each converter names its own position on the way out, so a
+    /// successful read allocates nothing for it - it only keeps enough state to answer where it was,
+    /// which is an index and, for a map, the current key.
     /// <para>
     /// A path of <c>$</c> means the root value itself was wrong; a null <see cref="CborException.Path"/>
     /// means no converter on the way up could name a position at all, which is what a failure inside a
@@ -33,7 +34,9 @@ namespace Dahomey.Cbor.Tests.Issues
         {
             public Child Child { get; set; }
             public List<Child> Items { get; set; }
+            public Child[] Array { get; set; }
             public Dictionary<string, int> Map { get; set; }
+            public Dictionary<int, int> IntMap { get; set; }
         }
 
         [CborObjectFormat(CborObjectFormat.IntKeyMap)]
@@ -162,7 +165,7 @@ namespace Dahomey.Cbor.Tests.Issues
             CborException exception = Assert.Throws<CborException>(
                 () => Cbor.Deserialize<Root>("A1634D6170A2616101616263616263".HexToBytes()));
 
-            Assert.Equal("$.Map['b']", exception.Path);
+            Assert.Equal("$.Map.b", exception.Path);
         }
 
         [Fact]
@@ -217,16 +220,169 @@ namespace Dahomey.Cbor.Tests.Issues
         }
 
         /// <summary>
-        /// Nothing is appended when a read succeeds, and the property stays null for an exception that
-        /// never passed through a converter.
+        /// The property stays null for an exception that never went through a read at all.
         /// </summary>
         [Fact]
-        public void AnExceptionRaisedOutsideAnyConverterHasNoPath()
+        public void AnExceptionRaisedOutsideAReadHasNoPath()
         {
             CborException exception = new CborException("boom");
 
             Assert.Null(exception.Path);
             Assert.Equal("boom", exception.Message);
+        }
+
+        /// <summary>
+        /// An array member is named the same way a list member is. The two are different converters,
+        /// and a path that named the member but not the position would be worse than no path: it would
+        /// point at a member that does not exist.
+        /// </summary>
+        [Fact]
+        public void ArrayMembersAreNamedLikeListMembers()
+        {
+            // a1                     map(1)
+            //    65 4172726179       "Array"
+            //    82                  array(2)
+            //       a1 644e616d65 63 616263    {"Name": "abc"}
+            //       a1 644e616d65 01           {"Name": 1}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Root>("A165417272617982A1644E616D6563616263A1644E616D6501".HexToBytes()));
+
+            Assert.Equal("$.Array[1].Name", exception.Path);
+        }
+
+        [Fact]
+        public void ARootArrayNamesTheFailingIndex()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<int[]>("820163616263".HexToBytes()));
+
+            Assert.Equal("$[1]", exception.Path);
+        }
+
+        /// <summary>The indefinite-length branch counts positions too, not only the sized one.</summary>
+        [Fact]
+        public void AnIndefiniteLengthArrayNamesTheFailingIndex()
+        {
+            // 9f 01 63 616263 ff   array(*) 1 "abc" break
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<int[]>("9F0163616263FF".HexToBytes()));
+
+            Assert.Equal("$[1]", exception.Path);
+        }
+
+        /// <summary>
+        /// A required member is validated after the read loop rather than inside it, which must not
+        /// cost it its path: the same failure reports the same way at the root as when nested.
+        /// </summary>
+        [Fact]
+        public void AMissingRequiredMemberHasAPathAtTheRootToo()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<Child>(objectMapping =>
+                objectMapping
+                    .AutoMap()
+                    .ClearMemberMappings()
+                    .MapMember(o => o.Name).SetRequired(RequirementPolicy.Always)
+            );
+
+            // a0   map(0) -- "Name" never arrives
+            CborException rootFailure = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>("A0".HexToBytes(), options));
+            CborException nestedFailure = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Root>("A1654368696C64A0".HexToBytes(), options));
+
+            Assert.Equal("$", rootFailure.Path);
+            Assert.Equal("$.Child", nestedFailure.Path);
+        }
+
+        /// <summary>
+        /// A scalar root has no structure to describe, but "the root" is still the answer -- and it is
+        /// exactly the failure the issue opened with.
+        /// </summary>
+        [Fact]
+        public void AScalarRootFailureIsReportedAsTheRoot()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<int>("63616263".HexToBytes()));
+
+            Assert.Equal("$", exception.Path);
+        }
+
+        /// <summary>
+        /// A name that is not a plain identifier is bracketed and quoted rather than pasted in, so it
+        /// cannot forge path structure or close the quotation the message wraps the path in.
+        /// </summary>
+        [Fact]
+        public void ANameThatWouldBeAmbiguousIsQuoted()
+        {
+            CborOptions options = new CborOptions { UnhandledNameMode = UnhandledNameMode.ThrowException };
+
+            CborException dotted = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>(WriteSingleMemberMap("a.b"), options));
+            CborException quoted = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>(WriteSingleMemberMap("ev\"il"), options));
+            CborException newlined = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>(WriteSingleMemberMap("a\nb"), options));
+
+            Assert.Equal("$['a.b']", dotted.Path);
+            Assert.Equal("$['ev\\\"il']", quoted.Path);
+            Assert.Equal("$['a\\u000ab']", newlined.Path);
+
+            // The delimiter the message puts around the path survives whatever the document sent.
+            Assert.EndsWith("\".", quoted.Message);
+        }
+
+        /// <summary>
+        /// A key that reads as a plain token needs no quoting, whatever the key type is.
+        /// </summary>
+        [Fact]
+        public void AnIntegerDictionaryKeyIsNotQuotedAsAString()
+        {
+            // a1                     map(1)
+            //    66 496e744d6170     "IntMap"
+            //    a1 07 63 616263     {7: "abc"}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Root>("A166496E744D6170A10763616263".HexToBytes()));
+
+            Assert.Equal("$.IntMap.7", exception.Path);
+        }
+
+        /// <summary>
+        /// The message reads as two sentences whether or not the reader's own message ended in one.
+        /// </summary>
+        [Fact]
+        public void ThePathIsSeparatedFromTheMessageAsASentence()
+        {
+            CborException noFullStop = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>("A1644E616D6501".HexToBytes()));
+
+            Assert.Contains(". Failed to deserialize from", noFullStop.Message);
+            Assert.DoesNotContain("..", noFullStop.Message);
+
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<Child>(objectMapping =>
+                objectMapping
+                    .AutoMap()
+                    .ClearMemberMappings()
+                    .MapMember(o => o.Name).SetRequired(RequirementPolicy.DisallowNull)
+            );
+
+            // a1 644e616d65 f6  -- {"Name": null}, whose message already ends in a full stop
+            CborException fullStop = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Child>("A1644E616D65F6".HexToBytes(), options));
+
+            Assert.Equal("Property 'Name' cannot be null. Failed to deserialize from \"$.Name\".", fullStop.Message);
+        }
+
+        private static byte[] WriteSingleMemberMap(string memberName)
+        {
+            ByteBufferWriter writer = new ByteBufferWriter();
+            CborWriter cborWriter = new CborWriter(writer);
+            cborWriter.WriteBeginMap(1);
+            cborWriter.WriteString(memberName);
+            cborWriter.WriteInt32(1);
+
+            return writer.WrittenSpan.ToArray();
         }
     }
 }

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0135.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0135.cs
@@ -1,6 +1,7 @@
 using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.ObjectModel;
 using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Serialization.Converters;
 using Dahomey.Cbor.Tests.Extensions;
 using Dahomey.Cbor.Util;
 using System.Collections.Generic;
@@ -453,6 +454,95 @@ namespace Dahomey.Cbor.Tests.Issues
 
             Assert.Contains("naïve", exception.Message);
             Assert.Equal("$.naïve", exception.Path);
+        }
+
+        /// <summary>
+        /// A converter that decodes a structure of its own can name positions inside it, which is
+        /// otherwise the one thing the framework cannot do on a caller's behalf.
+        /// </summary>
+        private class BodyConverter : CborConverterBase<Body>
+        {
+            public override Body Read(ref CborReader reader)
+            {
+                reader.ReadBeginArray();
+                reader.ReadSize();
+
+                try
+                {
+                    return new Body { Count = reader.ReadInt32() };
+                }
+                catch (CborException exception)
+                {
+                    exception.PrependPathIndex(0);
+                    throw;
+                }
+            }
+
+            public override void Write(ref CborWriter writer, Body value, LengthMode lengthMode)
+            {
+                writer.WriteBeginArray(1);
+                writer.WriteInt32(value.Count);
+                writer.WriteEndArray(1);
+            }
+        }
+
+        private class Body
+        {
+            public int Count { get; set; }
+        }
+
+        private class BodyHolder
+        {
+            public Body Body { get; set; }
+        }
+
+        [Fact]
+        public void ACustomConverterCanNamePositionsWithinItself()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ConverterRegistry.RegisterConverter(typeof(Body), new BodyConverter());
+
+            // a1                  map(1)
+            //    64 426f6479      "Body"
+            //    81               array(1)
+            //       63 616263     "abc", where an integer was required
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<BodyHolder>("A164426F64798163616263".HexToBytes(), options));
+
+            Assert.Equal("$.Body[0]", exception.Path);
+        }
+
+        /// <summary>
+        /// Doing nothing remains correct: a custom converter that adds no segment is still named by
+        /// the member holding it, which is why the seam above is a refinement rather than a duty.
+        /// </summary>
+        [Fact]
+        public void ACustomConverterThatAddsNothingIsStillNamedByItsMember()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ConverterRegistry.RegisterConverter(typeof(Body), new SilentBodyConverter());
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<BodyHolder>("A164426F64798163616263".HexToBytes(), options));
+
+            Assert.Equal("$.Body", exception.Path);
+        }
+
+        private class SilentBodyConverter : CborConverterBase<Body>
+        {
+            public override Body Read(ref CborReader reader)
+            {
+                reader.ReadBeginArray();
+                reader.ReadSize();
+                return new Body { Count = reader.ReadInt32() };
+            }
+
+            public override void Write(ref CborWriter writer, Body value, LengthMode lengthMode)
+            {
+                writer.WriteBeginArray(1);
+                writer.WriteInt32(value.Count);
+                writer.WriteEndArray(1);
+            }
         }
 
         private static byte[] WriteSingleMemberMap(string memberName)

--- a/src/Dahomey.Cbor.Tests/SemanticTagProbeTests.cs
+++ b/src/Dahomey.Cbor.Tests/SemanticTagProbeTests.cs
@@ -400,7 +400,7 @@ namespace Dahomey.Cbor.Tests
             CborException exception = Assert.Throws<CborException>(
                 () => Cbor.Deserialize<IntHolder>("A16556616C7565C1C001".HexToBytes()));
 
-            Assert.Equal("[9] Invalid major type SemanticTag Failed to deserialize from \"$.Value\".", exception.Message);
+            Assert.Equal("[9] Invalid major type SemanticTag. Failed to deserialize from \"$.Value\".", exception.Message);
         }
     }
 }

--- a/src/Dahomey.Cbor.Tests/SemanticTagProbeTests.cs
+++ b/src/Dahomey.Cbor.Tests/SemanticTagProbeTests.cs
@@ -351,7 +351,7 @@ namespace Dahomey.Cbor.Tests
             CborException exception = Assert.Throws<CborException>(
                 () => Cbor.Deserialize<RequiredValueHolder>("A1664D656D626572F7".HexToBytes()));
 
-            Assert.Equal("Property 'Member' cannot be null.", exception.Message);
+            Assert.Equal("Property 'Member' cannot be null. Failed to deserialize from \"$.Member\".", exception.Message);
         }
 
         /// <summary>The same byte without the policy reads as before.</summary>
@@ -400,7 +400,7 @@ namespace Dahomey.Cbor.Tests
             CborException exception = Assert.Throws<CborException>(
                 () => Cbor.Deserialize<IntHolder>("A16556616C7565C1C001".HexToBytes()));
 
-            Assert.Equal("[9] Invalid major type SemanticTag", exception.Message);
+            Assert.Equal("[9] Invalid major type SemanticTag Failed to deserialize from \"$.Value\".", exception.Message);
         }
     }
 }

--- a/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
+++ b/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
@@ -584,7 +584,7 @@ namespace Dahomey.Cbor.Tests
             // A1 map(1) 6153 "S" F6 null
             CborException exception = Assert.Throws<CborException>(
                 () => Cbor.Deserialize<NullableSamplesHolder>("A16153F6".HexToBytes(), options));
-            Assert.Equal("Property 'S' cannot be null.", exception.Message);
+            Assert.Equal("Property 'S' cannot be null. Failed to deserialize from \"$.S\".", exception.Message);
         }
 
         [Fact]

--- a/src/Dahomey.Cbor/Cbor.cs
+++ b/src/Dahomey.Cbor/Cbor.cs
@@ -298,6 +298,48 @@ namespace Dahomey.Cbor
             }
         }
 
+        /// <summary>
+        /// Reads one value at the root of a document, so that a failure on the root itself still has a
+        /// position to report: <see cref="CborException.Path"/> of <c>$</c>.
+        /// </summary>
+        /// <remarks>
+        /// The converters that name members, indices and keys only do so from inside a container. A
+        /// document that contradicts the requested type outright never reaches one of them, and that is
+        /// the failure the caller is least able to place from a byte offset alone -- so the root is
+        /// marked here, where every read passes exactly once.
+        /// <para>
+        /// The speculative read in <c>TryReadItem</c> is deliberately not routed through this: it
+        /// throws as a matter of course while waiting for more of the stream, and discards what it
+        /// catches.
+        /// </para>
+        /// </remarks>
+        private static T ReadRoot<T>(ref CborReader reader, ICborConverter<T> converter)
+        {
+            try
+            {
+                return converter.Read(ref reader);
+            }
+            catch (CborException exception)
+            {
+                exception.MarkPathKnown();
+                throw;
+            }
+        }
+
+        /// <inheritdoc cref="ReadRoot{T}(ref CborReader, ICborConverter{T})"/>
+        private static object? ReadRoot(ref CborReader reader, ICborConverter converter)
+        {
+            try
+            {
+                return converter.Read(ref reader);
+            }
+            catch (CborException exception)
+            {
+                exception.MarkPathKnown();
+                throw;
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Deserialize<T>(
             ReadOnlySpan<byte> buffer,
@@ -306,7 +348,7 @@ namespace Dahomey.Cbor
             options ??= CborOptions.Default;
             CborReader reader = new CborReader(buffer, options.MaxDepth);
             ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
-            return converter.Read(ref reader);
+            return ReadRoot(ref reader, converter);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -317,7 +359,7 @@ namespace Dahomey.Cbor
             options ??= CborOptions.Default;
             CborReader reader = new CborReader(buffer, options.MaxDepth);
             ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
-            return converter.Read(ref reader);
+            return ReadRoot(ref reader, converter);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -329,7 +371,7 @@ namespace Dahomey.Cbor
             options ??= CborOptions.Default;
             CborReader reader = new CborReader(buffer, options.MaxDepth);
             ICborConverter cborConverter = options.Registry.ConverterRegistry.Lookup(objectType);
-            return cborConverter.Read(ref reader);
+            return ReadRoot(ref reader, cborConverter);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -341,7 +383,7 @@ namespace Dahomey.Cbor
             options ??= CborOptions.Default;
             CborReader reader = new CborReader(buffer, options.MaxDepth);
             ICborConverter cborConverter = options.Registry.ConverterRegistry.Lookup(objectType);
-            return cborConverter.Read(ref reader);
+            return ReadRoot(ref reader, cborConverter);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -355,7 +397,7 @@ namespace Dahomey.Cbor
             while (reader.DataAvailable)
             {
                 ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
-                list.Add(converter.Read(ref reader));
+                list.Add(ReadRoot(ref reader, converter));
             }
             return list.ToArray();
         }
@@ -371,7 +413,7 @@ namespace Dahomey.Cbor
             while (reader.DataAvailable)
             {
                 ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
-                list.Add(converter.Read(ref reader));
+                list.Add(ReadRoot(ref reader, converter));
             }
             return list.ToArray();
         }
@@ -389,7 +431,7 @@ namespace Dahomey.Cbor
             {
                 ICborConverter cborConverter = options.Registry.ConverterRegistry.Lookup(objectType);
 
-                var obj = cborConverter.Read(ref reader);
+                var obj = ReadRoot(ref reader, cborConverter);
                 if (obj != null)
                 {
                     list.Add(obj);
@@ -410,7 +452,7 @@ namespace Dahomey.Cbor
             while (reader.DataAvailable)
             {
                 ICborConverter cborConverter = options.Registry.ConverterRegistry.Lookup(objectType);
-                var obj = cborConverter.Read(ref reader);
+                var obj = ReadRoot(ref reader, cborConverter);
                 if (obj != null)
                 {
                     list.Add(obj);

--- a/src/Dahomey.Cbor/Cbor.cs
+++ b/src/Dahomey.Cbor/Cbor.cs
@@ -298,48 +298,6 @@ namespace Dahomey.Cbor
             }
         }
 
-        /// <summary>
-        /// Reads one value at the root of a document, so that a failure on the root itself still has a
-        /// position to report: <see cref="CborException.Path"/> of <c>$</c>.
-        /// </summary>
-        /// <remarks>
-        /// The converters that name members, indices and keys only do so from inside a container. A
-        /// document that contradicts the requested type outright never reaches one of them, and that is
-        /// the failure the caller is least able to place from a byte offset alone -- so the root is
-        /// marked here, where every read passes exactly once.
-        /// <para>
-        /// The speculative read in <c>TryReadItem</c> is deliberately not routed through this: it
-        /// throws as a matter of course while waiting for more of the stream, and discards what it
-        /// catches.
-        /// </para>
-        /// </remarks>
-        private static T ReadRoot<T>(ref CborReader reader, ICborConverter<T> converter)
-        {
-            try
-            {
-                return converter.Read(ref reader);
-            }
-            catch (CborException exception)
-            {
-                exception.MarkPathKnown();
-                throw;
-            }
-        }
-
-        /// <inheritdoc cref="ReadRoot{T}(ref CborReader, ICborConverter{T})"/>
-        private static object? ReadRoot(ref CborReader reader, ICborConverter converter)
-        {
-            try
-            {
-                return converter.Read(ref reader);
-            }
-            catch (CborException exception)
-            {
-                exception.MarkPathKnown();
-                throw;
-            }
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Deserialize<T>(
             ReadOnlySpan<byte> buffer,
@@ -348,7 +306,7 @@ namespace Dahomey.Cbor
             options ??= CborOptions.Default;
             CborReader reader = new CborReader(buffer, options.MaxDepth);
             ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
-            return ReadRoot(ref reader, converter);
+            return RootReader.Read(ref reader, converter);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -359,7 +317,7 @@ namespace Dahomey.Cbor
             options ??= CborOptions.Default;
             CborReader reader = new CborReader(buffer, options.MaxDepth);
             ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
-            return ReadRoot(ref reader, converter);
+            return RootReader.Read(ref reader, converter);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -371,7 +329,7 @@ namespace Dahomey.Cbor
             options ??= CborOptions.Default;
             CborReader reader = new CborReader(buffer, options.MaxDepth);
             ICborConverter cborConverter = options.Registry.ConverterRegistry.Lookup(objectType);
-            return ReadRoot(ref reader, cborConverter);
+            return RootReader.Read(ref reader, cborConverter);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -383,7 +341,7 @@ namespace Dahomey.Cbor
             options ??= CborOptions.Default;
             CborReader reader = new CborReader(buffer, options.MaxDepth);
             ICborConverter cborConverter = options.Registry.ConverterRegistry.Lookup(objectType);
-            return ReadRoot(ref reader, cborConverter);
+            return RootReader.Read(ref reader, cborConverter);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -397,7 +355,7 @@ namespace Dahomey.Cbor
             while (reader.DataAvailable)
             {
                 ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
-                list.Add(ReadRoot(ref reader, converter));
+                list.Add(RootReader.Read(ref reader, converter));
             }
             return list.ToArray();
         }
@@ -413,7 +371,7 @@ namespace Dahomey.Cbor
             while (reader.DataAvailable)
             {
                 ICborConverter<T> converter = options.Registry.ConverterRegistry.Lookup<T>();
-                list.Add(ReadRoot(ref reader, converter));
+                list.Add(RootReader.Read(ref reader, converter));
             }
             return list.ToArray();
         }
@@ -431,7 +389,7 @@ namespace Dahomey.Cbor
             {
                 ICborConverter cborConverter = options.Registry.ConverterRegistry.Lookup(objectType);
 
-                var obj = ReadRoot(ref reader, cborConverter);
+                var obj = RootReader.Read(ref reader, cborConverter);
                 if (obj != null)
                 {
                     list.Add(obj);
@@ -452,7 +410,7 @@ namespace Dahomey.Cbor
             while (reader.DataAvailable)
             {
                 ICborConverter cborConverter = options.Registry.ConverterRegistry.Lookup(objectType);
-                var obj = ReadRoot(ref reader, cborConverter);
+                var obj = RootReader.Read(ref reader, cborConverter);
                 if (obj != null)
                 {
                     list.Add(obj);

--- a/src/Dahomey.Cbor/CborException.cs
+++ b/src/Dahomey.Cbor/CborException.cs
@@ -27,10 +27,19 @@ namespace Dahomey.Cbor
 
         /// <summary>
         /// Where in the deserialized model the failure occurred, in the notation used by
-        /// <c>System.Text.Json</c>: <c>$.Items[7].Name</c>. <c>$</c> alone means the root value, and
-        /// <c>null</c> means the path is unknown - the failure happened outside any converter that
-        /// contributes a segment, which includes converters supplied by the caller.
+        /// <c>System.Text.Json</c>: <c>$.Items[7].Name</c>. <c>$</c> alone means the root value itself.
         /// </summary>
+        /// <remarks>
+        /// Every failure raised while deserializing has a path, down to <c>$</c> for a document that
+        /// contradicts the requested type outright. <c>null</c> therefore means the exception did not
+        /// come from a read at all - a serialization failure, or a mapping the registry refused to
+        /// build.
+        /// <para>
+        /// A path is as precise as the converters it passed through. Converters supplied by the caller
+        /// contribute no segment of their own, so a failure inside one is reported against the member
+        /// that holds it rather than against anything within.
+        /// </para>
+        /// </remarks>
         public string? Path
         {
             get
@@ -68,21 +77,29 @@ namespace Dahomey.Cbor
             get
             {
                 string? path = Path;
-                return path == null
-                    ? base.Message
-                    : $"{base.Message} Failed to deserialize from \"{path}\".";
+
+                if (path == null)
+                {
+                    return base.Message;
+                }
+
+                return $"{base.Message}{SentenceSeparator(base.Message)}Failed to deserialize from \"{path}\".";
             }
         }
 
-        /// <summary>Records that this failure happened inside the member <paramref name="name"/>.</summary>
+        /// <summary>
+        /// Records that this failure happened under <paramref name="name"/> - a member of an object or
+        /// a key of a map, which read the same way in a path and are not worth distinguishing.
+        /// </summary>
         /// <remarks>
-        /// The name is the one the document used, not necessarily one the type declares - an unknown
-        /// member rejected by <see cref="UnhandledNameMode"/> fails under whatever name it arrived with
-        /// - so it is truncated on the same terms as any other quoted document text.
+        /// The name is whatever the document sent, not necessarily one the type declares: an unknown
+        /// member rejected by <see cref="UnhandledNameMode"/> fails under the name it arrived with, and
+        /// a map key is arbitrary by definition. It is therefore bounded and quoted rather than pasted
+        /// in, so that a chosen name cannot forge structure in the message that carries it.
         /// </remarks>
-        internal void PushMember(string name)
+        internal void PushName(string? name)
         {
-            PushSegment("." + TextTruncation.Ellipsize(name));
+            PushSegment(FormatName(TextTruncation.Ellipsize(name ?? string.Empty)));
         }
 
         /// <summary>Records that this failure happened at position <paramref name="index"/> of an array.</summary>
@@ -91,10 +108,78 @@ namespace Dahomey.Cbor
             PushSegment($"[{index}]");
         }
 
-        /// <summary>Records that this failure happened under the map key <paramref name="key"/>.</summary>
-        internal void PushKey(string? key)
+        /// <summary>
+        /// <c>.Name</c> for a name that reads unambiguously as one, <c>['Name']</c> for anything else.
+        /// </summary>
+        /// <remarks>
+        /// A name containing a dot, a bracket or a quote would otherwise be indistinguishable from the
+        /// path syntax around it: <c>a.b</c> as a single member reads exactly like member <c>b</c> of
+        /// member <c>a</c>. The bracketed form is the same answer <c>System.Text.Json</c> gives, and
+        /// escaping inside it is what stops a name from closing the quotation the message wraps the
+        /// path in.
+        /// </remarks>
+        private static string FormatName(string name)
         {
-            PushSegment($"['{TextTruncation.Ellipsize(key ?? string.Empty)}']");
+            if (name.Length != 0 && IsSimpleName(name))
+            {
+                return "." + name;
+            }
+
+            StringBuilder builder = new StringBuilder(name.Length + 4);
+            builder.Append("['");
+
+            foreach (char c in name)
+            {
+                switch (c)
+                {
+                    case '\\':
+                    case '\'':
+                    case '"':
+                        builder.Append('\\').Append(c);
+                        break;
+                    default:
+                        if (c < ' ' || c == '\u007f')
+                        {
+                            builder.Append("\\u").Append(((int)c).ToString("x4"));
+                        }
+                        else
+                        {
+                            builder.Append(c);
+                        }
+                        break;
+                }
+            }
+
+            return builder.Append("']").ToString();
+        }
+
+        private static bool IsSimpleName(string name)
+        {
+            foreach (char c in name)
+            {
+                if (!char.IsLetterOrDigit(c) && c != '_')
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// What to put between the base message and the path. The two are separate sentences, but base
+        /// messages are inconsistent about ending in a full stop and adding a second one reads worse
+        /// than adding none.
+        /// </summary>
+        private static string SentenceSeparator(string message)
+        {
+            if (message.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            char last = message[message.Length - 1];
+            return last == '.' || last == '!' || last == '?' ? " " : ". ";
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor/CborException.cs
+++ b/src/Dahomey.Cbor/CborException.cs
@@ -1,12 +1,121 @@
-﻿using System;
+﻿using Dahomey.Cbor.Util;
+using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace Dahomey.Cbor
 {
     public class CborException : Exception
     {
+        /// <summary>
+        /// The path segments collected so far, innermost first.
+        /// </summary>
+        /// <remarks>
+        /// The path is assembled as the exception travels back up the converter stack rather than
+        /// tracked as the reader descends: each converter knows only its own segment, and only the
+        /// converters an actual failure passed through pay anything at all. Reading well-formed data
+        /// never allocates this list.
+        /// </remarks>
+        private List<string>? _segments;
+        private string? _path;
+        private bool _pathKnown;
+
         public CborException(string message)
             : base(message)
         {
+        }
+
+        /// <summary>
+        /// Where in the deserialized model the failure occurred, in the notation used by
+        /// <c>System.Text.Json</c>: <c>$.Items[7].Name</c>. <c>$</c> alone means the root value, and
+        /// <c>null</c> means the path is unknown - the failure happened outside any converter that
+        /// contributes a segment, which includes converters supplied by the caller.
+        /// </summary>
+        public string? Path
+        {
+            get
+            {
+                if (!_pathKnown)
+                {
+                    return null;
+                }
+
+                if (_path == null)
+                {
+                    StringBuilder pathBuilder = new StringBuilder("$");
+
+                    for (int i = (_segments?.Count ?? 0) - 1; i >= 0; i--)
+                    {
+                        pathBuilder.Append(_segments![i]);
+                    }
+
+                    _path = pathBuilder.ToString();
+                }
+
+                return _path;
+            }
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// Overridden rather than baked into the message at construction time because the path is not
+        /// known yet when the reader throws: the byte offset is all it has. Everything the base message
+        /// said is preserved, and the path is appended to it once the stack has unwound far enough for
+        /// the model position to be known.
+        /// </remarks>
+        public override string Message
+        {
+            get
+            {
+                string? path = Path;
+                return path == null
+                    ? base.Message
+                    : $"{base.Message} Failed to deserialize from \"{path}\".";
+            }
+        }
+
+        /// <summary>Records that this failure happened inside the member <paramref name="name"/>.</summary>
+        /// <remarks>
+        /// The name is the one the document used, not necessarily one the type declares - an unknown
+        /// member rejected by <see cref="UnhandledNameMode"/> fails under whatever name it arrived with
+        /// - so it is truncated on the same terms as any other quoted document text.
+        /// </remarks>
+        internal void PushMember(string name)
+        {
+            PushSegment("." + TextTruncation.Ellipsize(name));
+        }
+
+        /// <summary>Records that this failure happened at position <paramref name="index"/> of an array.</summary>
+        internal void PushIndex(int index)
+        {
+            PushSegment($"[{index}]");
+        }
+
+        /// <summary>Records that this failure happened under the map key <paramref name="key"/>.</summary>
+        internal void PushKey(string? key)
+        {
+            PushSegment($"['{TextTruncation.Ellipsize(key ?? string.Empty)}']");
+        }
+
+        /// <summary>
+        /// Records that the failure was seen by a converter, without naming a position inside it.
+        /// </summary>
+        /// <remarks>
+        /// This is what turns a failure on the root value itself - a document whose very first byte
+        /// contradicts the requested type - into the path <c>$</c> rather than no path at all. Without
+        /// it, "the failure is at the root" and "no converter on the way up could name a position"
+        /// would produce the same empty result, and those are worth telling apart.
+        /// </remarks>
+        internal void MarkPathKnown()
+        {
+            _pathKnown = true;
+        }
+
+        private void PushSegment(string segment)
+        {
+            (_segments ??= new List<string>()).Add(segment);
+            _pathKnown = true;
+            _path = null;
         }
     }
 }

--- a/src/Dahomey.Cbor/CborException.cs
+++ b/src/Dahomey.Cbor/CborException.cs
@@ -33,8 +33,9 @@ namespace Dahomey.Cbor
         /// Every failure raised while deserializing has a path, down to <c>$</c> for a document that
         /// contradicts the requested type outright. <c>null</c> therefore means the exception did not
         /// come from a read at all - a serialization failure, or a mapping the registry refused to
-        /// build - unless a caller has put segments on it themselves through
-        /// <see cref="PrependPathMember(string)"/>.
+        /// build - unless a caller has marked it themselves through
+        /// <see cref="PrependPathMember(string)"/> or <see cref="PrependPathIndex(int)"/>, either of
+        /// which makes a path known even where it adds no segment.
         /// <para>
         /// A path is as precise as the converters it passed through. Converters supplied by the caller
         /// contribute no segment of their own, so a failure inside one is reported against the member
@@ -97,7 +98,9 @@ namespace Dahomey.Cbor
 
         /// <summary>
         /// Records that this failure happened under <paramref name="name"/> - a member of an object or
-        /// a key of a map, which read the same way in a path and are not worth distinguishing.
+        /// a key of a map, which read the same way in a path and are not worth distinguishing. Call it
+        /// from a converter's <c>catch</c> and rethrow the same exception with a bare <c>throw;</c>:
+        /// wrapping it in a new one bakes a half-built path into the new message.
         /// </summary>
         /// <remarks>
         /// Call this from a converter's <c>catch</c> and rethrow the same exception with a bare

--- a/src/Dahomey.Cbor/CborException.cs
+++ b/src/Dahomey.Cbor/CborException.cs
@@ -33,7 +33,8 @@ namespace Dahomey.Cbor
         /// Every failure raised while deserializing has a path, down to <c>$</c> for a document that
         /// contradicts the requested type outright. <c>null</c> therefore means the exception did not
         /// come from a read at all - a serialization failure, or a mapping the registry refused to
-        /// build.
+        /// build - unless a caller has put segments on it themselves through
+        /// <see cref="PrependPathMember(string)"/>.
         /// <para>
         /// A path is as precise as the converters it passed through. Converters supplied by the caller
         /// contribute no segment of their own, so a failure inside one is reported against the member
@@ -71,6 +72,13 @@ namespace Dahomey.Cbor
         /// known yet when the reader throws: the byte offset is all it has. Everything the base message
         /// said is preserved, and the path is appended to it once the stack has unwound far enough for
         /// the model position to be known.
+        /// <para>
+        /// It follows that this grows as the exception travels: read while the stack is still
+        /// unwinding, it reports the path as far as it is known, not the whole of it. Anything that
+        /// captures the text mid-flight - an intercepting <c>catch</c> that logs and rethrows, a
+        /// wrapper exception built from it - captures a partial answer. <see cref="Path"/> has the same
+        /// property, for the same reason.
+        /// </para>
         /// </remarks>
         public override string Message
         {
@@ -92,8 +100,8 @@ namespace Dahomey.Cbor
         /// a key of a map, which read the same way in a path and are not worth distinguishing.
         /// </summary>
         /// <remarks>
-        /// Call this from a converter's <c>catch</c> and rethrow with a bare <c>throw;</c>, so that the
-        /// original stack trace survives. Each frame adds only its own segment, outermost last:
+        /// Call this from a converter's <c>catch</c> and rethrow the same exception with a bare
+        /// <c>throw;</c>. Each frame adds only its own segment, outermost last:
         /// <code>
         /// try
         /// {
@@ -106,6 +114,14 @@ namespace Dahomey.Cbor
         /// }
         /// </code>
         /// <para>
+        /// Rethrowing the same exception is not only about the stack trace. <see cref="Message"/> is
+        /// composed on demand from the segments collected so far, so wrapping this exception in a new
+        /// one - <c>throw new CborException("…" + exception.Message)</c> - freezes a half-built path
+        /// into the new message and then appends the rest of it a second time as the stack keeps
+        /// unwinding. Read <see cref="Message"/> or <see cref="Path"/> once the read has failed, not
+        /// part of the way out of it.
+        /// </para>
+        /// <para>
         /// Only a converter that decodes a structure of its own needs this. One registered against a
         /// member is already named by the object holding it, and one that delegates to other converters
         /// inherits whatever they contribute.
@@ -113,9 +129,10 @@ namespace Dahomey.Cbor
         /// <para>
         /// The name may be one the document chose rather than one a type declares - a map key is
         /// arbitrary by definition - so it is bounded in length and escaped, and cannot forge structure
-        /// in the message that carries it. A null or empty name is recorded as an unnamed segment
-        /// rather than rejected: this runs while an exception is already in flight, and throwing a
-        /// second one over a diagnostic would lose the first.
+        /// in the message that carries it. A null or empty name is recorded rather than rejected, since
+        /// this runs while an exception is already in flight and throwing a second one over a
+        /// diagnostic would lose the first; it renders as <c>['']</c>, which a genuinely empty name
+        /// also does, so prefer <see cref="PrependPathIndex(int)"/> where a position is known.
         /// </para>
         /// </remarks>
         public void PrependPathMember(string? name)
@@ -124,11 +141,19 @@ namespace Dahomey.Cbor
         }
 
         /// <summary>
-        /// Records that this failure happened at position <paramref name="index"/> of an array.
+        /// Records that this failure happened at position <paramref name="index"/> of a sequence. A
+        /// negative index is not a position and contributes no segment, though the failure is still
+        /// marked as having been seen here.
         /// </summary>
         /// <inheritdoc cref="PrependPathMember(string)" path="/remarks"/>
         public void PrependPathIndex(int index)
         {
+            if (index < 0)
+            {
+                MarkPathKnown();
+                return;
+            }
+
             PushSegment($"[{index}]");
         }
 

--- a/src/Dahomey.Cbor/CborException.cs
+++ b/src/Dahomey.Cbor/CborException.cs
@@ -92,18 +92,42 @@ namespace Dahomey.Cbor
         /// a key of a map, which read the same way in a path and are not worth distinguishing.
         /// </summary>
         /// <remarks>
-        /// The name is whatever the document sent, not necessarily one the type declares: an unknown
-        /// member rejected by <see cref="UnhandledNameMode"/> fails under the name it arrived with, and
-        /// a map key is arbitrary by definition. It is therefore bounded and quoted rather than pasted
-        /// in, so that a chosen name cannot forge structure in the message that carries it.
+        /// Call this from a converter's <c>catch</c> and rethrow with a bare <c>throw;</c>, so that the
+        /// original stack trace survives. Each frame adds only its own segment, outermost last:
+        /// <code>
+        /// try
+        /// {
+        ///     return ReadPayload(ref reader);
+        /// }
+        /// catch (CborException exception)
+        /// {
+        ///     exception.PrependPathMember("Payload");
+        ///     throw;
+        /// }
+        /// </code>
+        /// <para>
+        /// Only a converter that decodes a structure of its own needs this. One registered against a
+        /// member is already named by the object holding it, and one that delegates to other converters
+        /// inherits whatever they contribute.
+        /// </para>
+        /// <para>
+        /// The name may be one the document chose rather than one a type declares - a map key is
+        /// arbitrary by definition - so it is bounded in length and escaped, and cannot forge structure
+        /// in the message that carries it. A null or empty name is recorded as an unnamed segment
+        /// rather than rejected: this runs while an exception is already in flight, and throwing a
+        /// second one over a diagnostic would lose the first.
+        /// </para>
         /// </remarks>
-        internal void PushName(string? name)
+        public void PrependPathMember(string? name)
         {
             PushSegment(FormatName(name ?? string.Empty));
         }
 
-        /// <summary>Records that this failure happened at position <paramref name="index"/> of an array.</summary>
-        internal void PushIndex(int index)
+        /// <summary>
+        /// Records that this failure happened at position <paramref name="index"/> of an array.
+        /// </summary>
+        /// <inheritdoc cref="PrependPathMember(string)" path="/remarks"/>
+        public void PrependPathIndex(int index)
         {
             PushSegment($"[{index}]");
         }

--- a/src/Dahomey.Cbor/CborException.cs
+++ b/src/Dahomey.Cbor/CborException.cs
@@ -99,7 +99,7 @@ namespace Dahomey.Cbor
         /// </remarks>
         internal void PushName(string? name)
         {
-            PushSegment(FormatName(TextTruncation.Ellipsize(name ?? string.Empty)));
+            PushSegment(FormatName(name ?? string.Empty));
         }
 
         /// <summary>Records that this failure happened at position <paramref name="index"/> of an array.</summary>
@@ -120,37 +120,14 @@ namespace Dahomey.Cbor
         /// </remarks>
         private static string FormatName(string name)
         {
-            if (name.Length != 0 && IsSimpleName(name))
+            // A name short enough to survive whole and made only of token characters needs neither
+            // bracketing nor escaping, so it reads as what it is.
+            if (name.Length != 0 && name.Length <= TextTruncation.MaxCharsInMessage && IsSimpleName(name))
             {
                 return "." + name;
             }
 
-            StringBuilder builder = new StringBuilder(name.Length + 4);
-            builder.Append("['");
-
-            foreach (char c in name)
-            {
-                switch (c)
-                {
-                    case '\\':
-                    case '\'':
-                    case '"':
-                        builder.Append('\\').Append(c);
-                        break;
-                    default:
-                        if (c < ' ' || c == '\u007f')
-                        {
-                            builder.Append("\\u").Append(((int)c).ToString("x4"));
-                        }
-                        else
-                        {
-                            builder.Append(c);
-                        }
-                        break;
-                }
-            }
-
-            return builder.Append("']").ToString();
+            return "['" + TextTruncation.Ellipsize(name, escapeApostrophe: true) + "']";
         }
 
         private static bool IsSimpleName(string name)

--- a/src/Dahomey.Cbor/Dahomey.Cbor.csproj
+++ b/src/Dahomey.Cbor/Dahomey.Cbor.csproj
@@ -16,6 +16,14 @@
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/29336625?s=200&amp;v=4</PackageIconUrl>
     <Copyright>Copyright © Dahomey Technologies 2020</Copyright>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <!--
+      Ships the XML doc alongside the assembly, so that the guidance on the public surface - notably
+      how a custom converter contributes to CborException.Path, and why it must rethrow rather than
+      wrap - reaches consumers in IntelliSense rather than living only in this repository.
+      CS1591 stays off: documenting every public member is a larger undertaking than this enables.
+    -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Dahomey.Cbor/ObjectModel/CborArray.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborArray.cs
@@ -197,7 +197,7 @@ namespace Dahomey.Cbor.ObjectModel
 
             ICborConverter<T> objectConverter = options.Registry.ConverterRegistry.Lookup<T>();
             CborReader reader = new CborReader(buffer.WrittenSpan);
-            return objectConverter.Read(ref reader);
+            return RootReader.Read(ref reader, objectConverter);
         }
     }
 }

--- a/src/Dahomey.Cbor/ObjectModel/CborObject.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborObject.cs
@@ -232,7 +232,7 @@ namespace Dahomey.Cbor.ObjectModel
 
             ICborConverter<T> objectConverter = options.Registry.ConverterRegistry.Lookup<T>();
             CborReader reader = new CborReader(buffer.WrittenSpan);
-            return objectConverter.Read(ref reader);
+            return RootReader.Read(ref reader, objectConverter);
         }
 
         public override bool TryGetMember(GetMemberBinder binder, [MaybeNullWhen(false)] out object? result)

--- a/src/Dahomey.Cbor/ObjectModel/CborObject.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborObject.cs
@@ -218,7 +218,7 @@ namespace Dahomey.Cbor.ObjectModel
 
             ICborConverter<CborObject> cborObjectConverter = options.Registry.ConverterRegistry.Lookup<CborObject>();
             CborReader reader = new CborReader(buffer.WrittenSpan);
-            return cborObjectConverter.Read(ref reader);
+            return RootReader.Read(ref reader, cborObjectConverter);
         }
 
         public T ToObject<T>(CborOptions? options = null)

--- a/src/Dahomey.Cbor/ObjectModel/CborValue.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborValue.cs
@@ -249,7 +249,7 @@ namespace Dahomey.Cbor.ObjectModel
 
             ICborConverter<CborValue> cborValueConverter = options.Registry.ConverterRegistry.Lookup<CborValue>();
             CborReader reader = new CborReader(buffer.WrittenSpan);
-            return cborValueConverter.Read(ref reader);
+            return RootReader.Read(ref reader, cborValueConverter);
         }
 }
 }

--- a/src/Dahomey.Cbor/Serialization/CborDataItemScanner.cs
+++ b/src/Dahomey.Cbor/Serialization/CborDataItemScanner.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Buffers;
 using System.Buffers.Binary;
 
@@ -221,6 +221,7 @@ namespace Dahomey.Cbor.Serialization
         /// Counts the complete data items in <paramref name="buffer"/> and reports how many bytes they
         /// occupy, so a caller can tell a cleanly-terminated sequence from a truncated one.
         /// </summary>
+        /// <param name="buffer">The bytes to scan.</param>
         /// <param name="consumed">Bytes occupied by the complete items.</param>
         /// <param name="count">Number of complete items found.</param>
         /// <returns>

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -102,6 +102,7 @@ namespace Dahomey.Cbor.Serialization
         {
         }
 
+        /// <param name="buffer">The document to read.</param>
         /// <param name="maxDepth">
         /// Maximum nesting depth of maps and arrays. Exceeding it throws a <see cref="CborException"/>
         /// rather than recursing until the stack is exhausted, which is what deeply nested hostile
@@ -269,7 +270,7 @@ namespace Dahomey.Cbor.Serialization
         /// One consequence, which is the reason this is not simply equivalent: a null behind a
         /// semantic tag reads as a tag rather than as null, so the probe does not see it. The value's
         /// converter still calls <c>ReadNull()</c>, which skips the tag and yields null, so the value
-        /// is unaffected -- but <see cref="RequirementPolicy.DisallowNull"/> no longer rejects that
+        /// is unaffected -- but <see cref="Attributes.RequirementPolicy.DisallowNull"/> no longer rejects that
         /// one exotic shape. Pinned by <c>ATaggedNullIsNotRejectedByDisallowNull</c> and
         /// <c>ATaggedUndefinedIsNotRejectedByDisallowNull</c>.
         /// </para>

--- a/src/Dahomey.Cbor/Serialization/CborWriter.cs
+++ b/src/Dahomey.Cbor/Serialization/CborWriter.cs
@@ -47,6 +47,7 @@ namespace Dahomey.Cbor.Serialization
         {
         }
 
+        /// <param name="bufferWriter">Where the encoded bytes are written.</param>
         /// <param name="maxDepth">
         /// Maximum nesting depth of maps and arrays. Exceeding it throws a <see cref="CborException"/>
         /// rather than recursing until the stack is exhausted, which is what an object graph
@@ -57,6 +58,12 @@ namespace Dahomey.Cbor.Serialization
         {
         }
 
+        /// <param name="bufferWriter">Where the encoded bytes are written.</param>
+        /// <param name="maxDepth">
+        /// Maximum nesting depth of maps and arrays. Exceeding it throws a <see cref="CborException"/>
+        /// rather than recursing until the stack is exhausted, which is what an object graph
+        /// containing a reference cycle would otherwise do. Must be positive.
+        /// </param>
         /// <param name="deterministic">
         /// Refuse indefinite lengths, which admit more than one encoding of the same value. Checked
         /// here rather than only on <see cref="CborOptions"/> because the options are the

--- a/src/Dahomey.Cbor/Serialization/Conventions/DefaultDiscriminatorConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/DefaultDiscriminatorConvention.cs
@@ -40,6 +40,8 @@ namespace Dahomey.Cbor.Serialization.Conventions
         /// <see cref="UnhandledNameMode.Silent"/>, otherwise the unknown subtype's extra members throw
         /// instead of being skipped.
         /// </remarks>
+        /// <param name="serializationRegistry">The registry the convention resolves types through.</param>
+        /// <param name="memberName">Name of the member carrying the discriminator.</param>
         public DefaultDiscriminatorConvention(
             SerializationRegistry serializationRegistry, string memberName, Type? fallbackType)
         {

--- a/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
@@ -30,7 +30,6 @@ namespace Dahomey.Cbor.Serialization.Conventions
         /// Registers the convention.This behaves like a stack, so the 
         /// last convention registered is the first convention consulted.
         /// </summary>
-        /// <param name="type">The type.</param>
         /// <param name="convention">The convention.</param>
         public void RegisterConvention(IDiscriminatorConvention convention)
         {

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
@@ -12,6 +12,16 @@ namespace Dahomey.Cbor.Serialization.Converters
         public struct ReaderContext
         {
             public ICollection<TI> collection;
+
+            /// <summary>
+            /// Index of the item currently being read, or -1 before the first one.
+            /// </summary>
+            /// <remarks>
+            /// Only read when an item has thrown, to name the position in
+            /// <see cref="CborException.Path"/>. It is incremented before the item is read rather than
+            /// after, so that the failing index is the one reported.
+            /// </remarks>
+            public int index;
         }
 
         public struct WriterContext
@@ -54,8 +64,27 @@ namespace Dahomey.Cbor.Serialization.Converters
                 return default!;
             }
 
-            ReaderContext context = new ReaderContext();
-            reader.ReadArray(this, ref context);
+            // Before the first item, so that a failure on the array header itself - the common case
+            // of a document that is not an array at all - is not attributed to item 0.
+            ReaderContext context = new ReaderContext { index = -1 };
+
+            try
+            {
+                reader.ReadArray(this, ref context);
+            }
+            catch (CborException exception)
+            {
+                if (context.index >= 0)
+                {
+                    exception.PushIndex(context.index);
+                }
+                else
+                {
+                    exception.MarkPathKnown();
+                }
+
+                throw;
+            }
 
             return InstantiateCollection(context.collection);
         }
@@ -129,6 +158,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public void ReadArrayItem(ref CborReader reader, ref ReaderContext context)
         {
+            context.index++;
             TI item = ItemConverter.Read(ref reader);
             context.collection.Add(item);
         }

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
@@ -87,7 +87,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 if (context.index >= 0)
                 {
-                    exception.PushIndex(context.index);
+                    exception.PrependPathIndex(context.index);
                 }
                 else
                 {

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
@@ -51,7 +51,18 @@ namespace Dahomey.Cbor.Serialization.Converters
 
                 if (reader.TryReadSemanticTag(out ulong tag) && TypedArrayTags.IsTypedArrayTag(tag))
                 {
-                    return ReadTypedArray(ref reader, tag);
+                    try
+                    {
+                        return ReadTypedArray(ref reader, tag);
+                    }
+                    catch (CborException exception)
+                    {
+                        // A typed array is decoded whole rather than item by item, so a failure is a
+                        // property of the array, not of a position in it. The collection itself is
+                        // still a position worth reporting.
+                        exception.MarkPathKnown();
+                        throw;
+                    }
                 }
 
                 // Some other tag, which CBOR says to ignore. Hand it back so the ReadNull below skips

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -70,9 +70,11 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
             catch (CborException exception)
             {
-                if (context.hasKey)
+                string? key = context.hasKey ? DescribeKey(context.key) : null;
+
+                if (key != null)
                 {
-                    exception.PushName(DescribeKey(context.key));
+                    exception.PushName(key);
                 }
                 else if (context.index >= 0)
                 {
@@ -160,8 +162,12 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// <remarks>
         /// <typeparamref name="TK"/> is the caller's type and its <c>ToString</c> is the caller's code,
         /// running here while an exception is already in flight. Letting it throw would replace the
-        /// failure being reported with an unrelated one and lose the read error entirely, so an
-        /// unnameable key is reported as no name rather than as a new problem.
+        /// failure being reported with an unrelated one and lose the read error entirely.
+        /// <para>
+        /// Returning null hands the caller back to the entry's index, which says something true, rather
+        /// than to an empty name, which would be indistinguishable from a key that really is the empty
+        /// string.
+        /// </para>
         /// </remarks>
         private static string? DescribeKey(TK? key)
         {

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -74,11 +74,11 @@ namespace Dahomey.Cbor.Serialization.Converters
 
                 if (key != null)
                 {
-                    exception.PushName(key);
+                    exception.PrependPathMember(key);
                 }
                 else if (context.index >= 0)
                 {
-                    exception.PushIndex(context.index);
+                    exception.PrependPathIndex(context.index);
                 }
                 else
                 {

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -72,7 +72,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 if (context.hasKey)
                 {
-                    exception.PushKey(context.key?.ToString());
+                    exception.PushName(DescribeKey(context.key));
                 }
                 else if (context.index >= 0)
                 {
@@ -151,6 +151,27 @@ namespace Dahomey.Cbor.Serialization.Converters
             catch (ArgumentException exception)
             {
                 throw reader.BuildException(DescribeAddFailure(context.dict, key, exception));
+            }
+        }
+
+        /// <summary>
+        /// How to name the key in a path, when naming it is all that is left to do.
+        /// </summary>
+        /// <remarks>
+        /// <typeparamref name="TK"/> is the caller's type and its <c>ToString</c> is the caller's code,
+        /// running here while an exception is already in flight. Letting it throw would replace the
+        /// failure being reported with an unrelated one and lose the read error entirely, so an
+        /// unnameable key is reported as no name rather than as a new problem.
+        /// </remarks>
+        private static string? DescribeKey(TK? key)
+        {
+            try
+            {
+                return key?.ToString();
+            }
+            catch (Exception)
+            {
+                return null;
             }
         }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -13,6 +13,24 @@ namespace Dahomey.Cbor.Serialization.Converters
         public struct ReaderContext
         {
             public IDictionary<TK, TV> dict;
+
+            /// <summary>
+            /// Where the entry currently being read sits, and what it is keyed by once that much has
+            /// been decoded. Only read when an entry has thrown, to name the position in
+            /// <see cref="CborException.Path"/>.
+            /// </summary>
+            /// <remarks>
+            /// The key is the better name of the two, so <see cref="index"/> - which counts entries
+            /// from 0, and is -1 before the first one - is only used for a failure that happened
+            /// before the key itself could be read.
+            /// </remarks>
+            public int index;
+
+            /// <inheritdoc cref="index"/>
+            public TK? key;
+
+            /// <inheritdoc cref="index"/>
+            public bool hasKey;
         }
 
         public struct WriterContext
@@ -42,8 +60,32 @@ namespace Dahomey.Cbor.Serialization.Converters
                 return default!;
             }
 
-            ReaderContext context = new ReaderContext();
-            reader.ReadMap(this, ref context);
+            // Before the first entry, so that a failure on the map header itself is not attributed
+            // to entry 0.
+            ReaderContext context = new ReaderContext { index = -1 };
+
+            try
+            {
+                reader.ReadMap(this, ref context);
+            }
+            catch (CborException exception)
+            {
+                if (context.hasKey)
+                {
+                    exception.PushKey(context.key?.ToString());
+                }
+                else if (context.index >= 0)
+                {
+                    exception.PushIndex(context.index);
+                }
+                else
+                {
+                    exception.MarkPathKnown();
+                }
+
+                throw;
+            }
+
             return InstantiateCollection(context.dict);
         }
 
@@ -90,7 +132,14 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public void ReadMapItem(ref CborReader reader, ref ReaderContext context)
         {
+            context.index++;
+            context.hasKey = false;
+
             TK key = KeyConverter.Read(ref reader);
+
+            context.key = key;
+            context.hasKey = true;
+
             TV value = ValueConverter.Read(ref reader);
 
             // See CborValueConverter.ReadMapItem: these are malformed input, and were already refused

--- a/src/Dahomey.Cbor/Serialization/Converters/ArrayConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ArrayConverter.cs
@@ -60,7 +60,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 if (context.index >= 0)
                 {
-                    exception.PushIndex(context.index);
+                    exception.PrependPathIndex(context.index);
                 }
                 else
                 {

--- a/src/Dahomey.Cbor/Serialization/Converters/ArrayConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ArrayConverter.cs
@@ -11,6 +11,17 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             public TI[] array;
             public List<TI> list;
+
+            /// <summary>
+            /// Index of the item currently being read, or -1 before the first one. Doubles as the
+            /// write position on the definite-length branch, where the array is allocated up front.
+            /// </summary>
+            /// <remarks>
+            /// Read on failure to name the position in <see cref="CborException.Path"/>. It is
+            /// advanced before the item is read rather than as a side effect of storing it, so that
+            /// an item that throws has already claimed its own index and the indefinite-length branch
+            /// counts too.
+            /// </remarks>
             public int index;
         }
 
@@ -37,8 +48,27 @@ namespace Dahomey.Cbor.Serialization.Converters
                 return null;
             }
 
-            ReaderContext context = new ReaderContext();
-            reader.ReadArray(this, ref context);
+            // Before the first item, so that a failure on the array header itself - the common case of
+            // a document that is not an array at all - is not attributed to item 0.
+            ReaderContext context = new ReaderContext { index = -1 };
+
+            try
+            {
+                reader.ReadArray(this, ref context);
+            }
+            catch (CborException exception)
+            {
+                if (context.index >= 0)
+                {
+                    exception.PushIndex(context.index);
+                }
+                else
+                {
+                    exception.MarkPathKnown();
+                }
+
+                throw;
+            }
 
             if (context.array != null)
             {
@@ -82,11 +112,12 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public void ReadArrayItem(ref CborReader reader, ref ReaderContext context)
         {
+            int index = ++context.index;
             TI item = ItemConverter.Read(ref reader);
 
             if (context.array != null)
             {
-                context.array[context.index++] = item;
+                context.array[index] = item;
             }
             else
             {

--- a/src/Dahomey.Cbor/Serialization/Converters/DeterministicKeyOrder.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/DeterministicKeyOrder.cs
@@ -1,4 +1,4 @@
-using Dahomey.Cbor.ObjectModel;
+﻿using Dahomey.Cbor.ObjectModel;
 using Dahomey.Cbor.Util;
 using System;
 using System.Collections.Generic;
@@ -41,6 +41,8 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// Returns the entries in deterministic key order, encoding each key exactly once with
         /// <paramref name="keyConverter" />.
         /// </summary>
+        /// <param name="entries">The entries to order.</param>
+        /// <param name="keyConverter">Encodes each key, so the order is the order of the bytes written.</param>
         /// <param name="maxDepth">
         /// Depth bound for the scratch writer. A key is normally a scalar, but nothing forbids a
         /// composite one, and the bound should be the caller's rather than the default.

--- a/src/Dahomey.Cbor/Serialization/Converters/MapKeyErrors.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MapKeyErrors.cs
@@ -1,3 +1,5 @@
+using Dahomey.Cbor.Util;
+
 namespace Dahomey.Cbor.Serialization.Converters
 {
     /// <summary>
@@ -12,13 +14,6 @@ namespace Dahomey.Cbor.Serialization.Converters
     /// </remarks>
     internal static class MapKeyErrors
     {
-        /// <summary>
-        /// How much of a key is worth repeating. A key comes from the document being decoded, which for
-        /// anything reading untrusted frames means an attacker chooses it, and exception messages end
-        /// up in logs.
-        /// </summary>
-        private const int MaxKeyCharsInMessage = 64;
-
         public static string NullKey()
         {
             return "A map key cannot be null.";
@@ -40,11 +35,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         private static string Describe(object key)
         {
-            string text = key.ToString() ?? string.Empty;
-
-            return text.Length <= MaxKeyCharsInMessage
-                ? text
-                : text.Substring(0, MaxKeyCharsInMessage) + $"... ({text.Length} characters)";
+            return TextTruncation.Ellipsize(key.ToString() ?? string.Empty);
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -271,9 +271,12 @@ namespace Dahomey.Cbor.Serialization.Converters
             };
 
             // Members name themselves in ReadItem, where the name is still in hand. What is left for
-            // this frame is the failure that never reached a member -- a document whose shape
-            // contradicts the mapping outright -- which has no segment to contribute but is still a
-            // position worth reporting as such: the object itself, $ at the root.
+            // this frame is every failure that never reached a member -- a document whose shape
+            // contradicts the mapping outright, a creator that rejects what was collected, a required
+            // member that never arrived -- which has no segment to contribute but is still a position
+            // worth reporting as such: the object itself, $ at the root. The whole body is covered so
+            // that a required member missing from the root reports the same way as one missing from a
+            // nested object, rather than losing its path for being validated after the loop.
             try
             {
                 switch (_objectMapping.ObjectFormat)
@@ -300,84 +303,84 @@ namespace Dahomey.Cbor.Serialization.Converters
                         }
                         break;
                 }
+
+                if (context.converter == null)
+                {
+                    context.converter = this;
+                }
+                IObjectMapping objectMapping = context.converter.ObjectMapping;
+
+                if (objectMapping.CreatorMapping != null)
+                {
+                    switch (_objectMapping.ObjectFormat)
+                    {
+                        case CborObjectFormat.StringKeyMap:
+                            {
+                                context.obj = (T)objectMapping.CreatorMapping.CreateInstance(context.creatorValues!);
+                                if (objectMapping.OnDeserializingMethod != null)
+                                {
+                                    ((Action<T>)objectMapping.OnDeserializingMethod)(context.obj);
+                                }
+
+                                foreach (KeyValuePair<RawString, object> value in context.regularValues!)
+                                {
+                                    if (!context.converter.MemberConvertersForRead.TryGetValue(value.Key.Buffer.Span, out IMemberConverter? memberConverter))
+                                    {
+                                        // should not happen
+                                        throw new CborException("Unexpected error");
+                                    }
+
+                                    memberConverter.Set(context.obj, value.Value);
+                                }
+                            }
+                            break;
+                        case CborObjectFormat.IntKeyMap:
+                        case CborObjectFormat.Array:
+                            {
+                                context.obj = (T)objectMapping.CreatorMapping.CreateInstance(context.creatorValuesByIndex!);
+                                if (objectMapping.OnDeserializingMethod != null)
+                                {
+                                    ((Action<T>)objectMapping.OnDeserializingMethod)(context.obj);
+                                }
+
+                                foreach (KeyValuePair<int, object> value in context.regularValuesByIndex!)
+                                {
+                                    if (!context.converter.MemberConvertersForReadByIndex.TryGetValue(value.Key, out IMemberConverter? memberConverter))
+                                    {
+                                        // should not happen
+                                        throw new CborException("Unexpected error");
+                                    }
+
+                                    memberConverter.Set(context.obj, value.Value);
+                                }
+                            }
+                            break;
+                    }
+                }
+
+                if (context.readMembers != null)
+                {
+                    foreach (IMemberConverter memberConverter in context.converter.RequiredMemberConvertersForRead)
+                    {
+                        if (!context.readMembers.Contains(memberConverter))
+                        {
+                            throw new CborException($"Required property '{Encoding.UTF8.GetString(memberConverter.MemberName)}' not found in JSON.");
+                        }
+                    }
+                }
+
+                if (objectMapping.OnDeserializedMethod != null)
+                {
+                    ((Action<T>)objectMapping.OnDeserializedMethod)(context.obj);
+                }
+
+                return context.obj;
             }
             catch (CborException exception)
             {
                 exception.MarkPathKnown();
                 throw;
             }
-
-            if (context.converter == null)
-            {
-                context.converter = this;
-            }
-            IObjectMapping objectMapping = context.converter.ObjectMapping;
-
-            if (objectMapping.CreatorMapping != null)
-            {
-                switch (_objectMapping.ObjectFormat)
-                {
-                    case CborObjectFormat.StringKeyMap:
-                        {
-                            context.obj = (T)objectMapping.CreatorMapping.CreateInstance(context.creatorValues!);
-                            if (objectMapping.OnDeserializingMethod != null)
-                            {
-                                ((Action<T>)objectMapping.OnDeserializingMethod)(context.obj);
-                            }
-
-                            foreach (KeyValuePair<RawString, object> value in context.regularValues!)
-                            {
-                                if (!context.converter.MemberConvertersForRead.TryGetValue(value.Key.Buffer.Span, out IMemberConverter? memberConverter))
-                                {
-                                    // should not happen
-                                    throw new CborException("Unexpected error");
-                                }
-
-                                memberConverter.Set(context.obj, value.Value);
-                            }
-                        }
-                        break;
-                    case CborObjectFormat.IntKeyMap:
-                    case CborObjectFormat.Array:
-                        {
-                            context.obj = (T)objectMapping.CreatorMapping.CreateInstance(context.creatorValuesByIndex!);
-                            if (objectMapping.OnDeserializingMethod != null)
-                            {
-                                ((Action<T>)objectMapping.OnDeserializingMethod)(context.obj);
-                            }
-
-                            foreach (KeyValuePair<int, object> value in context.regularValuesByIndex!)
-                            {
-                                if (!context.converter.MemberConvertersForReadByIndex.TryGetValue(value.Key, out IMemberConverter? memberConverter))
-                                {
-                                    // should not happen
-                                    throw new CborException("Unexpected error");
-                                }
-
-                                memberConverter.Set(context.obj, value.Value);
-                            }
-                        }
-                        break;
-                }
-            }
-
-            if (context.readMembers != null)
-            {
-                foreach (IMemberConverter memberConverter in context.converter.RequiredMemberConvertersForRead)
-                {
-                    if (!context.readMembers.Contains(memberConverter))
-                    {
-                        throw new CborException($"Required property '{Encoding.UTF8.GetString(memberConverter.MemberName)}' not found in JSON.");
-                    }
-                }
-            }
-
-            if (objectMapping.OnDeserializedMethod != null)
-            {
-                ((Action<T>)objectMapping.OnDeserializedMethod)(context.obj);
-            }
-
-            return context.obj;
         }
 
         public void ReadValue(ref CborReader reader, object obj, ReadOnlySpan<byte> memberName, HashSet<IMemberConverter> readMembers)
@@ -731,7 +734,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                         {
                             // The name as it appears in the document. Decoding it here rather than
                             // keeping it around costs nothing until something has already failed.
-                            exception.PushMember(Encoding.UTF8.GetString(memberName));
+                            exception.PushName(Encoding.UTF8.GetString(memberName));
                             throw;
                         }
                     }
@@ -824,7 +827,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 if (memberMapping.MemberIndex == memberIndex && memberMapping.MemberInfo != null)
                 {
-                    exception.PushMember(memberMapping.MemberInfo.Name);
+                    exception.PushName(memberMapping.MemberInfo.Name);
                     return;
                 }
             }

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -1038,10 +1038,12 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             if (_options.UnhandledNameMode == UnhandledNameMode.ThrowException)
             {
-                // The name is whatever the document chose to send, so it is quoted back on the same
-                // terms as any other document text rather than copied into the message whole.
+                // The name is whatever the document chose to send, so it is bounded and escaped on the
+                // same terms as any other document text rather than copied into the message whole.
+                // UTF-8 rather than ASCII: a CBOR text string is UTF-8, and decoding it as ASCII turned
+                // every non-ASCII member name into a row of question marks.
                 throw reader.BuildException(
-                    $"Unhandled name [{TextTruncation.Ellipsize(Encoding.ASCII.GetString(rawName))}] in class [{type.Name}] while deserializing.");
+                    $"Unhandled name [{TextTruncation.Ellipsize(Encoding.UTF8.GetString(rawName))}] in class [{type.Name}] while deserializing.");
             }
         }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -734,7 +734,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                         {
                             // The name as it appears in the document. Decoding it here rather than
                             // keeping it around costs nothing until something has already failed.
-                            exception.PushName(Encoding.UTF8.GetString(memberName));
+                            exception.PrependPathMember(Encoding.UTF8.GetString(memberName));
                             throw;
                         }
                     }
@@ -827,12 +827,12 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 if (memberMapping.MemberIndex == memberIndex && memberMapping.MemberInfo != null)
                 {
-                    exception.PushName(memberMapping.MemberInfo.Name);
+                    exception.PrependPathMember(memberMapping.MemberInfo.Name);
                     return;
                 }
             }
 
-            exception.PushIndex(memberIndex);
+            exception.PrependPathIndex(memberIndex);
         }
 
         private void ReadValueForStruct(ref CborReader reader, ref T instance, ReadOnlySpan<byte> memberName, HashSet<IMemberConverter> readMembers)

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -270,29 +270,41 @@ namespace Dahomey.Cbor.Serialization.Converters
                 readMembers = _requiredMemberConvertersForRead.Count != 0 ? new HashSet<IMemberConverter>() : null
             };
 
-            switch (_objectMapping.ObjectFormat)
+            // Members name themselves in ReadItem, where the name is still in hand. What is left for
+            // this frame is the failure that never reached a member -- a document whose shape
+            // contradicts the mapping outright -- which has no segment to contribute but is still a
+            // position worth reporting as such: the object itself, $ at the root.
+            try
             {
-                case CborObjectFormat.StringKeyMap:
-                    {
-                        context.creatorValues = _objectMapping.CreatorMapping != null ? new() : null;
-                        context.regularValues = _objectMapping.CreatorMapping != null ? new () : null;
-                        reader.ReadMap(this, ref context);
-                    }
-                    break;
-                case CborObjectFormat.IntKeyMap:
-                    {
-                        context.creatorValuesByIndex = _objectMapping.CreatorMapping != null ? new() : null;
-                        context.regularValuesByIndex = _objectMapping.CreatorMapping != null ? new() : null;
-                        reader.ReadMap(this, ref context);
-                    }
-                    break;
-                case CborObjectFormat.Array:
-                    {
-                        context.creatorValuesByIndex = _objectMapping.CreatorMapping != null ? new() : null;
-                        context.regularValuesByIndex = _objectMapping.CreatorMapping != null ? new() : null;
-                        reader.ReadArray(this, ref context);
-                    }
-                    break;
+                switch (_objectMapping.ObjectFormat)
+                {
+                    case CborObjectFormat.StringKeyMap:
+                        {
+                            context.creatorValues = _objectMapping.CreatorMapping != null ? new() : null;
+                            context.regularValues = _objectMapping.CreatorMapping != null ? new () : null;
+                            reader.ReadMap(this, ref context);
+                        }
+                        break;
+                    case CborObjectFormat.IntKeyMap:
+                        {
+                            context.creatorValuesByIndex = _objectMapping.CreatorMapping != null ? new() : null;
+                            context.regularValuesByIndex = _objectMapping.CreatorMapping != null ? new() : null;
+                            reader.ReadMap(this, ref context);
+                        }
+                        break;
+                    case CborObjectFormat.Array:
+                        {
+                            context.creatorValuesByIndex = _objectMapping.CreatorMapping != null ? new() : null;
+                            context.regularValuesByIndex = _objectMapping.CreatorMapping != null ? new() : null;
+                            reader.ReadArray(this, ref context);
+                        }
+                        break;
+                }
+            }
+            catch (CborException exception)
+            {
+                exception.MarkPathKnown();
+                throw;
             }
 
             if (context.converter == null)
@@ -689,27 +701,38 @@ namespace Dahomey.Cbor.Serialization.Converters
                 case CborObjectFormat.StringKeyMap:
                     {
                         ReadOnlySpan<byte> memberName = reader.ReadRawString();
-                        if (context.creatorValues == null)
+
+                        try
                         {
-                            if (_isStruct)
+                            if (context.creatorValues == null)
                             {
-                                ReadValueForStruct(ref reader, ref context.obj, memberName, context.readMembers!);
+                                if (_isStruct)
+                                {
+                                    ReadValueForStruct(ref reader, ref context.obj, memberName, context.readMembers!);
+                                }
+                                else
+                                {
+                                    context.converter.ReadValue(ref reader, context.obj!, memberName, context.readMembers!);
+                                }
                             }
-                            else
+                            else if (context.converter.ReadValue(ref reader, memberName, context.readMembers!, out object? value))
                             {
-                                context.converter.ReadValue(ref reader, context.obj!, memberName, context.readMembers!);
+                                if (context.converter.ObjectMapping.IsCreatorMember(memberName))
+                                {
+                                    AddMemberValue(ref reader, context.creatorValues, new RawString(memberName), value);
+                                }
+                                else
+                                {
+                                    AddMemberValue(ref reader, context.regularValues!, new RawString(memberName), value);
+                                }
                             }
                         }
-                        else if (context.converter.ReadValue(ref reader, memberName, context.readMembers!, out object? value))
+                        catch (CborException exception)
                         {
-                            if (context.converter.ObjectMapping.IsCreatorMember(memberName))
-                            {
-                                AddMemberValue(ref reader, context.creatorValues, new RawString(memberName), value);
-                            }
-                            else
-                            {
-                                AddMemberValue(ref reader, context.regularValues!, new RawString(memberName), value);
-                            }
+                            // The name as it appears in the document. Decoding it here rather than
+                            // keeping it around costs nothing until something has already failed.
+                            exception.PushMember(Encoding.UTF8.GetString(memberName));
+                            throw;
                         }
                     }
                     break;
@@ -717,57 +740,96 @@ namespace Dahomey.Cbor.Serialization.Converters
                     {
                         int memberIndex = reader.ReadInt32();
 
-                        if (context.creatorValuesByIndex == null)
+                        try
                         {
-                            if (_isStruct)
+                            if (context.creatorValuesByIndex == null)
                             {
-                                ReadValueForStruct(ref reader, ref context.obj, memberIndex, context.readMembers!);
+                                if (_isStruct)
+                                {
+                                    ReadValueForStruct(ref reader, ref context.obj, memberIndex, context.readMembers!);
+                                }
+                                else
+                                {
+                                    context.converter.ReadValue(ref reader, context.obj!, memberIndex, context.readMembers!);
+                                }
                             }
-                            else
+                            else if (context.converter.ReadValue(ref reader, memberIndex, context.readMembers!, out object? value))
                             {
-                                context.converter.ReadValue(ref reader, context.obj!, memberIndex, context.readMembers!);
+                                if (context.converter.ObjectMapping.IsCreatorMember(memberIndex))
+                                {
+                                    AddMemberValue(ref reader, context.creatorValuesByIndex, memberIndex, value);
+                                }
+                                else
+                                {
+                                    AddMemberValue(ref reader, context.regularValuesByIndex!, memberIndex, value);
+                                }
                             }
                         }
-                        else if (context.converter.ReadValue(ref reader, memberIndex, context.readMembers!, out object? value))
+                        catch (CborException exception)
                         {
-                            if (context.converter.ObjectMapping.IsCreatorMember(memberIndex))
-                            {
-                                AddMemberValue(ref reader, context.creatorValuesByIndex, memberIndex, value);
-                            }
-                            else
-                            {
-                                AddMemberValue(ref reader, context.regularValuesByIndex!, memberIndex, value);
-                            }
+                            PushMemberSegment(exception, context.converter, memberIndex);
+                            throw;
                         }
                     }
                     break;
                 case CborObjectFormat.Array:
-                    if (context.creatorValuesByIndex == null)
+                    try
                     {
-                        if (_isStruct)
+                        if (context.creatorValuesByIndex == null)
                         {
-                            ReadValueForStruct(ref reader, ref context.obj, context.memberIndex, context.readMembers!);
+                            if (_isStruct)
+                            {
+                                ReadValueForStruct(ref reader, ref context.obj, context.memberIndex, context.readMembers!);
+                            }
+                            else
+                            {
+                                context.converter.ReadValue(ref reader, context.obj!, context.memberIndex, context.readMembers!);
+                            }
                         }
-                        else
+                        else if (context.converter.ReadValue(ref reader, context.memberIndex, context.readMembers!, out object? value))
                         {
-                            context.converter.ReadValue(ref reader, context.obj!, context.memberIndex, context.readMembers!);
+                            if (context.converter.ObjectMapping.IsCreatorMember(context.memberIndex))
+                            {
+                                AddMemberValue(ref reader, context.creatorValuesByIndex, context.memberIndex, value);
+                            }
+                            else
+                            {
+                                AddMemberValue(ref reader, context.regularValuesByIndex!, context.memberIndex, value);
+                            }
                         }
                     }
-                    else if (context.converter.ReadValue(ref reader, context.memberIndex, context.readMembers!, out object? value))
+                    catch (CborException exception)
                     {
-                        if (context.converter.ObjectMapping.IsCreatorMember(context.memberIndex))
-                        {
-                            AddMemberValue(ref reader, context.creatorValuesByIndex, context.memberIndex, value);
-                        }
-                        else
-                        {
-                            AddMemberValue(ref reader, context.regularValuesByIndex!, context.memberIndex, value);
-                        }
+                        PushMemberSegment(exception, context.converter, context.memberIndex);
+                        throw;
                     }
 
                     context.memberIndex++;
                     break;
             }
+        }
+
+        /// <summary>
+        /// Names the member at <paramref name="memberIndex"/> in the failure path, by the name it has
+        /// on the type rather than by its position, which is what a caller reading the message is
+        /// looking for. Falls back to the position when the index maps to no member -- an index the
+        /// document invented, which has no name to give.
+        /// </summary>
+        private static void PushMemberSegment(CborException exception, IObjectConverter converter, int memberIndex)
+        {
+            // The name comes from the mapping rather than from the member converter: an integer-keyed
+            // member has no name in the document, so the converter carries an empty one, and the name
+            // on the type is exactly what the document does not say and the caller needs told.
+            foreach (IMemberMapping memberMapping in converter.ObjectMapping.MemberMappings)
+            {
+                if (memberMapping.MemberIndex == memberIndex && memberMapping.MemberInfo != null)
+                {
+                    exception.PushMember(memberMapping.MemberInfo.Name);
+                    return;
+                }
+            }
+
+            exception.PushIndex(memberIndex);
         }
 
         private void ReadValueForStruct(ref CborReader reader, ref T instance, ReadOnlySpan<byte> memberName, HashSet<IMemberConverter> readMembers)
@@ -973,7 +1035,10 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             if (_options.UnhandledNameMode == UnhandledNameMode.ThrowException)
             {
-                throw reader.BuildException($"Unhandled name [{Encoding.ASCII.GetString(rawName)}] in class [{type.Name}] while deserializing.");
+                // The name is whatever the document chose to send, so it is quoted back on the same
+                // terms as any other document text rather than copied into the message whole.
+                throw reader.BuildException(
+                    $"Unhandled name [{TextTruncation.Ellipsize(Encoding.ASCII.GetString(rawName))}] in class [{type.Name}] while deserializing.");
             }
         }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
@@ -1,5 +1,29 @@
-namespace Dahomey.Cbor.Serialization.Converters
+﻿namespace Dahomey.Cbor.Serialization.Converters
 {
+    /// <summary>
+    /// Reads one item of a tuple, naming its position in <see cref="CborException.Path"/> if it fails.
+    /// </summary>
+    /// <remarks>
+    /// A tuple has no member names to report, so the position is all there is to say - and it is what a
+    /// caller needs, because the items of a tuple are otherwise indistinguishable in a message. Shared
+    /// by every arity rather than written out in each, since each item read is otherwise identical.
+    /// </remarks>
+    internal static class TupleItemReader
+    {
+        public static T Read<T>(ref CborReader reader, ICborConverter<T> converter, int index)
+        {
+            try
+            {
+                return converter.Read(ref reader);
+            }
+            catch (CborException exception)
+            {
+                exception.PushIndex(index);
+                throw;
+            }
+        }
+    }
+
     public class Tuple2Converter<T1, T2> : CborConverterBase<(T1, T2)>
     {
         private readonly CborOptions _options;
@@ -31,13 +55,13 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 throw new CborException("Expected CBOR Array of size 2");
             }
-            T1 item1 = _item1Converter.Read(ref reader);
+            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 2");
             }
-            T2 item2 = _item2Converter.Read(ref reader);
+            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
 
             return (item1, item2);
         }
@@ -87,19 +111,19 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 throw new CborException("Expected CBOR Array of size 3");
             }
-            T1 item1 = _item1Converter.Read(ref reader);
+            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 3");
             }
-            T2 item2 = _item2Converter.Read(ref reader);
+            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 3");
             }
-            T3 item3 = _item3Converter.Read(ref reader);
+            T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
 
             return (item1, item2, item3);
         }
@@ -152,25 +176,25 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 throw new CborException("Expected CBOR Array of size 4");
             }
-            T1 item1 = _item1Converter.Read(ref reader);
+            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 4");
             }
-            T2 item2 = _item2Converter.Read(ref reader);
+            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 4");
             }
-            T3 item3 = _item3Converter.Read(ref reader);
+            T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 4");
             }
-            T4 item4 = _item4Converter.Read(ref reader);
+            T4 item4 = TupleItemReader.Read(ref reader, _item4Converter, 3);
 
             return (item1, item2, item3, item4);
         }
@@ -226,31 +250,31 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 throw new CborException("Expected CBOR Array of size 5");
             }
-            T1 item1 = _item1Converter.Read(ref reader);
+            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 5");
             }
-            T2 item2 = _item2Converter.Read(ref reader);
+            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 5");
             }
-            T3 item3 = _item3Converter.Read(ref reader);
+            T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 5");
             }
-            T4 item4 = _item4Converter.Read(ref reader);
+            T4 item4 = TupleItemReader.Read(ref reader, _item4Converter, 3);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 5");
             }
-            T5 item5 = _item5Converter.Read(ref reader);
+            T5 item5 = TupleItemReader.Read(ref reader, _item5Converter, 4);
 
             return (item1, item2, item3, item4, item5);
         }
@@ -309,37 +333,37 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 throw new CborException("Expected CBOR Array of size 6");
             }
-            T1 item1 = _item1Converter.Read(ref reader);
+            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 6");
             }
-            T2 item2 = _item2Converter.Read(ref reader);
+            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 6");
             }
-            T3 item3 = _item3Converter.Read(ref reader);
+            T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 6");
             }
-            T4 item4 = _item4Converter.Read(ref reader);
+            T4 item4 = TupleItemReader.Read(ref reader, _item4Converter, 3);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 6");
             }
-            T5 item5 = _item5Converter.Read(ref reader);
+            T5 item5 = TupleItemReader.Read(ref reader, _item5Converter, 4);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 6");
             }
-            T6 item6 = _item6Converter.Read(ref reader);
+            T6 item6 = TupleItemReader.Read(ref reader, _item6Converter, 5);
 
             return (item1, item2, item3, item4, item5, item6);
         }
@@ -401,43 +425,43 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
-            T1 item1 = _item1Converter.Read(ref reader);
+            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
-            T2 item2 = _item2Converter.Read(ref reader);
+            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
-            T3 item3 = _item3Converter.Read(ref reader);
+            T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
-            T4 item4 = _item4Converter.Read(ref reader);
+            T4 item4 = TupleItemReader.Read(ref reader, _item4Converter, 3);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
-            T5 item5 = _item5Converter.Read(ref reader);
+            T5 item5 = TupleItemReader.Read(ref reader, _item5Converter, 4);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
-            T6 item6 = _item6Converter.Read(ref reader);
+            T6 item6 = TupleItemReader.Read(ref reader, _item6Converter, 5);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 7");
             }
-            T7 item7 = _item7Converter.Read(ref reader);
+            T7 item7 = TupleItemReader.Read(ref reader, _item7Converter, 6);
 
             return (item1, item2, item3, item4, item5, item6, item7);
         }
@@ -501,50 +525,50 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
-            T1 item1 = _item1Converter.Read(ref reader);
+            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
-            T2 item2 = _item2Converter.Read(ref reader);
+            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
-            T3 item3 = _item3Converter.Read(ref reader);
+            T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
-            T4 item4 = _item4Converter.Read(ref reader);
+            T4 item4 = TupleItemReader.Read(ref reader, _item4Converter, 3);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
-            T5 item5 = _item5Converter.Read(ref reader);
+            T5 item5 = TupleItemReader.Read(ref reader, _item5Converter, 4);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
-            T6 item6 = _item6Converter.Read(ref reader);
+            T6 item6 = TupleItemReader.Read(ref reader, _item6Converter, 5);
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
-            T7 item7 = _item7Converter.Read(ref reader);
+            T7 item7 = TupleItemReader.Read(ref reader, _item7Converter, 6);
 
 
             if (size == -1 && reader.IsBreak())
             {
                 throw new CborException("Expected CBOR Array of size 8");
             }
-            T8 item8 = _item8Converter.Read(ref reader);
+            T8 item8 = TupleItemReader.Read(ref reader, _item8Converter, 7);
 
             return (item1, item2, item3, item4, item5, item6, item7, item8);
         }

--- a/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
@@ -18,7 +18,7 @@
             }
             catch (CborException exception)
             {
-                exception.PushIndex(index);
+                exception.PrependPathIndex(index);
                 throw;
             }
         }

--- a/src/Dahomey.Cbor/Serialization/Converters/TypedArrayConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TypedArrayConverter.cs
@@ -61,7 +61,17 @@ namespace Dahomey.Cbor.Serialization.Converters
 
                 if (reader.TryReadSemanticTag(out ulong tag) && TypedArrayTags.IsTypedArrayTag(tag))
                 {
-                    return ReadTypedArray(ref reader, tag);
+                    try
+                    {
+                        return ReadTypedArray(ref reader, tag);
+                    }
+                    catch (CborException exception)
+                    {
+                        // Decoded whole rather than item by item, so a failure belongs to the array
+                        // itself. See AbstractCollectionConverter.Read.
+                        exception.MarkPathKnown();
+                        throw;
+                    }
                 }
 
                 // Some other tag, which CBOR says to ignore. Hand it back rather than keeping it

--- a/src/Dahomey.Cbor/Serialization/RootReader.cs
+++ b/src/Dahomey.Cbor/Serialization/RootReader.cs
@@ -1,0 +1,50 @@
+using Dahomey.Cbor.Serialization.Converters;
+
+namespace Dahomey.Cbor.Serialization
+{
+    /// <summary>
+    /// Reads the value at the root of a document, so that a failure on the root itself still has a
+    /// position to report: <see cref="CborException.Path"/> of <c>$</c>.
+    /// </summary>
+    /// <remarks>
+    /// The converters that name members, indices and keys only do so from inside a container. A
+    /// document that contradicts the requested type outright never reaches one of them, and that is
+    /// the failure a caller is least able to place from a byte offset alone. Every entry point that
+    /// starts a read goes through here, which is what lets <see cref="CborException.Path"/> promise
+    /// that a null value means the exception did not come from a read at all.
+    /// <para>
+    /// The speculative read behind the <c>PipeReader</c> overloads is deliberately not routed through
+    /// this: it throws as a matter of course while waiting for more of a stream, and discards what it
+    /// catches.
+    /// </para>
+    /// </remarks>
+    internal static class RootReader
+    {
+        public static T Read<T>(ref CborReader reader, ICborConverter<T> converter)
+        {
+            try
+            {
+                return converter.Read(ref reader);
+            }
+            catch (CborException exception)
+            {
+                exception.MarkPathKnown();
+                throw;
+            }
+        }
+
+        /// <inheritdoc cref="Read{T}(ref CborReader, ICborConverter{T})"/>
+        public static object? Read(ref CborReader reader, ICborConverter converter)
+        {
+            try
+            {
+                return converter.Read(ref reader);
+            }
+            catch (CborException exception)
+            {
+                exception.MarkPathKnown();
+                throw;
+            }
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Util/SequenceReader.cs
+++ b/src/Dahomey.Cbor/Util/SequenceReader.cs
@@ -340,7 +340,7 @@ namespace System.Buffers
         /// </summary>
         /// <remarks>
         /// This API is used to copy a fixed amount of data out of the sequence if possible. It does not advance
-        /// the reader. To look ahead for a specific stream of data <see cref="IsNext(ReadOnlySpan{T}, bool)"/> can be used.
+        /// the reader. To look ahead for a specific stream of data <c>IsNext</c> can be used.
         /// </remarks>
         /// <param name="destination">Destination span to copy to.</param>
         /// <returns>True if there is enough data to completely fill the <paramref name="destination"/> span.</returns>

--- a/src/Dahomey.Cbor/Util/TextTruncation.cs
+++ b/src/Dahomey.Cbor/Util/TextTruncation.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 
 namespace Dahomey.Cbor.Util
@@ -24,6 +24,7 @@ namespace Dahomey.Cbor.Util
         /// </remarks>
         public const int MaxCharsInMessage = 64;
 
+        /// <param name="text">The document text to render.</param>
         /// <param name="escapeApostrophe">
         /// Set where the result is wrapped in <c>'…'</c>, as a path segment is. Left off elsewhere so
         /// that ordinary prose is not littered with backslashes.

--- a/src/Dahomey.Cbor/Util/TextTruncation.cs
+++ b/src/Dahomey.Cbor/Util/TextTruncation.cs
@@ -1,0 +1,23 @@
+namespace Dahomey.Cbor.Util
+{
+    /// <summary>
+    /// How much text taken from the document being decoded may be repeated back in an exception.
+    /// </summary>
+    /// <remarks>
+    /// Map keys, member names and the paths built out of them all come from the document, which for
+    /// anything reading untrusted frames means an attacker chooses them - and exception messages end up
+    /// in logs. One policy, applied everywhere such text is quoted, keeps a message's length a function
+    /// of the document's shape rather than of its contents.
+    /// </remarks>
+    internal static class TextTruncation
+    {
+        public const int MaxCharsInMessage = 64;
+
+        public static string Ellipsize(string text)
+        {
+            return text.Length <= MaxCharsInMessage
+                ? text
+                : text.Substring(0, MaxCharsInMessage) + $"... ({text.Length} characters)";
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Util/TextTruncation.cs
+++ b/src/Dahomey.Cbor/Util/TextTruncation.cs
@@ -1,23 +1,124 @@
+using System;
+using System.Text;
+
 namespace Dahomey.Cbor.Util
 {
     /// <summary>
-    /// How much text taken from the document being decoded may be repeated back in an exception.
+    /// How text taken from the document being decoded may be repeated back in an exception.
     /// </summary>
     /// <remarks>
     /// Map keys, member names and the paths built out of them all come from the document, which for
     /// anything reading untrusted frames means an attacker chooses them - and exception messages end up
-    /// in logs. One policy, applied everywhere such text is quoted, keeps a message's length a function
-    /// of the document's shape rather than of its contents.
+    /// in logs. One policy, applied everywhere such text is quoted, keeps a message bounded in length
+    /// and free of characters that would let the quoted text pass itself off as the structure around
+    /// it.
     /// </remarks>
     internal static class TextTruncation
     {
+        /// <summary>
+        /// The budget, counted in characters of the rendered result rather than of the source.
+        /// </summary>
+        /// <remarks>
+        /// Counting the source instead would make the real bound six times this, since one control
+        /// character renders as six - which is exactly the length a hostile name would choose.
+        /// </remarks>
         public const int MaxCharsInMessage = 64;
 
-        public static string Ellipsize(string text)
+        /// <param name="escapeApostrophe">
+        /// Set where the result is wrapped in <c>'…'</c>, as a path segment is. Left off elsewhere so
+        /// that ordinary prose is not littered with backslashes.
+        /// </param>
+        public static string Ellipsize(string text, bool escapeApostrophe = false)
         {
-            return text.Length <= MaxCharsInMessage
-                ? text
-                : text.Substring(0, MaxCharsInMessage) + $"... ({text.Length} characters)";
+            if (text.Length <= MaxCharsInMessage && IsPlain(text, escapeApostrophe))
+            {
+                return text;
+            }
+
+            StringBuilder builder = new StringBuilder(MaxCharsInMessage + 24);
+            int consumed = 0;
+
+            while (consumed < text.Length)
+            {
+                // A surrogate pair is one character and is kept whole; truncating between its halves
+                // would emit a lone surrogate, which is not valid UTF-16 and can break a log sink.
+                bool isPair = char.IsHighSurrogate(text[consumed])
+                    && consumed + 1 < text.Length
+                    && char.IsLowSurrogate(text[consumed + 1]);
+
+                if (builder.Length + (isPair ? 2 : EscapedLength(text[consumed], escapeApostrophe)) > MaxCharsInMessage)
+                {
+                    break;
+                }
+
+                if (isPair)
+                {
+                    builder.Append(text[consumed]).Append(text[consumed + 1]);
+                    consumed += 2;
+                }
+                else
+                {
+                    AppendEscaped(builder, text[consumed], escapeApostrophe);
+                    consumed++;
+                }
+            }
+
+            if (consumed < text.Length)
+            {
+                builder.Append($"... ({text.Length} characters)");
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool IsPlain(string text, bool escapeApostrophe)
+        {
+            foreach (char c in text)
+            {
+                if (EscapedLength(c, escapeApostrophe) != 1)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static int EscapedLength(char c, bool escapeApostrophe)
+        {
+            if (NeedsBackslash(c, escapeApostrophe))
+            {
+                return 2;
+            }
+
+            // A surrogate reaching here is unpaired: the caller keeps valid pairs whole.
+            return IsOpaque(c) ? 6 : 1;
+        }
+
+        private static void AppendEscaped(StringBuilder builder, char c, bool escapeApostrophe)
+        {
+            if (NeedsBackslash(c, escapeApostrophe))
+            {
+                builder.Append('\\').Append(c);
+            }
+            else if (IsOpaque(c))
+            {
+                builder.Append("\\u").Append(((int)c).ToString("x4"));
+            }
+            else
+            {
+                builder.Append(c);
+            }
+        }
+
+        private static bool NeedsBackslash(char c, bool escapeApostrophe)
+        {
+            return c == '\\' || c == '"' || (escapeApostrophe && c == '\'');
+        }
+
+        private static bool IsOpaque(char c)
+        {
+            return c < ' ' || c == '\u007f' || char.IsSurrogate(c);
         }
     }
 }


### PR DESCRIPTION
Closes #135.

A `CborException` named the offending byte offset and nothing else, leaving the caller to map an offset back onto a POCO graph by hand. It now also names the position it was reached from, in the notation `System.Text.Json` uses:

```
[129] Expected major type TextString (3). Failed to deserialize from "$.Items[7].Name".
```

The same path is available on its own, so a `catch` can route on it without parsing prose:

```csharp
catch (CborException exception)
{
    logger.LogWarning("rejected at {Path}", exception.Path);   // $.Items[7].Name
    throw;
}
```

## How it works

The path is assembled **as the exception unwinds**, not tracked as the reader descends. Each converter catches `CborException`, prepends its own segment and rethrows with a bare `throw;`.

The issue proposed the opposite — having the reader collect the levels on the way down. Three reasons not to:

1. **The reader doesn't know the model.** `CborReader` is a `ref struct` that sees major types; member names are resolved a layer up. A path stack down there would yield raw map keys at best, never `Object.PropertyA`.
2. **It sits on the hot path.** `ReadMap`/`ReadArray` are `AggressiveInlining`, and `EnterNestedItem` documents that its matching `_depth--` is deliberately kept out of a `finally` to preserve that. Pushing and popping segments per level would make every successful read pay for the diagnostics of the failing ones.
3. **Bookmarks.** `ReturnToBookmark` restores position but not depth, so eagerly maintained path state would need rewinding on every lookahead — with silent desynchronisation as the failure mode.

Unwinding costs nothing until something has thrown: only the frames a real failure passed through allocate at all.

Objects name members, collections, arrays and tuples name indices, dictionaries name keys. An integer-keyed member is named from the mapping rather than from the member converter, which carries no name for it — the name on the type is exactly what the document does not say.

## Semantics

`$` alone means the root value itself was wrong. Every read has at least that much — all eleven read entry points, including the `CborObject`/`CborArray`/`CborValue` conversions, mark the root — so `Path` being `null` means the exception did not come from a read at all.

The one deliberate exclusion is the speculative read behind the `PipeReader` overloads: it throws as a matter of course while waiting for more of a stream and discards what it catches.

The path grows while the stack unwinds, so `Message` and `Path` should be read once the read has failed, not part of the way out of it. An intercepting `catch` that wraps the exception freezes a half-built path into the new message.

## Custom converters

Raised on the issue: a converter you register yourself contributes no segment of its own — and could not, since the seam was internal. Two methods are public now:

```csharp
catch (CborException exception)
{
    exception.PrependPathMember("Body");   // or PrependPathIndex(i) inside a sequence
    throw;                                 // rethrow the same exception, do not wrap it
}
```

Additive and opt-in. The alternative — a path argument on `ICborConverter<T>.Read` — would break every existing converter and put the state back on the descending path, which is the thing this design exists to avoid.

Most custom converters still need do nothing: one registered against a member is already named by the object holding it, and one that delegates to other converters inherits their segments.

## Hostile input

Member names and map keys come from the document. One shared policy in `TextTruncation` bounds and escapes them everywhere they are quoted — paths, map-key errors, and the unhandled-name message, which was previously repeating an attacker-chosen name whole and decoding it as ASCII. The budget is spent on the *rendered* result, so a name of control characters cannot expand past it, and truncation lands between characters so a surrogate pair is never split.

A name that does not read as a plain token is bracketed and escaped, as `System.Text.Json` does: a member genuinely named `a.b` is `$['a.b']`.

## Also in here

`GenerateDocumentationFile` is on, so the guidance on the public surface reaches consumers in IntelliSense instead of living only in this repository. Enabling it surfaced thirteen pre-existing doc-comment problems — comments documenting half their parameters, an unresolved `cref`, a `<param>` naming an argument that does not exist — all fixed rather than suppressed. `CS1591` stays off.

## Verification

`Issue0135.cs` carries 29 tests: root failures, nesting, collection and array indices, dictionary keys, tuples, integer keys, object-model conversions, escaping, length bounds against text chosen to defeat them, surrogate integrity, and both custom-converter cases. Full suite green at 1283 on `net8.0` and `net10.0`, plus 35 generator tests; all four target frameworks build with zero doc warnings.

Four existing tests asserted an exact message and were updated with the expected suffix. The truncation test's bound moved from 200 to 300, the message now carrying two bounded quotations of the key rather than one, and it gained an assertion that the full key never appears.

One thing consciously accepted: exceptions discarded by the `PipeReader` speculative read now allocate a small path where they previously allocated none. That is second-order against the cost of the throw itself, which was already there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BA2b1ZeBh2LMYjPeQdfz6s