### PR TITLE
Reject a duplicate map key on every decode target, closes #169

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,13 +454,12 @@ A repeated key that matches no member is not a duplicate member — what happens
 ``UnhandledNameMode``'s question, and repeating one does not change the answer. Neither is a null map
 key, which is refused in both modes: there is no earlier occurrence for a later one to win over.
 
-Two consequences of that follow, both by construction rather than by choice:
+The **discriminator** is refused when repeated, even though it is a key of the map rather than a
+member of the type: two readers disagreeing about which occurrence names the type is how one document
+comes to mean two things.
 
-* **A repeated discriminator key is not refused.** The discriminator is not a deserializable member,
-  so a repeat of it is an unknown name like any other, and the first occurrence is the one that
-  decides the type.
-* **A type whose members are mapped to the same CBOR name** — two ``[CborProperty("X")]`` on one type,
-  say — writes a document with a repeated key that it then cannot read back. The mapping is ambiguous
-  in both directions, since only one of the two members can ever be read from key ``X``, so it is
-  worth removing rather than working around; ``DuplicateKeyMode.LastWins`` will read such a document
-  if you have one already.
+One case the policy does not reach: **a type mapping two members to the same CBOR name** — two
+``[CborProperty("X")]``, say — writes a document with a repeated key that it then cannot read back.
+The mapping is ambiguous in both directions, since only one of the two members can ever be read from
+key ``X``, so it is worth removing rather than working around; ``DuplicateKeyMode.LastWins`` will read
+such a document if you have one already.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ High-performance [CBOR](https://cbor.io/) serialization framework for .Net (C#)
 * Support for dynamics
 * Support for structs
 * Support for RFC 8746 typed arrays, opt-in per direction (CborOptions.TypedArrayMode)
+* Duplicate map keys rejected on every decode target, with a last-wins opt-out (CborOptions.DuplicateKeyMode)
 
 ## Installation
 ### NuGet
@@ -405,3 +406,46 @@ being configured in the wrong order.
 drops members this version doesn't know about, and re-encoding then produces different — and
 differently hashing — bytes than what was received. Hash the wire bytes directly.
 
+
+### Duplicate map keys (RFC 8949 §5.6)
+
+A CBOR map carrying the same key twice is rejected with a ``CborException`` naming the key and where
+it was read:
+
+```
+[7] Duplicate map key: "a"
+```
+
+This applies to every decode target — the ``CborValue`` object model, ``Dictionary<K,V>`` and the
+other dictionary types, and mapped classes with or without a creator mapping. §5.6 requires a
+protocol to define what happens on repeated keys and leaves rejecting, first-wins and last-wins all
+open to the decoder, so this is a library policy rather than a conformance result. Rejecting is the
+default because silently keeping one of two values for the same key is the failure mode nobody
+notices, which is the wrong default for anything decoding untrusted frames.
+
+For a protocol that does define last-wins, ask for it:
+
+```csharp
+CborOptions options = new CborOptions { DuplicateKeyMode = DuplicateKeyMode.LastWins };
+```
+
+That applies to every target too. A mode that reached only some of them would leave the policy
+depending on what a document is being read into, which is the problem it exists to remove. First-wins
+is not offered.
+
+> **Behaviour change.** A mapped class **whose members are assigned** — anything without a creator
+> mapping, which is most classes — used to take the last occurrence of a repeated member silently, and
+> now throws. Dictionaries, the object model, and classes with a non-default constructor already
+> rejected, so this is the row that changes. If your producers emit duplicates, a deserialize that
+> worked will now throw with nothing in your own code having changed; set
+> ``DuplicateKeyMode.LastWins`` to keep the old behaviour.
+>
+> What made this worth breaking is that the old behaviour was not a choice anyone made: values for a
+> type with a non-default constructor are collected in a dictionary until the constructor can be
+> called, so they hit ``Add`` and were refused, while a type with a default constructor has its
+> members assigned, so a repeat overwrote. The same class changed behaviour when someone added or
+> removed a constructor.
+
+A repeated key that matches no member is not a duplicate member — what happens to an unknown name is
+``UnhandledNameMode``'s question, and repeating one does not change the answer. Neither is a null map
+key, which is refused in both modes: there is no earlier occurrence for a later one to win over.

--- a/README.md
+++ b/README.md
@@ -409,12 +409,16 @@ differently hashing — bytes than what was received. Hash the wire bytes direct
 
 ### Duplicate map keys (RFC 8949 §5.6)
 
-A CBOR map carrying the same key twice is rejected with a ``CborException`` naming the key and where
-it was read:
+A CBOR map carrying the same key twice is rejected with a ``CborException`` naming the key, the byte
+it was read at, and the path it sits at:
 
 ```
-[7] Duplicate map key: "a"
+[6] Duplicate map key: A. Failed to deserialize from "$.A".
 ```
+
+The object model is the one target that reports no path segment for it — ``CborValue``/``CborObject``
+maps are not members, so the path of a duplicate at the root of one stays ``$``. The offset and the
+key are given whatever the target.
 
 This applies to every decode target — the ``CborValue`` object model, ``Dictionary<K,V>`` and the
 other dictionary types, and mapped classes with or without a creator mapping. §5.6 requires a
@@ -449,3 +453,14 @@ is not offered.
 A repeated key that matches no member is not a duplicate member — what happens to an unknown name is
 ``UnhandledNameMode``'s question, and repeating one does not change the answer. Neither is a null map
 key, which is refused in both modes: there is no earlier occurrence for a later one to win over.
+
+Two consequences of that follow, both by construction rather than by choice:
+
+* **A repeated discriminator key is not refused.** The discriminator is not a deserializable member,
+  so a repeat of it is an unknown name like any other, and the first occurrence is the one that
+  decides the type.
+* **A type whose members are mapped to the same CBOR name** — two ``[CborProperty("X")]`` on one type,
+  say — writes a document with a repeated key that it then cannot read back. The mapping is ambiguous
+  in both directions, since only one of the two members can ever be read from key ``X``, so it is
+  worth removing rather than working around; ``DuplicateKeyMode.LastWins`` will read such a document
+  if you have one already.

--- a/src/Dahomey.Cbor.Tests/ByteBufferDictionaryTests.cs
+++ b/src/Dahomey.Cbor.Tests/ByteBufferDictionaryTests.cs
@@ -1,4 +1,5 @@
 ﻿using Dahomey.Cbor.Util;
+using System.Text;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests
@@ -27,5 +28,38 @@ namespace Dahomey.Cbor.Tests
                 Assert.Equal(value, actualValue);
             }
         }
-    }
+    
+        /// <summary>
+        /// A key is stored one node per eight bytes, so a longer key builds nodes for its prefixes on
+        /// the way. Those are not entries, and looking one up must miss rather than answer with the
+        /// default value of a stored one.
+        /// </summary>
+        /// <remarks>
+        /// What it answered instead was <c>default(T)</c> with <c>true</c>, which for a member lookup
+        /// is a null converter — a <see cref="System.NullReferenceException"/> from a document that
+        /// merely used a key eight bytes long.
+        /// </remarks>
+        [Fact]
+        public void APrefixOfALongerKeyIsNotFound()
+        {
+            ByteBufferDictionary<int> dictionary = new ByteBufferDictionary<int>();
+            dictionary.Add(Encoding.UTF8.GetBytes("PropertyAlpha"), 12);
+
+            Assert.False(dictionary.TryGetValue(Encoding.UTF8.GetBytes("Property"), out int _));
+            Assert.True(dictionary.TryGetValue(Encoding.UTF8.GetBytes("PropertyAlpha"), out int found));
+            Assert.Equal(12, found);
+        }
+
+        /// <summary>And a prefix that was itself added is found, being an entry in its own right.</summary>
+        [Fact]
+        public void APrefixThatIsAlsoAKeyIsFound()
+        {
+            ByteBufferDictionary<int> dictionary = new ByteBufferDictionary<int>();
+            dictionary.Add(Encoding.UTF8.GetBytes("PropertyAlpha"), 12);
+            dictionary.Add(Encoding.UTF8.GetBytes("Property"), 13);
+
+            Assert.True(dictionary.TryGetValue(Encoding.UTF8.GetBytes("Property"), out int found));
+            Assert.Equal(13, found);
+        }
+}
 }

--- a/src/Dahomey.Cbor.Tests/ByteBufferDictionaryTests.cs
+++ b/src/Dahomey.Cbor.Tests/ByteBufferDictionaryTests.cs
@@ -28,7 +28,7 @@ namespace Dahomey.Cbor.Tests
                 Assert.Equal(value, actualValue);
             }
         }
-    
+
         /// <summary>
         /// A key is stored one node per eight bytes, so a longer key builds nodes for its prefixes on
         /// the way. Those are not entries, and looking one up must miss rather than answer with the
@@ -61,5 +61,5 @@ namespace Dahomey.Cbor.Tests
             Assert.True(dictionary.TryGetValue(Encoding.UTF8.GetBytes("Property"), out int found));
             Assert.Equal(13, found);
         }
-}
+    }
 }

--- a/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
+++ b/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
@@ -18,9 +18,10 @@ namespace Dahomey.Cbor.Tests
     /// catch. For anything decoding untrusted frames that is the difference between a handled bad frame
     /// and an unhandled exception, and nothing in the message said which key or where.
     /// <para>
-    /// Rejecting rather than letting the last occurrence win is the behaviour that was already there;
-    /// this changes the exception, not the outcome. Silently keeping one of two values for the same key
-    /// would be a data-integrity decision, and a much larger change than a contract fix.
+    /// Rejecting was already the behaviour of every target that inserts into a dictionary; #167 changed
+    /// the exception, not the outcome. What target-dependence was left - a mapped class with settable
+    /// members taking the last occurrence - is settled in #169, which makes rejecting the policy
+    /// everywhere and puts last-wins behind <see cref="CborOptions.DuplicateKeyMode"/>.
     /// </para>
     /// </remarks>
     public class DuplicateMapKeyTests
@@ -96,17 +97,18 @@ namespace Dahomey.Cbor.Tests
         }
 
         /// <summary>
-        /// Duplicate members of a POCO are a different question and deliberately unchanged: the last
-        /// occurrence wins, as it did before, because a member is matched by name rather than inserted
-        /// into a dictionary.
+        /// Duplicate members of a POCO are refused too, since #169 settled the policy as reject
+        /// everywhere. The full matrix of targets and modes lives in
+        /// <see cref="Issues.Issue0169"/>; this is the one row that used to read the other way.
         /// </summary>
         [Fact]
-        public void DuplicatePocoMembersStillTakeTheLastValue()
+        public void DuplicatePocoMembersAreRejected()
         {
             // a2 6141 01 6141 02  -- {"A": 1, "A": 2}
-            DuplicateHolder holder = Cbor.Deserialize<DuplicateHolder>("A2614101614102".HexToBytes());
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<DuplicateHolder>("A2614101614102".HexToBytes()));
 
-            Assert.Equal(2, holder.A);
+            Assert.Contains("Duplicate map key", exception.Message);
         }
 
         public class DuplicateHolder

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0169.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0169.cs
@@ -501,6 +501,79 @@ namespace Dahomey.Cbor.Tests.Issues
             Assert.Equal("$.A", exception.Path);
         }
 
+        /// <summary>
+        /// The discriminator is a key of the map without being a member of the type, so it has no
+        /// ordinal - but it is still a key, and a document repeating it is refused like any other.
+        /// Worth refusing specifically: two readers disagreeing on which occurrence names the type is
+        /// how a document means one thing here and another thing downstream.
+        /// </summary>
+        [Fact]
+        public void ARepeatedDiscriminatorIsRejected()
+        {
+            byte[] document = Map(("_t", "Square"), ("_t", "Square"), ("B", 2));
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Shape>(document, Polymorphic()));
+
+            Assert.Contains("Duplicate map key", exception.Message);
+            Assert.Contains("_t", exception.Message);
+        }
+
+        /// <summary>
+        /// And under LastWins it is read like any other repeated key, the last occurrence winning -
+        /// which for the discriminator means the first one still chose the type, since that is the one
+        /// the convention read on the way in.
+        /// </summary>
+        [Fact]
+        public void ARepeatedDiscriminatorIsAcceptedUnderLastWins()
+        {
+            CborOptions options = Polymorphic();
+            options.DuplicateKeyMode = DuplicateKeyMode.LastWins;
+
+            byte[] document = Map(("_t", "Square"), ("_t", "Square"), ("B", 2));
+
+            Square square = Assert.IsType<Square>(Cbor.Deserialize<Shape>(document, options));
+            Assert.Equal(2, square.B);
+        }
+
+        /// <summary>
+        /// The discriminator is expected where it appears, so it is not an unhandled name. It was
+        /// reported as one, which made <see cref="UnhandledNameMode.ThrowException"/> and polymorphism
+        /// mutually exclusive: every polymorphic read threw on its own type tag.
+        /// </summary>
+        [Fact]
+        public void TheDiscriminatorIsNotAnUnhandledName()
+        {
+            CborOptions options = Polymorphic();
+            options.UnhandledNameMode = UnhandledNameMode.ThrowException;
+
+            byte[] document = Map(("_t", "Square"), ("A", 1), ("B", 2));
+
+            Square square = Assert.IsType<Square>(Cbor.Deserialize<Shape>(document, options));
+            Assert.Equal(1, square.A);
+            Assert.Equal(2, square.B);
+        }
+
+        /// <summary>
+        /// A member name eight bytes long that is the prefix of a longer member's name resolves to no
+        /// member, and has to be treated as the unknown name it is rather than as the first member of
+        /// the type - which is what the lookup used to answer, ordinal and all.
+        /// </summary>
+        [Fact]
+        public void AKeyThatIsAPrefixOfAMemberNameIsNotAMember()
+        {
+            byte[] document = Map(("PropertyAlpha", 1), ("Property", 2));
+
+            PrefixHolder holder = Cbor.Deserialize<PrefixHolder>(document);
+
+            Assert.Equal(1, holder.PropertyAlpha);
+        }
+
+        public class PrefixHolder
+        {
+            public int PropertyAlpha { get; set; }
+        }
+
         [CborObjectFormat(CborObjectFormat.Array)]
         public class ArrayHolder
         {

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0169.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0169.cs
@@ -599,6 +599,31 @@ namespace Dahomey.Cbor.Tests.Issues
             Assert.Equal(13, holder.B);
         }
 
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        public class IndexOneHolder
+        {
+            [CborProperty(1)]
+            public int Value { get; set; }
+        }
+
+        /// <summary>
+        /// Index 0 is where a discriminator sits, but only for a type that writes one. On a type that
+        /// does not, an unmapped 0 is an unknown index like any other and must be reported as one -
+        /// recognising it by position alone would swallow it, and report a repeat of it as a duplicate
+        /// discriminator the document never carried.
+        /// </summary>
+        [Fact]
+        public void AnUnmappedIndexZeroIsNotTakenForADiscriminator()
+        {
+            CborOptions options = new CborOptions { UnhandledNameMode = UnhandledNameMode.ThrowException };
+
+            // a2 00 09 01 02  -- {0: 9, 1: 2}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<IndexOneHolder>("A2000901 02".Replace(" ", "").HexToBytes(), options));
+
+            Assert.Contains("Unhandled index [0]", exception.Message);
+        }
+
         public class Pair
         {
             public Holder First { get; set; }

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0169.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0169.cs
@@ -438,6 +438,239 @@ namespace Dahomey.Cbor.Tests.Issues
 
         #endregion
 
+        #region The paths where a per-converter ordinal could go wrong
+
+        public abstract class Shape
+        {
+            public int A { get; set; }
+        }
+
+        [CborDiscriminator("Square")]
+        public class Square : Shape
+        {
+            public int B { get; set; }
+        }
+
+        private static CborOptions Polymorphic()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<Square>();
+            return options;
+        }
+
+        /// <summary>
+        /// A polymorphic read runs on the derived type's converter, not the one the call started on,
+        /// so the ordinals in play are that converter's. A well-formed document has to survive it.
+        /// </summary>
+        [Fact]
+        public void APolymorphicDocumentWithoutDuplicatesIsRead()
+        {
+            byte[] document = Map(("_t", "Square"), ("A", 1), ("B", 2));
+
+            Shape shape = Cbor.Deserialize<Shape>(document, Polymorphic());
+
+            Square square = Assert.IsType<Square>(shape);
+            Assert.Equal(1, square.A);
+            Assert.Equal(2, square.B);
+        }
+
+        /// <summary>A member declared on the derived type, repeated.</summary>
+        [Fact]
+        public void APolymorphicDuplicateOnADerivedMemberIsRejected()
+        {
+            byte[] document = Map(("_t", "Square"), ("A", 1), ("B", 2), ("B", 3));
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Shape>(document, Polymorphic()));
+
+            Assert.Equal("$.B", exception.Path);
+            Assert.Contains("Duplicate map key", exception.Message);
+        }
+
+        /// <summary>
+        /// And one inherited from the base, which the derived converter numbers among its own members.
+        /// </summary>
+        [Fact]
+        public void APolymorphicDuplicateOnAnInheritedMemberIsRejected()
+        {
+            byte[] document = Map(("_t", "Square"), ("A", 1), ("A", 2));
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Shape>(document, Polymorphic()));
+
+            Assert.Equal("$.A", exception.Path);
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class ArrayHolder
+        {
+            [CborProperty(0)]
+            public int A { get; set; }
+
+            [CborProperty(1)]
+            public int B { get; set; }
+        }
+
+        /// <summary>
+        /// Array format cannot express a repeated key - members are positional - so nothing there is
+        /// ever a duplicate. The assertion worth having is that the tracking does not invent one, since
+        /// each item is read at an index the reader advances itself.
+        /// </summary>
+        [Fact]
+        public void ArrayFormatIsUnaffected()
+        {
+            // 82 0c 0d  -- [12, 13]
+            ArrayHolder holder = Cbor.Deserialize<ArrayHolder>("820C0D".HexToBytes());
+
+            Assert.Equal(12, holder.A);
+            Assert.Equal(13, holder.B);
+        }
+
+        public class Pair
+        {
+            public Holder First { get; set; }
+            public Holder Second { get; set; }
+            public List<Holder> Items { get; set; }
+        }
+
+        /// <summary>
+        /// Two objects of the same type in one document each get their own state. If it leaked between
+        /// them - a field on the converter rather than in the reader context, say - the second would be
+        /// refused for a member the first had read.
+        /// </summary>
+        [Fact]
+        public void SiblingsOfTheSameTypeDoNotShareState()
+        {
+            byte[] document = SiblingsDocument();
+
+            Pair pair = Cbor.Deserialize<Pair>(document);
+
+            Assert.Equal(1, pair.First.A);
+            Assert.Equal(2, pair.Second.A);
+            Assert.Equal(new[] { 3, 4 }, pair.Items.ConvertAll(item => item.A));
+        }
+
+        /// <summary>And a duplicate nested inside one of them is still caught, and named by its path.</summary>
+        [Fact]
+        public void ADuplicateNestedInAMemberIsRejected()
+        {
+            ByteBufferWriter writer = new ByteBufferWriter();
+            CborWriter cborWriter = new CborWriter(writer);
+            cborWriter.WriteBeginMap(1);
+            cborWriter.WriteString("Second");
+            cborWriter.WriteBeginMap(2);
+            cborWriter.WriteString("A");
+            cborWriter.WriteInt32(1);
+            cborWriter.WriteString("A");
+            cborWriter.WriteInt32(2);
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Pair>(writer.WrittenSpan.ToArray()));
+
+            Assert.Equal("$.Second.A", exception.Path);
+        }
+
+        public class MixedHolder
+        {
+            public int Id { get; set; }
+            public int Extra { get; set; }
+
+            [CborConstructor]
+            public MixedHolder(int id)
+            {
+                Id = id;
+            }
+        }
+
+        /// <summary>
+        /// A creator type collects constructor arguments and ordinary members into two different
+        /// dictionaries. Both are member reads, so a repeat of either is refused the same way.
+        /// </summary>
+        [Fact]
+        public void AMixedCreatorTypeRejectsADuplicateOnEitherKindOfMember()
+        {
+            CborException onCreatorMember = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<MixedHolder>(Map(("Id", 12), ("Id", 13), ("Extra", 1))));
+
+            Assert.Equal("$.Id", onCreatorMember.Path);
+
+            CborException onRegularMember = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<MixedHolder>(Map(("Id", 12), ("Extra", 1), ("Extra", 2))));
+
+            Assert.Equal("$.Extra", onRegularMember.Path);
+        }
+
+        [Fact]
+        public void AMixedCreatorTypeKeepsTheLastValueOfEitherKindUnderLastWins()
+        {
+            MixedHolder onCreatorMember =
+                Cbor.Deserialize<MixedHolder>(Map(("Id", 12), ("Id", 13), ("Extra", 1)), LastWins);
+
+            Assert.Equal(13, onCreatorMember.Id);
+
+            MixedHolder onRegularMember =
+                Cbor.Deserialize<MixedHolder>(Map(("Id", 12), ("Extra", 1), ("Extra", 2)), LastWins);
+
+            Assert.Equal(2, onRegularMember.Extra);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// A map of text keys to values that are either an int or a string, written in the order given
+        /// so that a repeated key stays repeated.
+        /// </summary>
+        private static byte[] Map(params (string Key, object Value)[] entries)
+        {
+            ByteBufferWriter writer = new ByteBufferWriter();
+            CborWriter cborWriter = new CborWriter(writer);
+            cborWriter.WriteBeginMap(entries.Length);
+
+            foreach ((string key, object value) in entries)
+            {
+                cborWriter.WriteString(key);
+
+                if (value is int number)
+                {
+                    cborWriter.WriteInt32(number);
+                }
+                else
+                {
+                    cborWriter.WriteString((string)value);
+                }
+            }
+
+            return writer.WrittenSpan.ToArray();
+        }
+
+        /// <summary>{"First": {"A": 1}, "Second": {"A": 2}, "Items": [{"A": 3}, {"A": 4}]}</summary>
+        private static byte[] SiblingsDocument()
+        {
+            ByteBufferWriter writer = new ByteBufferWriter();
+            CborWriter cborWriter = new CborWriter(writer);
+            cborWriter.WriteBeginMap(3);
+
+            cborWriter.WriteString("First");
+            WriteHolder(ref cborWriter, 1);
+
+            cborWriter.WriteString("Second");
+            WriteHolder(ref cborWriter, 2);
+
+            cborWriter.WriteString("Items");
+            cborWriter.WriteBeginArray(2);
+            WriteHolder(ref cborWriter, 3);
+            WriteHolder(ref cborWriter, 4);
+
+            return writer.WrittenSpan.ToArray();
+        }
+
+        private static void WriteHolder(ref CborWriter writer, int a)
+        {
+            writer.WriteBeginMap(1);
+            writer.WriteString("A");
+            writer.WriteInt32(a);
+        }
+
         /// <summary>
         /// A two-entry map carrying the same text key twice, for keys whose hex is not worth spelling
         /// out by hand.

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0169.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0169.cs
@@ -1,0 +1,458 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using Dahomey.Cbor.Util;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #169: whether a document repeating a key was refused depended on what it was being read
+    /// into. Three targets rejected; a mapped class with settable members silently took the last
+    /// occurrence, so the same class changed behaviour when someone added or removed a constructor.
+    /// </summary>
+    /// <remarks>
+    /// RFC 8949 §5.6 declines to settle this — it requires a protocol to define what happens on
+    /// repeated keys and leaves rejecting, first-wins and last-wins all open to the decoder — so the
+    /// answer is a library policy rather than a conformance result. The policy is now reject
+    /// everywhere, with <see cref="DuplicateKeyMode.LastWins"/> as the opt-out for
+    /// protocols that define last-wins and for upgrading from a version where the assign path behaved
+    /// that way unconditionally.
+    /// <para>
+    /// Both modes are asserted against every target, in both directions. The mode existing but
+    /// applying to only some targets would be the same target-dependence wearing a different hat, and
+    /// a matrix this small is exactly where that would rot unseen.
+    /// </para>
+    /// </remarks>
+    public class Issue0169
+    {
+        // a2 6161 01 6161 02  -- {"a": 1, "a": 2}
+        private const string DuplicateLowerA = "A2616101616102";
+
+        // a2 6141 01 6141 02  -- {"A": 1, "A": 2}
+        private const string DuplicateMemberA = "A2614101614102";
+
+        // a2 624964 0c 624964 0d  -- {"Id": 12, "Id": 13}
+        private const string DuplicateId = "A26249640C6249640D";
+
+        // a2 00 0c 00 0d  -- {0: 12, 0: 13}
+        private const string DuplicateIndexZero = "A2000C000D";
+
+        private static CborOptions LastWins => new CborOptions { DuplicateKeyMode = DuplicateKeyMode.LastWins };
+
+        public class Holder
+        {
+            public int A { get; set; }
+        }
+
+        public struct HolderStruct
+        {
+            public int A { get; set; }
+        }
+
+        public class ConstructedHolder
+        {
+            public int Id { get; set; }
+
+            [CborConstructor]
+            public ConstructedHolder(int id)
+            {
+                Id = id;
+            }
+        }
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        public class IndexedHolder
+        {
+            [CborProperty(0)]
+            public int Id { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        public class IndexedConstructedHolder
+        {
+            [CborProperty(0)]
+            public int Id { get; set; }
+
+            [CborConstructor]
+            public IndexedConstructedHolder(int id)
+            {
+                Id = id;
+            }
+        }
+
+        public class RequiredHolder
+        {
+            [CborRequired]
+            public int A { get; set; }
+        }
+
+        /// <summary>
+        /// More members than fit in the bitmask "already read" is tracked in, so that the fallback for
+        /// wider types is exercised rather than assumed.
+        /// </summary>
+        public class WideHolder
+        {
+            public int P0 { get; set; }
+            public int P1 { get; set; }
+            public int P2 { get; set; }
+            public int P3 { get; set; }
+            public int P4 { get; set; }
+            public int P5 { get; set; }
+            public int P6 { get; set; }
+            public int P7 { get; set; }
+            public int P8 { get; set; }
+            public int P9 { get; set; }
+            public int P10 { get; set; }
+            public int P11 { get; set; }
+            public int P12 { get; set; }
+            public int P13 { get; set; }
+            public int P14 { get; set; }
+            public int P15 { get; set; }
+            public int P16 { get; set; }
+            public int P17 { get; set; }
+            public int P18 { get; set; }
+            public int P19 { get; set; }
+            public int P20 { get; set; }
+            public int P21 { get; set; }
+            public int P22 { get; set; }
+            public int P23 { get; set; }
+            public int P24 { get; set; }
+            public int P25 { get; set; }
+            public int P26 { get; set; }
+            public int P27 { get; set; }
+            public int P28 { get; set; }
+            public int P29 { get; set; }
+            public int P30 { get; set; }
+            public int P31 { get; set; }
+            public int P32 { get; set; }
+            public int P33 { get; set; }
+            public int P34 { get; set; }
+            public int P35 { get; set; }
+            public int P36 { get; set; }
+            public int P37 { get; set; }
+            public int P38 { get; set; }
+            public int P39 { get; set; }
+            public int P40 { get; set; }
+            public int P41 { get; set; }
+            public int P42 { get; set; }
+            public int P43 { get; set; }
+            public int P44 { get; set; }
+            public int P45 { get; set; }
+            public int P46 { get; set; }
+            public int P47 { get; set; }
+            public int P48 { get; set; }
+            public int P49 { get; set; }
+            public int P50 { get; set; }
+            public int P51 { get; set; }
+            public int P52 { get; set; }
+            public int P53 { get; set; }
+            public int P54 { get; set; }
+            public int P55 { get; set; }
+            public int P56 { get; set; }
+            public int P57 { get; set; }
+            public int P58 { get; set; }
+            public int P59 { get; set; }
+            public int P60 { get; set; }
+            public int P61 { get; set; }
+            public int P62 { get; set; }
+            public int P63 { get; set; }
+            public int P64 { get; set; }
+            public int P65 { get; set; }
+        }
+
+        #region Reject, which is the default
+
+        [Fact]
+        public void TheObjectModelRejectsADuplicate()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<CborObject>(DuplicateLowerA.HexToBytes()));
+
+            Assert.Contains("Duplicate map key", exception.Message);
+        }
+
+        [Fact]
+        public void ADictionaryRejectsADuplicate()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<string, int>>(DuplicateLowerA.HexToBytes()));
+
+            Assert.Contains("Duplicate map key", exception.Message);
+        }
+
+        /// <summary>
+        /// A type with a creator mapping, whose member values are collected into a dictionary until the
+        /// constructor can be called. Rejecting here is what #167 standardised.
+        /// </summary>
+        [Fact]
+        public void AConstructedTypeRejectsADuplicate()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<ConstructedHolder>(DuplicateId.HexToBytes()));
+
+            Assert.Contains("Duplicate map key", exception.Message);
+        }
+
+        /// <summary>
+        /// The row this issue is about: a type whose members are assigned rather than collected. It
+        /// took the last occurrence silently for the library's whole life, which is the behaviour break
+        /// the release note names.
+        /// </summary>
+        [Fact]
+        public void AMappedClassRejectsADuplicate()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Holder>(DuplicateMemberA.HexToBytes()));
+
+            Assert.Contains("Duplicate map key", exception.Message);
+        }
+
+        /// <summary>A struct assigns its members through a separate path, which has to agree.</summary>
+        [Fact]
+        public void AStructRejectsADuplicate()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<HolderStruct>(DuplicateMemberA.HexToBytes()));
+
+            Assert.Contains("Duplicate map key", exception.Message);
+        }
+
+        [Fact]
+        public void AnIntKeyedMappedClassRejectsADuplicate()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<IndexedHolder>(DuplicateIndexZero.HexToBytes()));
+
+            Assert.Contains("Duplicate map key", exception.Message);
+        }
+
+        [Fact]
+        public void AnIntKeyedConstructedTypeRejectsADuplicate()
+        {
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<IndexedConstructedHolder>(DuplicateIndexZero.HexToBytes()));
+        }
+
+        /// <summary>
+        /// The message says which member and where, like every other read failure: a caller rejecting
+        /// a frame needs to be able to say what was wrong with it.
+        /// </summary>
+        [Fact]
+        public void TheFailureNamesTheMemberAndItsPath()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Holder>(DuplicateMemberA.HexToBytes()));
+
+            Assert.Equal("$.A", exception.Path);
+            Assert.Contains("Duplicate map key", exception.Message);
+            Assert.Contains("A", exception.Message);
+        }
+
+        /// <summary>
+        /// Distinct members are unaffected, which is the assertion that would fail if the bitmask were
+        /// keyed on something members share.
+        /// </summary>
+        [Fact]
+        public void DistinctMembersAreUnaffected()
+        {
+            // a2 6141 0c 6142 0d  -- {"A": 12, "B": 13}
+            TwoMemberHolder holder = Cbor.Deserialize<TwoMemberHolder>("A261410C61420D".HexToBytes());
+
+            Assert.Equal(12, holder.A);
+            Assert.Equal(13, holder.B);
+        }
+
+        public class TwoMemberHolder
+        {
+            public int A { get; set; }
+            public int B { get; set; }
+        }
+
+        /// <summary>
+        /// A repeated name that matches no member is not a duplicate member. What happens to an unknown
+        /// name is <see cref="CborOptions.UnhandledNameMode"/>'s question, and repeating one does not
+        /// change the answer.
+        /// </summary>
+        [Fact]
+        public void ARepeatedUnknownNameIsNotReportedAsADuplicate()
+        {
+            // a3 6141 0c 617a 01 617a 02  -- {"A": 12, "z": 1, "z": 2}
+            Holder holder = Cbor.Deserialize<Holder>("A361410C617A01617A02".HexToBytes());
+
+            Assert.Equal(12, holder.A);
+        }
+
+        /// <summary>
+        /// A member past the 64th is tracked in the fallback rather than the bitmask. Every member is
+        /// tried, so the test does not depend on which ordinal a given property happens to be given.
+        /// </summary>
+        [Fact]
+        public void AWideTypeRejectsADuplicateOfAnyMember()
+        {
+            for (int i = 0; i < 66; i++)
+            {
+                byte[] document = MapWithRepeatedKey($"P{i}", 1, 2);
+
+                CborException exception = Assert.Throws<CborException>(
+                    () => Cbor.Deserialize<WideHolder>(document));
+
+                Assert.Contains("Duplicate map key", exception.Message);
+            }
+        }
+
+        /// <summary>
+        /// And a wide type with no duplicates reads, which is what fails if the fallback reports a
+        /// member as seen that was not.
+        /// </summary>
+        [Fact]
+        public void AWideTypeWithoutDuplicatesIsRead()
+        {
+            ByteBufferWriter writer = new ByteBufferWriter();
+            CborWriter cborWriter = new CborWriter(writer);
+            cborWriter.WriteBeginMap(66);
+
+            for (int i = 0; i < 66; i++)
+            {
+                cborWriter.WriteString($"P{i}");
+                cborWriter.WriteInt32(i);
+            }
+
+            WideHolder holder = Cbor.Deserialize<WideHolder>(writer.WrittenSpan.ToArray());
+
+            Assert.Equal(0, holder.P0);
+            Assert.Equal(65, holder.P65);
+        }
+
+        #endregion
+
+        #region LastWins, which has to reach every target or it recreates the problem
+
+        [Fact]
+        public void TheObjectModelKeepsTheLastValueUnderLastWins()
+        {
+            CborObject obj = Cbor.Deserialize<CborObject>(DuplicateLowerA.HexToBytes(), LastWins);
+
+            Assert.Single(obj);
+            Assert.Equal(2, obj["a"].Value<int>());
+        }
+
+        [Fact]
+        public void ADictionaryKeepsTheLastValueUnderLastWins()
+        {
+            Dictionary<string, int> dictionary =
+                Cbor.Deserialize<Dictionary<string, int>>(DuplicateLowerA.HexToBytes(), LastWins);
+
+            Assert.Single(dictionary);
+            Assert.Equal(2, dictionary["a"]);
+        }
+
+        [Fact]
+        public void AConstructedTypeKeepsTheLastValueUnderLastWins()
+        {
+            ConstructedHolder holder =
+                Cbor.Deserialize<ConstructedHolder>(DuplicateId.HexToBytes(), LastWins);
+
+            Assert.Equal(13, holder.Id);
+        }
+
+        [Fact]
+        public void AMappedClassKeepsTheLastValueUnderLastWins()
+        {
+            Holder holder = Cbor.Deserialize<Holder>(DuplicateMemberA.HexToBytes(), LastWins);
+
+            Assert.Equal(2, holder.A);
+        }
+
+        [Fact]
+        public void AStructKeepsTheLastValueUnderLastWins()
+        {
+            HolderStruct holder = Cbor.Deserialize<HolderStruct>(DuplicateMemberA.HexToBytes(), LastWins);
+
+            Assert.Equal(2, holder.A);
+        }
+
+        [Fact]
+        public void AnIntKeyedMappedClassKeepsTheLastValueUnderLastWins()
+        {
+            IndexedHolder holder = Cbor.Deserialize<IndexedHolder>(DuplicateIndexZero.HexToBytes(), LastWins);
+
+            Assert.Equal(13, holder.Id);
+        }
+
+        [Fact]
+        public void AnIntKeyedConstructedTypeKeepsTheLastValueUnderLastWins()
+        {
+            IndexedConstructedHolder holder =
+                Cbor.Deserialize<IndexedConstructedHolder>(DuplicateIndexZero.HexToBytes(), LastWins);
+
+            Assert.Equal(13, holder.Id);
+        }
+
+        [Fact]
+        public void AWideTypeKeepsTheLastValueUnderLastWins()
+        {
+            WideHolder holder = Cbor.Deserialize<WideHolder>(MapWithRepeatedKey("P65", 1, 2), LastWins);
+
+            Assert.Equal(2, holder.P65);
+        }
+
+        /// <summary>
+        /// A null key is not a duplicate, so <see cref="DuplicateKeyMode.LastWins"/> has nothing to say
+        /// about it: there is no earlier occurrence for a later one to win over, and the dictionary
+        /// refuses it either way. It must still be reported as what it is.
+        /// </summary>
+        [Fact]
+        public void ANullKeyIsStillRejectedUnderLastWins()
+        {
+            // a1 f6 01  -- {null: 1}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<string, int>>("A1F601".HexToBytes(), LastWins));
+
+            Assert.Contains("null", exception.Message);
+            Assert.DoesNotContain("Duplicate", exception.Message);
+        }
+
+        /// <summary>
+        /// A required member supplied twice is still a member that arrived. The two pieces of state are
+        /// tracked together, so this is the assertion that fails if the required one stops being
+        /// recorded on the mode that does not consult the other.
+        /// </summary>
+        [Fact]
+        public void ARepeatedRequiredMemberIsStillSatisfiedUnderLastWins()
+        {
+            RequiredHolder holder = Cbor.Deserialize<RequiredHolder>(DuplicateMemberA.HexToBytes(), LastWins);
+
+            Assert.Equal(2, holder.A);
+        }
+
+        /// <summary>And a required member that never arrives is still missing, in either mode.</summary>
+        [Fact]
+        public void AMissingRequiredMemberIsStillReportedUnderLastWins()
+        {
+            // a0  -- {}
+            Assert.Throws<CborException>(() => Cbor.Deserialize<RequiredHolder>("A0".HexToBytes(), LastWins));
+        }
+
+        #endregion
+
+        /// <summary>
+        /// A two-entry map carrying the same text key twice, for keys whose hex is not worth spelling
+        /// out by hand.
+        /// </summary>
+        private static byte[] MapWithRepeatedKey(string key, int first, int second)
+        {
+            ByteBufferWriter writer = new ByteBufferWriter();
+            CborWriter cborWriter = new CborWriter(writer);
+            cborWriter.WriteBeginMap(2);
+            cborWriter.WriteString(key);
+            cborWriter.WriteInt32(first);
+            cborWriter.WriteString(key);
+            cborWriter.WriteInt32(second);
+
+            return writer.WrittenSpan.ToArray();
+        }
+    }
+}

--- a/src/Dahomey.Cbor/CborOptions.cs
+++ b/src/Dahomey.Cbor/CborOptions.cs
@@ -230,8 +230,10 @@ namespace Dahomey.Cbor
         /// <see cref="DuplicateKeyMode.Reject"/>, uniformly across every decode target.
         /// </summary>
         /// <remarks>
-        /// Read once per repeated key rather than per key, so a document that contains no duplicates -
-        /// which is all of them until one does - pays nothing for this setting being available.
+        /// Read once when a map or an object starts, not per key, and each read then runs to the end
+        /// on the value it took. Settable at any point in an options object's life, including on the
+        /// long-lived <see cref="Default"/>; a change made while a document is being read applies to
+        /// the maps that start after it, so no single map is read half one way and half the other.
         /// </remarks>
         public DuplicateKeyMode DuplicateKeyMode { get; set; }
 

--- a/src/Dahomey.Cbor/CborOptions.cs
+++ b/src/Dahomey.Cbor/CborOptions.cs
@@ -25,6 +25,38 @@ namespace Dahomey.Cbor
     }
 
     /// <summary>
+    /// What reading a map does when the same key appears twice.
+    /// </summary>
+    /// <remarks>
+    /// RFC 8949 §5.6 declines to settle this: it requires a protocol to define what happens on
+    /// repeated keys and leaves rejecting, first-wins and last-wins all open to the decoder. So this
+    /// is a library policy rather than a conformance question, and it is one setting for every decode
+    /// target - the object model, dictionaries, and mapped classes with or without a creator mapping -
+    /// because a mode that applied to only some of them would recreate the target-dependence it exists
+    /// to remove.
+    /// <para>
+    /// First-wins is deliberately absent. It is a different operation from the other two - skipping a
+    /// value already read rather than declining to keep it - and no protocol has yet asked for it here.
+    /// </para>
+    /// </remarks>
+    public enum DuplicateKeyMode
+    {
+        /// <summary>
+        /// A repeated key is a <see cref="CborException"/>, naming the key and the position it was
+        /// read at. The default: silently keeping one of two values for the same key is the failure
+        /// mode nobody notices, which is the wrong default for anything decoding untrusted frames.
+        /// </summary>
+        Reject = 0,
+
+        /// <summary>
+        /// The last occurrence of a key wins and earlier ones are discarded, for every target. For
+        /// protocols that define last-wins - which §5.6 explicitly contemplates - and for upgrading
+        /// from a version where mapped classes with settable members behaved this way unconditionally.
+        /// </summary>
+        LastWins = 1,
+    }
+
+    /// <summary>
     /// https://tools.ietf.org/html/rfc7049#section-2.2
     /// </summary>
     public enum LengthMode
@@ -192,6 +224,16 @@ namespace Dahomey.Cbor
         /// deep nesting. Raise it if the data is genuinely deeper than 64 levels.
         /// </remarks>
         public int MaxDepth { get; set; } = Serialization.CborWriter.DefaultMaxDepth;
+
+        /// <summary>
+        /// What reading a map does when the same key appears twice. Default
+        /// <see cref="DuplicateKeyMode.Reject"/>, uniformly across every decode target.
+        /// </summary>
+        /// <remarks>
+        /// Read once per repeated key rather than per key, so a document that contains no duplicates -
+        /// which is all of them until one does - pays nothing for this setting being available.
+        /// </remarks>
+        public DuplicateKeyMode DuplicateKeyMode { get; set; }
 
         /// <summary>
         /// The default naming convention to use when no naming convention is specified.

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -144,6 +144,24 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             TV value = ValueConverter.Read(ref reader);
 
+            if (_options.DuplicateKeyMode == DuplicateKeyMode.LastWins)
+            {
+                // An indexer assignment rather than Add, so a repeated key overwrites. Still guarded:
+                // the dictionary is the caller's in the IDictionary case and may refuse an entry for
+                // reasons of its own, and a null key is refused whatever the mode -- it is not a
+                // duplicate, and there is no last occurrence of it to win.
+                try
+                {
+                    context.dict[key] = value;
+                }
+                catch (ArgumentException exception)
+                {
+                    throw reader.BuildException(DescribeSetFailure(key, exception));
+                }
+
+                return;
+            }
+
             // See CborValueConverter.ReadMapItem: these are malformed input, and were already refused
             // -- as an ArgumentException that escapes the CborException contract.
             try
@@ -194,6 +212,18 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             return dictionary.ContainsKey(key)
                 ? MapKeyErrors.Duplicate(key)
+                : MapKeyErrors.Rejected(key, exception.Message);
+        }
+
+        /// <summary>
+        /// Which failure occurred on the <see cref="DuplicateKeyMode.LastWins"/> path, where an
+        /// assignment cannot fail for being a repeat. A key already present is exactly what that mode
+        /// asks the dictionary to accept, so the reason is never a duplicate and is not probed for.
+        /// </summary>
+        private static string DescribeSetFailure(TK key, ArgumentException exception)
+        {
+            return key is null
+                ? MapKeyErrors.NullKey()
                 : MapKeyErrors.Rejected(key, exception.Message);
         }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -31,6 +31,9 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             /// <inheritdoc cref="index"/>
             public bool hasKey;
+
+            /// <inheritdoc cref="CborValueConverter.MapReaderContext.lastWins"/>
+            public bool lastWins;
         }
 
         public struct WriterContext
@@ -130,6 +133,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         public void ReadBeginMap(int size, ref ReaderContext context)
         {
             context.dict = InstantiateTempCollection();
+            context.lastWins = _options.DuplicateKeyMode == DuplicateKeyMode.LastWins;
         }
 
         public void ReadMapItem(ref CborReader reader, ref ReaderContext context)
@@ -144,7 +148,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             TV value = ValueConverter.Read(ref reader);
 
-            if (_options.DuplicateKeyMode == DuplicateKeyMode.LastWins)
+            if (context.lastWins)
             {
                 // An indexer assignment rather than Add, so a repeated key overwrites. Still guarded:
                 // the dictionary is the caller's in the IDictionary case and may refuse an entry for

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -16,6 +16,18 @@ namespace Dahomey.Cbor.Serialization.Converters
         public struct MapReaderContext
         {
             public CborObject obj;
+
+            /// <summary>
+            /// <see cref="CborOptions.DuplicateKeyMode"/> as it stood when this map started, so that
+            /// one map is read under one policy.
+            /// </summary>
+            /// <remarks>
+            /// The option is settable at any time, including on the process-wide
+            /// <see cref="CborOptions.Default"/>, so reading it per entry would let a change made
+            /// while a document is being read - by a custom converter, or by another thread - refuse
+            /// one repeated key in a map and overwrite on the next.
+            /// </remarks>
+            public bool lastWins;
         }
 
         public struct MapWriterContext
@@ -190,6 +202,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         void ICborMapReader<MapReaderContext>.ReadBeginMap(int size, ref MapReaderContext context)
         {
             context.obj = new CborObject();
+            context.lastWins = _options.DuplicateKeyMode == DuplicateKeyMode.LastWins;
         }
 
         void ICborMapReader<MapReaderContext>.ReadMapItem(ref CborReader reader, ref MapReaderContext context)
@@ -197,7 +210,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             CborValue key = Read(ref reader);
             CborValue value = Read(ref reader);
 
-            if (_options.DuplicateKeyMode == DuplicateKeyMode.LastWins)
+            if (context.lastWins)
             {
                 // An indexer assignment rather than Add: under LastWins a repeated key overwrites
                 // instead of throwing, and Add has no overwriting form.

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -197,6 +197,14 @@ namespace Dahomey.Cbor.Serialization.Converters
             CborValue key = Read(ref reader);
             CborValue value = Read(ref reader);
 
+            if (_options.DuplicateKeyMode == DuplicateKeyMode.LastWins)
+            {
+                // An indexer assignment rather than Add: under LastWins a repeated key overwrites
+                // instead of throwing, and Add has no overwriting form.
+                context.obj[key] = value;
+                return;
+            }
+
             // Caught rather than pre-checked with ContainsKey: a duplicate is malformed input, so the
             // cost belongs on that path and not on the lookup every well-formed pair would pay. The
             // document was already refused here; without this it is refused as an ArgumentException,

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberReadEntry.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberReadEntry.cs
@@ -27,9 +27,16 @@ namespace Dahomey.Cbor.Serialization.Converters
         public IMemberConverter Converter { get; }
 
         /// <summary>
-        /// This member's position in its converter's read set. Dense enough for a bitmask, and stable
-        /// for the life of the converter; nothing depends on the value beyond its being distinct.
+        /// This member's position in its converter's read set, counted from 1. Dense enough for a
+        /// bitmask, and stable for the life of the converter; nothing depends on the value beyond its
+        /// being distinct.
         /// </summary>
+        /// <remarks>
+        /// Counted from 1 so that 0 - the ordinal of <c>default(MemberReadEntry)</c> - identifies no
+        /// member. A lookup that reports success while yielding the default entry would otherwise hand
+        /// back the first member's identity, and be reported as a duplicate of it: a wrong answer
+        /// about a member that was never read, in place of whatever the real failure was.
+        /// </remarks>
         public int Ordinal { get; }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberReadEntry.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberReadEntry.cs
@@ -1,0 +1,35 @@
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// What an <see cref="ObjectConverter{T}"/> holds against a member's key: the converter that reads
+    /// it, and a small dense number identifying it within that converter.
+    /// </summary>
+    /// <remarks>
+    /// The number lets <see cref="MemberReadState"/> hold "already read" as a bit rather than a set
+    /// entry. It travels with the converter, in the same lookup, because the read path has already
+    /// hashed the key to find one: asking a second structure for the number would put a second hash on
+    /// every member of every object read, which is the cost the bitmask exists to avoid.
+    /// <para>
+    /// Numbered per converter and stored per converter, so nothing is assumed about member converter
+    /// instances being unique to one <see cref="ObjectConverter{T}"/> - a number kept on the member
+    /// converter itself would be silently wrong for one of two converters handed the same instance,
+    /// and wrong here means a duplicate reported that is not one.
+    /// </para>
+    /// </remarks>
+    public readonly struct MemberReadEntry
+    {
+        public MemberReadEntry(IMemberConverter converter, int ordinal)
+        {
+            Converter = converter;
+            Ordinal = ordinal;
+        }
+
+        public IMemberConverter Converter { get; }
+
+        /// <summary>
+        /// This member's position in its converter's read set. Dense enough for a bitmask, and stable
+        /// for the life of the converter; nothing depends on the value beyond its being distinct.
+        /// </summary>
+        public int Ordinal { get; }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
@@ -12,8 +12,9 @@ namespace Dahomey.Cbor.Serialization.Converters
     /// neither piece of state costs an allocation on the path taken by a document with no duplicates
     /// and no required members - which is most documents.
     /// <para>
-    /// Members are identified by an ordinal assigned per converter, so "already read" is a bit in a
-    /// <see cref="ulong"/>: one test and one or per member. A type with more than 64 deserializable
+    /// Members are identified by the ordinal their <see cref="MemberReadEntry"/> carries, so "already
+    /// read" is a bit in a <see cref="ulong"/>: one test and one or per member, with nothing to look
+    /// up, since the read path has the entry in hand already. A type with more than 64 deserializable
     /// members falls back to a set, allocated only if a member past the 64th is actually read.
     /// </para>
     /// </remarks>
@@ -43,19 +44,8 @@ namespace Dahomey.Cbor.Serialization.Converters
             _seenBeyond = null;
         }
 
-        /// <summary>
-        /// Whether a member read twice is to be refused. Checked before the ordinal is looked up, so
-        /// <see cref="DuplicateKeyMode.LastWins"/> pays nothing for the check being available.
-        /// </summary>
-        public readonly bool RejectsDuplicates => _rejectDuplicates;
-
         /// <summary>Whether required members are being tracked at all.</summary>
         public readonly bool TracksRequiredMembers => _requiredMembersRead != null;
-
-        public readonly void MarkRequiredMemberRead(IMemberConverter memberConverter)
-        {
-            _requiredMembersRead?.Add(memberConverter);
-        }
 
         public readonly bool WasRead(IMemberConverter memberConverter)
         {
@@ -63,31 +53,34 @@ namespace Dahomey.Cbor.Serialization.Converters
         }
 
         /// <summary>
-        /// Records that the member with this ordinal has been read, and says whether it had been read
-        /// already.
+        /// Records that the document has supplied this member, and says whether it had supplied it
+        /// once already - which is a duplicate map key, for a caller that means to refuse one.
         /// </summary>
-        /// <param name="ordinal">
-        /// The member's position in its converter's read set, or -1 for a member that has none. A
-        /// member with no ordinal is never reported as a repeat: saying "duplicate" about something
-        /// this cannot actually tell apart would be worse than saying nothing.
-        /// </param>
-        public bool MarkSeen(int ordinal)
+        /// <remarks>
+        /// Always false under <see cref="DuplicateKeyMode.LastWins"/>, where nothing is going to be
+        /// refused: the bookkeeping is skipped rather than done and discarded. A negative ordinal
+        /// belongs to a member this cannot tell apart from another and is never reported as a repeat -
+        /// saying "duplicate" about something unidentified would be worse than saying nothing.
+        /// </remarks>
+        public bool MarkRead(in MemberReadEntry entry)
         {
-            if (ordinal < 0)
+            _requiredMembersRead?.Add(entry.Converter);
+
+            if (!_rejectDuplicates || entry.Ordinal < 0)
             {
                 return false;
             }
 
-            if (ordinal < 64)
+            if (entry.Ordinal < 64)
             {
-                ulong bit = 1UL << ordinal;
-                bool alreadySeen = (_seen & bit) != 0;
+                ulong bit = 1UL << entry.Ordinal;
+                bool alreadyRead = (_seen & bit) != 0;
                 _seen |= bit;
-                return alreadySeen;
+                return alreadyRead;
             }
 
             _seenBeyond ??= new HashSet<int>();
-            return !_seenBeyond.Add(ordinal);
+            return !_seenBeyond.Add(entry.Ordinal);
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// What the document has supplied so far, for the members of the one object being read: which
+    /// required members have arrived, and - when <see cref="DuplicateKeyMode.Reject"/> is in force -
+    /// which members have already been read once, so that a repeat can be refused.
+    /// </summary>
+    /// <remarks>
+    /// A mutable struct, held in the reader context and passed by <c>ref</c> throughout, so that
+    /// neither piece of state costs an allocation on the path taken by a document with no duplicates
+    /// and no required members - which is most documents.
+    /// <para>
+    /// Members are identified by an ordinal assigned per converter, so "already read" is a bit in a
+    /// <see cref="ulong"/>: one test and one or per member. A type with more than 64 deserializable
+    /// members falls back to a set, allocated only if a member past the 64th is actually read.
+    /// </para>
+    /// </remarks>
+    public struct MemberReadState
+    {
+        /// <summary>
+        /// Null when the type has no required members, which is what keeps the set off the common
+        /// path. Not merged with the duplicate tracking below: this one holds member converters,
+        /// because the required check compares against another converter's member list, and it is
+        /// populated whatever <see cref="DuplicateKeyMode"/> is in force.
+        /// </summary>
+        private readonly HashSet<IMemberConverter>? _requiredMembersRead;
+
+        private readonly bool _rejectDuplicates;
+
+        /// <summary>Ordinals 0-63, one bit each.</summary>
+        private ulong _seen;
+
+        /// <summary>Ordinals 64 and above, for the rare type that has that many members.</summary>
+        private HashSet<int>? _seenBeyond;
+
+        public MemberReadState(bool trackRequiredMembers, bool rejectDuplicates)
+        {
+            _requiredMembersRead = trackRequiredMembers ? new HashSet<IMemberConverter>() : null;
+            _rejectDuplicates = rejectDuplicates;
+            _seen = 0;
+            _seenBeyond = null;
+        }
+
+        /// <summary>
+        /// Whether a member read twice is to be refused. Checked before the ordinal is looked up, so
+        /// <see cref="DuplicateKeyMode.LastWins"/> pays nothing for the check being available.
+        /// </summary>
+        public readonly bool RejectsDuplicates => _rejectDuplicates;
+
+        /// <summary>Whether required members are being tracked at all.</summary>
+        public readonly bool TracksRequiredMembers => _requiredMembersRead != null;
+
+        public readonly void MarkRequiredMemberRead(IMemberConverter memberConverter)
+        {
+            _requiredMembersRead?.Add(memberConverter);
+        }
+
+        public readonly bool WasRead(IMemberConverter memberConverter)
+        {
+            return _requiredMembersRead != null && _requiredMembersRead.Contains(memberConverter);
+        }
+
+        /// <summary>
+        /// Records that the member with this ordinal has been read, and says whether it had been read
+        /// already.
+        /// </summary>
+        /// <param name="ordinal">
+        /// The member's position in its converter's read set, or -1 for a member that has none. A
+        /// member with no ordinal is never reported as a repeat: saying "duplicate" about something
+        /// this cannot actually tell apart would be worse than saying nothing.
+        /// </param>
+        public bool MarkSeen(int ordinal)
+        {
+            if (ordinal < 0)
+            {
+                return false;
+            }
+
+            if (ordinal < 64)
+            {
+                ulong bit = 1UL << ordinal;
+                bool alreadySeen = (_seen & bit) != 0;
+                _seen |= bit;
+                return alreadySeen;
+            }
+
+            _seenBeyond ??= new HashSet<int>();
+            return !_seenBeyond.Add(ordinal);
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
@@ -36,6 +36,14 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// <summary>Ordinals 64 and above, for the rare type that has that many members.</summary>
         private HashSet<int>? _seenBeyond;
 
+        /// <summary>
+        /// The discriminator, which has no ordinal because it is not a member of the type: it names
+        /// the type rather than carrying a value, and is read by the convention rather than by a
+        /// member converter. It is still a key of the map, so a document repeating it is refused like
+        /// any other repeat.
+        /// </summary>
+        private bool _discriminatorRead;
+
         public MemberReadState(bool trackRequiredMembers, bool rejectDuplicates)
         {
             _requiredMembersRead = trackRequiredMembers ? new HashSet<IMemberConverter>() : null;
@@ -91,6 +99,19 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             _seenBeyond ??= new HashSet<int>();
             return !_seenBeyond.Add(index);
+        }
+
+        /// <inheritdoc cref="MarkRead(in MemberReadEntry)"/>
+        public bool MarkDiscriminatorRead()
+        {
+            if (!_rejectDuplicates)
+            {
+                return false;
+            }
+
+            bool alreadyRead = _discriminatorRead;
+            _discriminatorRead = true;
+            return alreadyRead;
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
@@ -50,15 +50,16 @@ namespace Dahomey.Cbor.Serialization.Converters
             _rejectDuplicates = rejectDuplicates;
             _seen = 0;
             _seenBeyond = null;
+            _discriminatorRead = false;
         }
 
         /// <summary>
-        /// Whether this read is running under <see cref="DuplicateKeyMode.LastWins"/>. Taken once,
-        /// when the read started, and answered from here rather than re-read from the options, so
-        /// that every path of one object read agrees on the policy even if the options change
-        /// underneath it.
+        /// The mode this read is running under. Taken once, when the read started, and answered from
+        /// here rather than re-read from the options, so that every path of one object read agrees on
+        /// the policy even if the options change underneath it.
         /// </summary>
-        public readonly bool LastWins => !_rejectDuplicates;
+        public readonly DuplicateKeyMode Mode
+            => _rejectDuplicates ? DuplicateKeyMode.Reject : DuplicateKeyMode.LastWins;
 
         /// <summary>Whether required members are being tracked at all.</summary>
         public readonly bool TracksRequiredMembers => _requiredMembersRead != null;

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
@@ -44,6 +44,14 @@ namespace Dahomey.Cbor.Serialization.Converters
             _seenBeyond = null;
         }
 
+        /// <summary>
+        /// Whether this read is running under <see cref="DuplicateKeyMode.LastWins"/>. Taken once,
+        /// when the read started, and answered from here rather than re-read from the options, so
+        /// that every path of one object read agrees on the policy even if the options change
+        /// underneath it.
+        /// </summary>
+        public readonly bool LastWins => !_rejectDuplicates;
+
         /// <summary>Whether required members are being tracked at all.</summary>
         public readonly bool TracksRequiredMembers => _requiredMembersRead != null;
 
@@ -58,29 +66,31 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// </summary>
         /// <remarks>
         /// Always false under <see cref="DuplicateKeyMode.LastWins"/>, where nothing is going to be
-        /// refused: the bookkeeping is skipped rather than done and discarded. A negative ordinal
-        /// belongs to a member this cannot tell apart from another and is never reported as a repeat -
-        /// saying "duplicate" about something unidentified would be worse than saying nothing.
+        /// refused: the bookkeeping is skipped rather than done and discarded. Also false for an entry
+        /// identifying no member - see <see cref="MemberReadEntry.Ordinal"/> - since saying "duplicate"
+        /// about something unidentified would be worse than saying nothing.
         /// </remarks>
         public bool MarkRead(in MemberReadEntry entry)
         {
             _requiredMembersRead?.Add(entry.Converter);
 
-            if (!_rejectDuplicates || entry.Ordinal < 0)
+            if (!_rejectDuplicates || entry.Ordinal <= 0)
             {
                 return false;
             }
 
-            if (entry.Ordinal < 64)
+            int index = entry.Ordinal - 1;
+
+            if (index < 64)
             {
-                ulong bit = 1UL << entry.Ordinal;
+                ulong bit = 1UL << index;
                 bool alreadyRead = (_seen & bit) != 0;
                 _seen |= bit;
                 return alreadyRead;
             }
 
             _seenBeyond ??= new HashSet<int>();
-            return !_seenBeyond.Add(entry.Ordinal);
+            return !_seenBeyond.Add(index);
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -95,9 +95,9 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// Numbers the members added to the read lookups above, so each carries a
         /// <see cref="MemberReadEntry.Ordinal"/> distinct within this converter. Counts entries rather
         /// than distinct member converters, so that presenting the same member converter twice cannot
-        /// hand two members one number.
+        /// hand two members one number. Starts at 1, leaving 0 to mean no member at all.
         /// </summary>
-        private int _nextReadOrdinal;
+        private int _nextReadOrdinal = 1;
         public List<IMemberConverter> _requiredMemberConvertersForRead = new List<IMemberConverter>();
         private readonly List<IMemberConverter> _memberConvertersForWrite;
         private List<IMemberConverter>? _deterministicMemberConvertersForWrite;
@@ -675,6 +675,10 @@ namespace Dahomey.Cbor.Serialization.Converters
                     }
                 }
 
+                // Settled once, on the first item, and not revisited: every member of this object is
+                // resolved by the converter chosen here, so the ordinals its entries carry mean the
+                // same thing for the whole read -- which is what lets one bitmask stand for "already
+                // read" across it.
                 if (context.creatorValues == null && context.creatorValuesByIndex == null)
                 {
                     if (!_isStruct && context.obj == null)
@@ -722,11 +726,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                             {
                                 if (context.converter.ObjectMapping.IsCreatorMember(memberName))
                                 {
-                                    AddMemberValue(ref reader, context.creatorValues, new RawString(memberName), value);
+                                    AddMemberValue(ref reader, context.readState.LastWins, context.creatorValues, new RawString(memberName), value);
                                 }
                                 else
                                 {
-                                    AddMemberValue(ref reader, context.regularValues!, new RawString(memberName), value);
+                                    AddMemberValue(ref reader, context.readState.LastWins, context.regularValues!, new RawString(memberName), value);
                                 }
                             }
                         }
@@ -760,11 +764,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                             {
                                 if (context.converter.ObjectMapping.IsCreatorMember(memberIndex))
                                 {
-                                    AddMemberValue(ref reader, context.creatorValuesByIndex, memberIndex, value);
+                                    AddMemberValue(ref reader, context.readState.LastWins, context.creatorValuesByIndex, memberIndex, value);
                                 }
                                 else
                                 {
-                                    AddMemberValue(ref reader, context.regularValuesByIndex!, memberIndex, value);
+                                    AddMemberValue(ref reader, context.readState.LastWins, context.regularValuesByIndex!, memberIndex, value);
                                 }
                             }
                         }
@@ -793,11 +797,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                         {
                             if (context.converter.ObjectMapping.IsCreatorMember(context.memberIndex))
                             {
-                                AddMemberValue(ref reader, context.creatorValuesByIndex, context.memberIndex, value);
+                                AddMemberValue(ref reader, context.readState.LastWins, context.creatorValuesByIndex, context.memberIndex, value);
                             }
                             else
                             {
-                                AddMemberValue(ref reader, context.regularValuesByIndex!, context.memberIndex, value);
+                                AddMemberValue(ref reader, context.readState.LastWins, context.regularValuesByIndex!, context.memberIndex, value);
                             }
                         }
                     }
@@ -918,19 +922,19 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// constructor can be called rather than being set on an instance.
         /// </summary>
         /// <remarks>
-        /// A document repeating a member reaches a <c>Dictionary.Add</c> here, exactly as a repeated
-        /// map key reaches one in the dictionary converters, and is refused the same way: as a
-        /// <see cref="CborException"/> rather than the <see cref="ArgumentException"/> the dictionary
-        /// raises. A type without a creator mapping does not reach this -- its members are assigned to
-        /// an instance -- so the repeat is caught for that path in <c>MarkMemberRead</c> instead, which
-        /// is what keeps the answer from depending on whether the type happens to have a non-default
-        /// constructor.
+        /// A repeated member is refused before it gets here: every value reaching this has come
+        /// through <c>ReadValue</c>, which resolves the member and calls <c>MarkMemberRead</c> first,
+        /// so under <see cref="DuplicateKeyMode.Reject"/> the <c>Add</c> below cannot be handed a key
+        /// it already holds. That is deliberate - one place decides what a repeated member means, for
+        /// the creator path and the assign path alike, rather than each learning it from the container
+        /// it happens to write into. What is left here is the container's own refusals, and a repeat
+        /// this converter could not identify, which <c>Add</c> still catches and names correctly.
         /// </remarks>
-        private void AddMemberValue<TKey>(
-            ref CborReader reader, Dictionary<TKey, object?> values, TKey key, object? value)
+        private static void AddMemberValue<TKey>(
+            ref CborReader reader, bool lastWins, Dictionary<TKey, object> values, TKey key, object value)
             where TKey : notnull
         {
-            if (_options.DuplicateKeyMode == DuplicateKeyMode.LastWins)
+            if (lastWins)
             {
                 values[key] = value;
                 return;

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -401,8 +401,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             if (!_memberConvertersForRead.TryGetValue(memberName, out MemberReadEntry entry))
             {
-                HandleUnknownName(ref reader, typeof(T), memberName);
-                reader.SkipDataItem();
+                HandleUnmappedName(ref reader, ref state, memberName);
             }
             else
             {
@@ -416,8 +415,7 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             if (!_memberConvertersForReadByIndex.TryGetValue(memberIndex, out MemberReadEntry entry))
             {
-                HandleUnknownIndex(ref reader, typeof(T), memberIndex);
-                reader.SkipDataItem();
+                HandleUnmappedIndex(ref reader, ref state, memberIndex);
             }
             else
             {
@@ -430,8 +428,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             if (!_memberConvertersForRead.TryGetValue(memberName, out MemberReadEntry entry))
             {
-                HandleUnknownName(ref reader, typeof(T), memberName);
-                reader.SkipDataItem();
+                HandleUnmappedName(ref reader, ref state, memberName);
                 value = default!;
                 return false;
             }
@@ -447,8 +444,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             if (!_memberConvertersForReadByIndex.TryGetValue(memberIndex, out MemberReadEntry entry))
             {
-                HandleUnknownIndex(ref reader, typeof(T), memberIndex);
-                reader.SkipDataItem();
+                HandleUnmappedIndex(ref reader, ref state, memberIndex);
                 value = default!;
                 return false;
             }
@@ -1070,6 +1066,54 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
 
             return context.memberIndex < context.memberConvertersForWrite.Count;
+        }
+
+        /// <summary>
+        /// A key that matched no member. That is the discriminator - which is a key of the map without
+        /// being a member of the type - or a name the type does not know, and the two are answered
+        /// differently: the discriminator is expected here and has already been read by the
+        /// convention, so it is skipped rather than reported as unhandled, while a repeat of it is a
+        /// duplicate map key like any other.
+        /// </summary>
+        /// <remarks>
+        /// Reached only once a lookup has already missed, so recognising the discriminator costs
+        /// nothing on the path taken by every member that maps to something.
+        /// </remarks>
+        private void HandleUnmappedName(ref CborReader reader, ref MemberReadState state, ReadOnlySpan<byte> memberName)
+        {
+            if (_discriminatorConvention != null && memberName.SequenceEqual(_discriminatorConvention.MemberName))
+            {
+                if (state.MarkDiscriminatorRead())
+                {
+                    throw reader.BuildException(MapKeyErrors.Duplicate(Encoding.UTF8.GetString(memberName)));
+                }
+            }
+            else
+            {
+                HandleUnknownName(ref reader, typeof(T), memberName);
+            }
+
+            reader.SkipDataItem();
+        }
+
+        /// <inheritdoc cref="HandleUnmappedName"/>
+        private void HandleUnmappedIndex(ref CborReader reader, ref MemberReadState state, int memberIndex)
+        {
+            // The discriminator is always written at index 0 -- see DiscriminatorMapping.MemberIndex --
+            // so in an integer-keyed map that index is its own whenever the type has a convention.
+            if (_discriminatorConvention != null && memberIndex == 0)
+            {
+                if (state.MarkDiscriminatorRead())
+                {
+                    throw reader.BuildException(MapKeyErrors.Duplicate(memberIndex));
+                }
+            }
+            else
+            {
+                HandleUnknownIndex(ref reader, typeof(T), memberIndex);
+            }
+
+            reader.SkipDataItem();
         }
 
         private void HandleUnknownName(ref CborReader reader, Type type, ReadOnlySpan<byte> rawName)

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -110,6 +110,19 @@ namespace Dahomey.Cbor.Serialization.Converters
         private readonly IDiscriminatorConvention? _discriminatorConvention = null;
 
         /// <summary>
+        /// Whether this type's own mapping carries a discriminator, as opposed to merely resolving a
+        /// convention.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="DiscriminatorConventionRegistry"/> answers with the convention of a hierarchy
+        /// for every base type and interface in it, so a convention being resolvable says nothing
+        /// about this type writing a discriminator. Only a type that does can have the key in its
+        /// documents, and only for such a type is an unmapped key at that name - or at index 0, where
+        /// a discriminator always sits - the discriminator rather than something the document made up.
+        /// </remarks>
+        private readonly bool _hasDiscriminatorMember;
+
+        /// <summary>
         /// The members to write, in the order to write them: declaration order normally, deterministic
         /// key order when <see cref="CborOptions.Deterministic"/> is set.
         /// </summary>
@@ -186,6 +199,8 @@ namespace Dahomey.Cbor.Serialization.Converters
             foreach (IMemberMapping memberMapping in _objectMapping.GetMemberMappingsForConverter(this))
             {
                 IMemberConverter memberConverter = memberMapping.GenerateMemberConverter();
+
+                _hasDiscriminatorMember |= memberMapping is IDiscriminatorMapping;
 
                 bool isCreatorMember = false;
 
@@ -722,11 +737,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                             {
                                 if (context.converter.ObjectMapping.IsCreatorMember(memberName))
                                 {
-                                    AddMemberValue(ref reader, context.readState.LastWins, context.creatorValues, new RawString(memberName), value);
+                                    AddMemberValue(ref reader, context.readState.Mode, context.creatorValues, new RawString(memberName), value);
                                 }
                                 else
                                 {
-                                    AddMemberValue(ref reader, context.readState.LastWins, context.regularValues!, new RawString(memberName), value);
+                                    AddMemberValue(ref reader, context.readState.Mode, context.regularValues!, new RawString(memberName), value);
                                 }
                             }
                         }
@@ -760,11 +775,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                             {
                                 if (context.converter.ObjectMapping.IsCreatorMember(memberIndex))
                                 {
-                                    AddMemberValue(ref reader, context.readState.LastWins, context.creatorValuesByIndex, memberIndex, value);
+                                    AddMemberValue(ref reader, context.readState.Mode, context.creatorValuesByIndex, memberIndex, value);
                                 }
                                 else
                                 {
-                                    AddMemberValue(ref reader, context.readState.LastWins, context.regularValuesByIndex!, memberIndex, value);
+                                    AddMemberValue(ref reader, context.readState.Mode, context.regularValuesByIndex!, memberIndex, value);
                                 }
                             }
                         }
@@ -793,11 +808,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                         {
                             if (context.converter.ObjectMapping.IsCreatorMember(context.memberIndex))
                             {
-                                AddMemberValue(ref reader, context.readState.LastWins, context.creatorValuesByIndex, context.memberIndex, value);
+                                AddMemberValue(ref reader, context.readState.Mode, context.creatorValuesByIndex, context.memberIndex, value);
                             }
                             else
                             {
-                                AddMemberValue(ref reader, context.readState.LastWins, context.regularValuesByIndex!, context.memberIndex, value);
+                                AddMemberValue(ref reader, context.readState.Mode, context.regularValuesByIndex!, context.memberIndex, value);
                             }
                         }
                     }
@@ -927,10 +942,10 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// this converter could not identify, which <c>Add</c> still catches and names correctly.
         /// </remarks>
         private static void AddMemberValue<TKey>(
-            ref CborReader reader, bool lastWins, Dictionary<TKey, object> values, TKey key, object value)
+            ref CborReader reader, DuplicateKeyMode mode, Dictionary<TKey, object> values, TKey key, object value)
             where TKey : notnull
         {
-            if (lastWins)
+            if (mode == DuplicateKeyMode.LastWins)
             {
                 values[key] = value;
                 return;
@@ -1081,7 +1096,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// </remarks>
         private void HandleUnmappedName(ref CborReader reader, ref MemberReadState state, ReadOnlySpan<byte> memberName)
         {
-            if (_discriminatorConvention != null && memberName.SequenceEqual(_discriminatorConvention.MemberName))
+            if (_hasDiscriminatorMember && memberName.SequenceEqual(_discriminatorConvention!.MemberName))
             {
                 if (state.MarkDiscriminatorRead())
                 {
@@ -1100,8 +1115,8 @@ namespace Dahomey.Cbor.Serialization.Converters
         private void HandleUnmappedIndex(ref CborReader reader, ref MemberReadState state, int memberIndex)
         {
             // The discriminator is always written at index 0 -- see DiscriminatorMapping.MemberIndex --
-            // so in an integer-keyed map that index is its own whenever the type has a convention.
-            if (_discriminatorConvention != null && memberIndex == 0)
+            // so in an integer-keyed map that index is its own, for a type that writes one.
+            if (_hasDiscriminatorMember && memberIndex == 0)
             {
                 if (state.MarkDiscriminatorRead())
                 {

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -14,10 +14,10 @@ namespace Dahomey.Cbor.Serialization.Converters
 {
     public interface IObjectConverter
     {
-        void ReadValue(ref CborReader reader, object obj, ReadOnlySpan<byte> memberName, HashSet<IMemberConverter> readMembers);
-        void ReadValue(ref CborReader reader, object obj, int memberIndex, HashSet<IMemberConverter> readMembers);
-        bool ReadValue(ref CborReader reader, ReadOnlySpan<byte> memberName, HashSet<IMemberConverter> readMembers, [MaybeNullWhen(false)] out object value);
-        bool ReadValue(ref CborReader reader, int memberIndex, HashSet<IMemberConverter> readMembers, [MaybeNullWhen(false)] out object value);
+        void ReadValue(ref CborReader reader, object obj, ReadOnlySpan<byte> memberName, ref MemberReadState state);
+        void ReadValue(ref CborReader reader, object obj, int memberIndex, ref MemberReadState state);
+        bool ReadValue(ref CborReader reader, ReadOnlySpan<byte> memberName, ref MemberReadState state, [MaybeNullWhen(false)] out object value);
+        bool ReadValue(ref CborReader reader, int memberIndex, ref MemberReadState state, [MaybeNullWhen(false)] out object value);
         IReadOnlyList<IMemberConverter> MemberConvertersForWrite { get; }
         ByteBufferDictionary<IMemberConverter> MemberConvertersForRead { get; }
         Dictionary<int, IMemberConverter> MemberConvertersForReadByIndex { get; }
@@ -46,7 +46,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             public Dictionary<RawString, object>? regularValues;
             public Dictionary<int, object>? creatorValuesByIndex;
             public Dictionary<int, object>? regularValuesByIndex;
-            public HashSet<IMemberConverter>? readMembers;
+            public MemberReadState readState;
             public int memberIndex;
         }
 
@@ -90,6 +90,22 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         private readonly ByteBufferDictionary<IMemberConverter> _memberConvertersForRead = new ByteBufferDictionary<IMemberConverter>();
         private readonly Dictionary<int, IMemberConverter> _memberConvertersForReadByIndex = new();
+
+        /// <summary>
+        /// A small dense number per deserializable member, so that <see cref="MemberReadState"/> can
+        /// hold "already read" as a bitmask instead of a set. Numbered by the order members were built
+        /// in, which is arbitrary but stable, since nothing depends on the value beyond its being
+        /// distinct within this converter.
+        /// </summary>
+        /// <remarks>
+        /// Built once per converter - which is itself built once per type and cached for the lifetime
+        /// of the options - and keyed by reference, like the required-member set. Kept here rather
+        /// than on <see cref="IMemberConverter"/> so that no member converter carries a number that
+        /// only means something relative to one converter: a mapping free to hand the same member
+        /// converter to two <see cref="ObjectConverter{T}"/>s would make such a number silently wrong
+        /// for one of them, and wrong here means a duplicate reported that is not one.
+        /// </remarks>
+        private readonly Dictionary<IMemberConverter, int> _readOrdinals = new();
         public List<IMemberConverter> _requiredMemberConvertersForRead = new List<IMemberConverter>();
         private readonly List<IMemberConverter> _memberConvertersForWrite;
         private List<IMemberConverter>? _deterministicMemberConvertersForWrite;
@@ -195,6 +211,8 @@ namespace Dahomey.Cbor.Serialization.Converters
 
                 if (memberMapping.CanBeDeserialized || isCreatorMember)
                 {
+                    _readOrdinals[memberConverter] = _readOrdinals.Count;
+
                     switch (_objectMapping.ObjectFormat)
                     {
                         case CborObjectFormat.StringKeyMap:
@@ -267,7 +285,9 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             ReaderContext context = new ReaderContext
             {
-                readMembers = _requiredMemberConvertersForRead.Count != 0 ? new HashSet<IMemberConverter>() : null
+                readState = new MemberReadState(
+                    trackRequiredMembers: _requiredMemberConvertersForRead.Count != 0,
+                    rejectDuplicates: _options.DuplicateKeyMode == DuplicateKeyMode.Reject)
             };
 
             // Members name themselves in ReadItem, where the name is still in hand. What is left for
@@ -358,11 +378,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                     }
                 }
 
-                if (context.readMembers != null)
+                if (context.readState.TracksRequiredMembers)
                 {
                     foreach (IMemberConverter memberConverter in context.converter.RequiredMemberConvertersForRead)
                     {
-                        if (!context.readMembers.Contains(memberConverter))
+                        if (!context.readState.WasRead(memberConverter))
                         {
                             throw new CborException($"Required property '{Encoding.UTF8.GetString(memberConverter.MemberName)}' not found in JSON.");
                         }
@@ -383,7 +403,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
         }
 
-        public void ReadValue(ref CborReader reader, object obj, ReadOnlySpan<byte> memberName, HashSet<IMemberConverter> readMembers)
+        public void ReadValue(ref CborReader reader, object obj, ReadOnlySpan<byte> memberName, ref MemberReadState state)
         {
             T value = (T)obj;
 
@@ -394,14 +414,11 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
             else
             {
-                if (readMembers != null)
-                {
-                    readMembers.Add(memberConverter);
-                }
+                MarkMemberRead(ref reader, ref state, memberConverter, memberName);
                 memberConverter.Read(ref reader, value);
             }
         }
-        public void ReadValue(ref CborReader reader, object obj, int memberIndex, HashSet<IMemberConverter> readMembers)
+        public void ReadValue(ref CborReader reader, object obj, int memberIndex, ref MemberReadState state)
         {
             T value = (T)obj;
 
@@ -412,15 +429,12 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
             else
             {
-                if (readMembers != null)
-                {
-                    readMembers.Add(memberConverter);
-                }
+                MarkMemberRead(ref reader, ref state, memberConverter, memberIndex);
                 memberConverter.Read(ref reader, value);
             }
         }
 
-        public bool ReadValue(ref CborReader reader, ReadOnlySpan<byte> memberName, HashSet<IMemberConverter> readMembers, [MaybeNullWhen(false)] out object value)
+        public bool ReadValue(ref CborReader reader, ReadOnlySpan<byte> memberName, ref MemberReadState state, [MaybeNullWhen(false)] out object value)
         {
             if (!_memberConvertersForRead.TryGetValue(memberName, out IMemberConverter? memberConverter))
             {
@@ -431,16 +445,13 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
             else
             {
-                if (readMembers != null)
-                {
-                    readMembers.Add(memberConverter);
-                }
+                MarkMemberRead(ref reader, ref state, memberConverter, memberName);
                 value = memberConverter.Read(ref reader);
                 return true;
             }
         }
 
-        public bool ReadValue(ref CborReader reader, int memberIndex, HashSet<IMemberConverter> readMembers, [MaybeNullWhen(false)] out object value)
+        public bool ReadValue(ref CborReader reader, int memberIndex, ref MemberReadState state, [MaybeNullWhen(false)] out object value)
         {
             if (!_memberConvertersForReadByIndex.TryGetValue(memberIndex, out IMemberConverter? memberConverter))
             {
@@ -451,10 +462,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
             else
             {
-                if (readMembers != null)
-                {
-                    readMembers.Add(memberConverter);
-                }
+                MarkMemberRead(ref reader, ref state, memberConverter, memberIndex);
                 value = memberConverter.Read(ref reader);
                 return true;
             }
@@ -711,14 +719,14 @@ namespace Dahomey.Cbor.Serialization.Converters
                             {
                                 if (_isStruct)
                                 {
-                                    ReadValueForStruct(ref reader, ref context.obj, memberName, context.readMembers!);
+                                    ReadValueForStruct(ref reader, ref context.obj, memberName, ref context.readState);
                                 }
                                 else
                                 {
-                                    context.converter.ReadValue(ref reader, context.obj!, memberName, context.readMembers!);
+                                    context.converter.ReadValue(ref reader, context.obj!, memberName, ref context.readState);
                                 }
                             }
-                            else if (context.converter.ReadValue(ref reader, memberName, context.readMembers!, out object? value))
+                            else if (context.converter.ReadValue(ref reader, memberName, ref context.readState, out object? value))
                             {
                                 if (context.converter.ObjectMapping.IsCreatorMember(memberName))
                                 {
@@ -749,14 +757,14 @@ namespace Dahomey.Cbor.Serialization.Converters
                             {
                                 if (_isStruct)
                                 {
-                                    ReadValueForStruct(ref reader, ref context.obj, memberIndex, context.readMembers!);
+                                    ReadValueForStruct(ref reader, ref context.obj, memberIndex, ref context.readState);
                                 }
                                 else
                                 {
-                                    context.converter.ReadValue(ref reader, context.obj!, memberIndex, context.readMembers!);
+                                    context.converter.ReadValue(ref reader, context.obj!, memberIndex, ref context.readState);
                                 }
                             }
-                            else if (context.converter.ReadValue(ref reader, memberIndex, context.readMembers!, out object? value))
+                            else if (context.converter.ReadValue(ref reader, memberIndex, ref context.readState, out object? value))
                             {
                                 if (context.converter.ObjectMapping.IsCreatorMember(memberIndex))
                                 {
@@ -782,14 +790,14 @@ namespace Dahomey.Cbor.Serialization.Converters
                         {
                             if (_isStruct)
                             {
-                                ReadValueForStruct(ref reader, ref context.obj, context.memberIndex, context.readMembers!);
+                                ReadValueForStruct(ref reader, ref context.obj, context.memberIndex, ref context.readState);
                             }
                             else
                             {
-                                context.converter.ReadValue(ref reader, context.obj!, context.memberIndex, context.readMembers!);
+                                context.converter.ReadValue(ref reader, context.obj!, context.memberIndex, ref context.readState);
                             }
                         }
-                        else if (context.converter.ReadValue(ref reader, context.memberIndex, context.readMembers!, out object? value))
+                        else if (context.converter.ReadValue(ref reader, context.memberIndex, ref context.readState, out object? value))
                         {
                             if (context.converter.ObjectMapping.IsCreatorMember(context.memberIndex))
                             {
@@ -835,14 +843,11 @@ namespace Dahomey.Cbor.Serialization.Converters
             exception.PrependPathIndex(memberIndex);
         }
 
-        private void ReadValueForStruct(ref CborReader reader, ref T instance, ReadOnlySpan<byte> memberName, HashSet<IMemberConverter> readMembers)
+        private void ReadValueForStruct(ref CborReader reader, ref T instance, ReadOnlySpan<byte> memberName, ref MemberReadState state)
         {
             if (_memberConvertersForRead.TryGetValue(memberName, out IMemberConverter? memberConverter))
             {
-                if (readMembers != null)
-                {
-                    readMembers.Add(memberConverter);
-                }
+                MarkMemberRead(ref reader, ref state, memberConverter, memberName);
 
                 ((IMemberConverter<T>)memberConverter).Read(ref reader, ref instance);
             }
@@ -852,14 +857,11 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
         }
 
-        private void ReadValueForStruct(ref CborReader reader, ref T instance, int memberIndex, HashSet<IMemberConverter> readMembers)
+        private void ReadValueForStruct(ref CborReader reader, ref T instance, int memberIndex, ref MemberReadState state)
         {
             if (_memberConvertersForReadByIndex.TryGetValue(memberIndex, out IMemberConverter? memberConverter))
             {
-                if (readMembers != null)
-                {
-                    readMembers.Add(memberConverter);
-                }
+                MarkMemberRead(ref reader, ref state, memberConverter, memberIndex);
 
                 ((IMemberConverter<T>)memberConverter).Read(ref reader, ref instance);
             }
@@ -867,6 +869,48 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 reader.SkipDataItem();
             }
+        }
+
+        /// <summary>
+        /// Records that the document has supplied this member, and refuses it if the document has
+        /// supplied it once already and <see cref="DuplicateKeyMode.Reject"/> is in force. Every site
+        /// that resolves a member converter goes through here, so that the assign path, the struct
+        /// path and both creator paths cannot drift apart on what a repeated member means.
+        /// </summary>
+        /// <remarks>
+        /// A key matching no member is not tracked and so is never refused as a repeat: it has no
+        /// member to be a repeat of, and what becomes of it is
+        /// <see cref="CborOptions.UnhandledNameMode"/>'s question rather than this one's.
+        /// </remarks>
+        private void MarkMemberRead(
+            ref CborReader reader, ref MemberReadState state, IMemberConverter memberConverter, ReadOnlySpan<byte> memberName)
+        {
+            if (IsRepeat(ref state, memberConverter))
+            {
+                // Decoded here rather than kept around: the name is in hand as bytes, and is only
+                // wanted as text once the read has already failed.
+                throw reader.BuildException(MapKeyErrors.Duplicate(Encoding.UTF8.GetString(memberName)));
+            }
+        }
+
+        /// <inheritdoc cref="MarkMemberRead(ref CborReader, ref MemberReadState, IMemberConverter, ReadOnlySpan{byte})"/>
+        private void MarkMemberRead(
+            ref CborReader reader, ref MemberReadState state, IMemberConverter memberConverter, int memberIndex)
+        {
+            if (IsRepeat(ref state, memberConverter))
+            {
+                throw reader.BuildException(MapKeyErrors.Duplicate(memberIndex));
+            }
+        }
+
+        private bool IsRepeat(ref MemberReadState state, IMemberConverter memberConverter)
+        {
+            state.MarkRequiredMemberRead(memberConverter);
+
+            // The ordinal lookup is skipped entirely under LastWins, where nothing is going to be
+            // refused and the answer would only be discarded.
+            return state.RejectsDuplicates
+                && state.MarkSeen(_readOrdinals.TryGetValue(memberConverter, out int ordinal) ? ordinal : -1);
         }
 
         private static int CompareMembersForDeterministicOrder(IMemberConverter x, IMemberConverter y)
@@ -893,15 +937,23 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// </summary>
         /// <remarks>
         /// A document repeating a member reaches a <c>Dictionary.Add</c> here, exactly as a repeated
-        /// map key reaches one in the dictionary converters, and has to be refused the same way: as a
+        /// map key reaches one in the dictionary converters, and is refused the same way: as a
         /// <see cref="CborException"/> rather than the <see cref="ArgumentException"/> the dictionary
-        /// raises. A type without a creator mapping never reaches this -- its members are assigned, so
-        /// the last occurrence wins there and always has.
+        /// raises. A type without a creator mapping does not reach this -- its members are assigned to
+        /// an instance -- so the repeat is caught for that path in <c>MarkMemberRead</c> instead, which
+        /// is what keeps the answer from depending on whether the type happens to have a non-default
+        /// constructor.
         /// </remarks>
-        private static void AddMemberValue<TKey>(
+        private void AddMemberValue<TKey>(
             ref CborReader reader, Dictionary<TKey, object?> values, TKey key, object? value)
             where TKey : notnull
         {
+            if (_options.DuplicateKeyMode == DuplicateKeyMode.LastWins)
+            {
+                values[key] = value;
+                return;
+            }
+
             try
             {
                 values.Add(key, value);

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -19,8 +19,8 @@ namespace Dahomey.Cbor.Serialization.Converters
         bool ReadValue(ref CborReader reader, ReadOnlySpan<byte> memberName, ref MemberReadState state, [MaybeNullWhen(false)] out object value);
         bool ReadValue(ref CborReader reader, int memberIndex, ref MemberReadState state, [MaybeNullWhen(false)] out object value);
         IReadOnlyList<IMemberConverter> MemberConvertersForWrite { get; }
-        ByteBufferDictionary<IMemberConverter> MemberConvertersForRead { get; }
-        Dictionary<int, IMemberConverter> MemberConvertersForReadByIndex { get; }
+        ByteBufferDictionary<MemberReadEntry> MemberConvertersForRead { get; }
+        Dictionary<int, MemberReadEntry> MemberConvertersForReadByIndex { get; }
         IReadOnlyList<IMemberConverter> RequiredMemberConvertersForRead { get; }
         IObjectMapping ObjectMapping { get; }
     }
@@ -88,24 +88,16 @@ namespace Dahomey.Cbor.Serialization.Converters
             public LengthMode lengthMode;
         }
 
-        private readonly ByteBufferDictionary<IMemberConverter> _memberConvertersForRead = new ByteBufferDictionary<IMemberConverter>();
-        private readonly Dictionary<int, IMemberConverter> _memberConvertersForReadByIndex = new();
+        private readonly ByteBufferDictionary<MemberReadEntry> _memberConvertersForRead = new ByteBufferDictionary<MemberReadEntry>();
+        private readonly Dictionary<int, MemberReadEntry> _memberConvertersForReadByIndex = new();
 
         /// <summary>
-        /// A small dense number per deserializable member, so that <see cref="MemberReadState"/> can
-        /// hold "already read" as a bitmask instead of a set. Numbered by the order members were built
-        /// in, which is arbitrary but stable, since nothing depends on the value beyond its being
-        /// distinct within this converter.
+        /// Numbers the members added to the read lookups above, so each carries a
+        /// <see cref="MemberReadEntry.Ordinal"/> distinct within this converter. Counts entries rather
+        /// than distinct member converters, so that presenting the same member converter twice cannot
+        /// hand two members one number.
         /// </summary>
-        /// <remarks>
-        /// Built once per converter - which is itself built once per type and cached for the lifetime
-        /// of the options - and keyed by reference, like the required-member set. Kept here rather
-        /// than on <see cref="IMemberConverter"/> so that no member converter carries a number that
-        /// only means something relative to one converter: a mapping free to hand the same member
-        /// converter to two <see cref="ObjectConverter{T}"/>s would make such a number silently wrong
-        /// for one of them, and wrong here means a duplicate reported that is not one.
-        /// </remarks>
-        private readonly Dictionary<IMemberConverter, int> _readOrdinals = new();
+        private int _nextReadOrdinal;
         public List<IMemberConverter> _requiredMemberConvertersForRead = new List<IMemberConverter>();
         private readonly List<IMemberConverter> _memberConvertersForWrite;
         private List<IMemberConverter>? _deterministicMemberConvertersForWrite;
@@ -161,8 +153,8 @@ namespace Dahomey.Cbor.Serialization.Converters
                 return sorted;
             }
         }
-        public ByteBufferDictionary<IMemberConverter> MemberConvertersForRead => _memberConvertersForRead;
-        public Dictionary<int, IMemberConverter> MemberConvertersForReadByIndex => _memberConvertersForReadByIndex;
+        public ByteBufferDictionary<MemberReadEntry> MemberConvertersForRead => _memberConvertersForRead;
+        public Dictionary<int, MemberReadEntry> MemberConvertersForReadByIndex => _memberConvertersForReadByIndex;
         public IReadOnlyList<IMemberConverter> RequiredMemberConvertersForRead => _requiredMemberConvertersForRead;
         public IObjectMapping ObjectMapping => _objectMapping;
 
@@ -211,18 +203,18 @@ namespace Dahomey.Cbor.Serialization.Converters
 
                 if (memberMapping.CanBeDeserialized || isCreatorMember)
                 {
-                    _readOrdinals[memberConverter] = _readOrdinals.Count;
-
                     switch (_objectMapping.ObjectFormat)
                     {
                         case CborObjectFormat.StringKeyMap:
-                            _memberConvertersForRead.Add(memberConverter.MemberName, memberConverter);
+                            _memberConvertersForRead.Add(
+                                memberConverter.MemberName, new MemberReadEntry(memberConverter, _nextReadOrdinal++));
                             break;
                         case CborObjectFormat.IntKeyMap:
                         case CborObjectFormat.Array:
                             if (memberConverter.MemberIndex.HasValue)
                             {
-                                _memberConvertersForReadByIndex.Add(memberConverter.MemberIndex.Value, memberConverter);
+                                _memberConvertersForReadByIndex.Add(
+                                    memberConverter.MemberIndex.Value, new MemberReadEntry(memberConverter, _nextReadOrdinal++));
                             }
                             break;
                     }
@@ -344,13 +336,13 @@ namespace Dahomey.Cbor.Serialization.Converters
 
                                 foreach (KeyValuePair<RawString, object> value in context.regularValues!)
                                 {
-                                    if (!context.converter.MemberConvertersForRead.TryGetValue(value.Key.Buffer.Span, out IMemberConverter? memberConverter))
+                                    if (!context.converter.MemberConvertersForRead.TryGetValue(value.Key.Buffer.Span, out MemberReadEntry entry))
                                     {
                                         // should not happen
                                         throw new CborException("Unexpected error");
                                     }
 
-                                    memberConverter.Set(context.obj, value.Value);
+                                    entry.Converter.Set(context.obj, value.Value);
                                 }
                             }
                             break;
@@ -365,13 +357,13 @@ namespace Dahomey.Cbor.Serialization.Converters
 
                                 foreach (KeyValuePair<int, object> value in context.regularValuesByIndex!)
                                 {
-                                    if (!context.converter.MemberConvertersForReadByIndex.TryGetValue(value.Key, out IMemberConverter? memberConverter))
+                                    if (!context.converter.MemberConvertersForReadByIndex.TryGetValue(value.Key, out MemberReadEntry entry))
                                     {
                                         // should not happen
                                         throw new CborException("Unexpected error");
                                     }
 
-                                    memberConverter.Set(context.obj, value.Value);
+                                    entry.Converter.Set(context.obj, value.Value);
                                 }
                             }
                             break;
@@ -407,36 +399,36 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             T value = (T)obj;
 
-            if (!_memberConvertersForRead.TryGetValue(memberName, out IMemberConverter? memberConverter))
+            if (!_memberConvertersForRead.TryGetValue(memberName, out MemberReadEntry entry))
             {
                 HandleUnknownName(ref reader, typeof(T), memberName);
                 reader.SkipDataItem();
             }
             else
             {
-                MarkMemberRead(ref reader, ref state, memberConverter, memberName);
-                memberConverter.Read(ref reader, value);
+                MarkMemberRead(ref reader, ref state, entry, memberName);
+                entry.Converter.Read(ref reader, value);
             }
         }
         public void ReadValue(ref CborReader reader, object obj, int memberIndex, ref MemberReadState state)
         {
             T value = (T)obj;
 
-            if (!_memberConvertersForReadByIndex.TryGetValue(memberIndex, out IMemberConverter? memberConverter))
+            if (!_memberConvertersForReadByIndex.TryGetValue(memberIndex, out MemberReadEntry entry))
             {
                 HandleUnknownIndex(ref reader, typeof(T), memberIndex);
                 reader.SkipDataItem();
             }
             else
             {
-                MarkMemberRead(ref reader, ref state, memberConverter, memberIndex);
-                memberConverter.Read(ref reader, value);
+                MarkMemberRead(ref reader, ref state, entry, memberIndex);
+                entry.Converter.Read(ref reader, value);
             }
         }
 
         public bool ReadValue(ref CborReader reader, ReadOnlySpan<byte> memberName, ref MemberReadState state, [MaybeNullWhen(false)] out object value)
         {
-            if (!_memberConvertersForRead.TryGetValue(memberName, out IMemberConverter? memberConverter))
+            if (!_memberConvertersForRead.TryGetValue(memberName, out MemberReadEntry entry))
             {
                 HandleUnknownName(ref reader, typeof(T), memberName);
                 reader.SkipDataItem();
@@ -445,15 +437,15 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
             else
             {
-                MarkMemberRead(ref reader, ref state, memberConverter, memberName);
-                value = memberConverter.Read(ref reader);
+                MarkMemberRead(ref reader, ref state, entry, memberName);
+                value = entry.Converter.Read(ref reader);
                 return true;
             }
         }
 
         public bool ReadValue(ref CborReader reader, int memberIndex, ref MemberReadState state, [MaybeNullWhen(false)] out object value)
         {
-            if (!_memberConvertersForReadByIndex.TryGetValue(memberIndex, out IMemberConverter? memberConverter))
+            if (!_memberConvertersForReadByIndex.TryGetValue(memberIndex, out MemberReadEntry entry))
             {
                 HandleUnknownIndex(ref reader, typeof(T), memberIndex);
                 reader.SkipDataItem();
@@ -462,8 +454,8 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
             else
             {
-                MarkMemberRead(ref reader, ref state, memberConverter, memberIndex);
-                value = memberConverter.Read(ref reader);
+                MarkMemberRead(ref reader, ref state, entry, memberIndex);
+                value = entry.Converter.Read(ref reader);
                 return true;
             }
         }
@@ -845,11 +837,11 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         private void ReadValueForStruct(ref CborReader reader, ref T instance, ReadOnlySpan<byte> memberName, ref MemberReadState state)
         {
-            if (_memberConvertersForRead.TryGetValue(memberName, out IMemberConverter? memberConverter))
+            if (_memberConvertersForRead.TryGetValue(memberName, out MemberReadEntry entry))
             {
-                MarkMemberRead(ref reader, ref state, memberConverter, memberName);
+                MarkMemberRead(ref reader, ref state, entry, memberName);
 
-                ((IMemberConverter<T>)memberConverter).Read(ref reader, ref instance);
+                ((IMemberConverter<T>)entry.Converter).Read(ref reader, ref instance);
             }
             else
             {
@@ -859,11 +851,11 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         private void ReadValueForStruct(ref CborReader reader, ref T instance, int memberIndex, ref MemberReadState state)
         {
-            if (_memberConvertersForReadByIndex.TryGetValue(memberIndex, out IMemberConverter? memberConverter))
+            if (_memberConvertersForReadByIndex.TryGetValue(memberIndex, out MemberReadEntry entry))
             {
-                MarkMemberRead(ref reader, ref state, memberConverter, memberIndex);
+                MarkMemberRead(ref reader, ref state, entry, memberIndex);
 
-                ((IMemberConverter<T>)memberConverter).Read(ref reader, ref instance);
+                ((IMemberConverter<T>)entry.Converter).Read(ref reader, ref instance);
             }
             else
             {
@@ -882,10 +874,10 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// member to be a repeat of, and what becomes of it is
         /// <see cref="CborOptions.UnhandledNameMode"/>'s question rather than this one's.
         /// </remarks>
-        private void MarkMemberRead(
-            ref CborReader reader, ref MemberReadState state, IMemberConverter memberConverter, ReadOnlySpan<byte> memberName)
+        private static void MarkMemberRead(
+            ref CborReader reader, ref MemberReadState state, in MemberReadEntry entry, ReadOnlySpan<byte> memberName)
         {
-            if (IsRepeat(ref state, memberConverter))
+            if (state.MarkRead(entry))
             {
                 // Decoded here rather than kept around: the name is in hand as bytes, and is only
                 // wanted as text once the read has already failed.
@@ -893,24 +885,14 @@ namespace Dahomey.Cbor.Serialization.Converters
             }
         }
 
-        /// <inheritdoc cref="MarkMemberRead(ref CborReader, ref MemberReadState, IMemberConverter, ReadOnlySpan{byte})"/>
-        private void MarkMemberRead(
-            ref CborReader reader, ref MemberReadState state, IMemberConverter memberConverter, int memberIndex)
+        /// <inheritdoc cref="MarkMemberRead(ref CborReader, ref MemberReadState, in MemberReadEntry, ReadOnlySpan{byte})"/>
+        private static void MarkMemberRead(
+            ref CborReader reader, ref MemberReadState state, in MemberReadEntry entry, int memberIndex)
         {
-            if (IsRepeat(ref state, memberConverter))
+            if (state.MarkRead(entry))
             {
                 throw reader.BuildException(MapKeyErrors.Duplicate(memberIndex));
             }
-        }
-
-        private bool IsRepeat(ref MemberReadState state, IMemberConverter memberConverter)
-        {
-            state.MarkRequiredMemberRead(memberConverter);
-
-            // The ordinal lookup is skipped entirely under LastWins, where nothing is going to be
-            // refused and the answer would only be discarded.
-            return state.RejectsDuplicates
-                && state.MarkSeen(_readOrdinals.TryGetValue(memberConverter, out int ordinal) ? ordinal : -1);
         }
 
         private static int CompareMembersForDeterministicOrder(IMemberConverter x, IMemberConverter y)

--- a/src/Dahomey.Cbor/Util/ByteBufferDictionary.cs
+++ b/src/Dahomey.Cbor/Util/ByteBufferDictionary.cs
@@ -14,6 +14,19 @@ namespace Dahomey.Cbor.Util
             public ulong key;
             public T value = default!;
             public NodeCollection? next;
+
+            /// <summary>
+            /// Whether this node is the end of a key that was actually added, as opposed to a segment
+            /// on the way to a longer one.
+            /// </summary>
+            /// <remarks>
+            /// Keys are split into eight-byte segments, one node each, so adding "PropertyAlpha"
+            /// creates a node for its first eight bytes - "Property" - that no lookup should ever
+            /// find. Without this flag it is found, and answers with <c>default(T)</c>: a null
+            /// converter, or an entry whose ordinal belongs to another member. The tree cannot tell a
+            /// stored default from an absent value, so the distinction has to be recorded.
+            /// </remarks>
+            public bool hasValue;
         }
 
         private class NodeCollection
@@ -141,6 +154,7 @@ namespace Dahomey.Cbor.Util
             }
 
             last.value = value;
+            last.hasValue = true;
         }
 
         public bool TryGetValue(ReadOnlySpan<byte> key, [MaybeNullWhen(false)] out T value)
@@ -177,6 +191,12 @@ namespace Dahomey.Cbor.Util
                         return false;
                     }
                 }
+            }
+
+            if (!node.hasValue)
+            {
+                value = default!;
+                return false;
             }
 
             value = node.value;


### PR DESCRIPTION
Implements the decision in [#169](https://github.com/dahomey-technologies/Dahomey.Cbor/issues/169#issuecomment-5225008451): reject everywhere by default, `LastWins` as the opt-out, applying to every target, and the break on the assign path taken deliberately.

Closes #169. Also closes #175 and #176, two older bugs this turned up that the policy could not be honest with in place.

## What changed

`CborOptions.DuplicateKeyMode`, two values, defaulting to `Reject`:

| Target | Before | `Reject` (default) | `LastWins` |
|---|---|---|---|
| `CborValue` / object model | `CborException` | `CborException` | last occurrence wins |
| `Dictionary<K,V>`, `IDictionary<K,V>`, immutable | `CborException` | `CborException` | last occurrence wins |
| mapped class **with** a creator mapping | `CborException` | `CborException` | last occurrence wins |
| mapped class **without** a creator mapping | **last-wins, silent** | **`CborException`** | last occurrence wins |
| the discriminator key | accepted (#176) | `CborException` | last occurrence wins |

Only the fourth row changes behaviour for a well-formed mapping, and it is the row the issue is about — the one where an implementation detail (assignment overwrites, `Dictionary.Add` does not) had become observable behaviour, so that adding or removing a constructor changed what a document meant.

Under `LastWins`, the dictionary-backed targets switch from `Add` to an indexer assignment, so the mode reaches all of them rather than meaning "mapped classes overwrite, dictionaries still throw". First-wins is not offered.

The message is the one #167 settled on, through the same `MapKeyErrors`, and carries the path:

```
[6] Duplicate map key: A. Failed to deserialize from "$.A".
```

The mode is read once when a map or an object read starts, not per entry, so no single map is read half under one policy and half under the other if the options object is changed underneath it.

## Tracking on the assign path

That path had no record of which members had been read, and a `HashSet` per deserialization to get one would be a poor trade for documents containing no duplicates. So members carry an ordinal within their converter, and "already read" is a bit in a `ulong` held in the reader context — one test and one or per member, no allocation, with a `HashSet<int>` fallback allocated only if a member past the 64th is actually read.

The ordinal travels **in the entry the read already resolved**: the read lookups hold a `MemberReadEntry` (converter + ordinal) rather than a bare `IMemberConverter`, so finding it costs nothing beyond the hash the read already paid to find the converter. Ordinals count from 1, leaving 0 to identify no member at all, so a lookup yielding `default(MemberReadEntry)` cannot borrow the first member's identity and be reported as a repeat of it.

Two invariants this rests on, both stated in the code: the converter that resolves members is settled once, on the first item, so one bitmask means the same thing for a whole read; and entries are numbered as they are added, so nothing is assumed about a member converter instance belonging to one `ObjectConverter<T>` — which matters on the polymorphic path, where the converter resolving the member is not the one the read started on.

`readMembers` (required-member tracking) moves into the same `MemberReadState` struct rather than sitting beside it, and is recorded before the `LastWins` short-circuit, so a required member supplied twice is still satisfied in that mode.

## The two older bugs

* **#175** — `ByteBufferDictionary` stores a key as one node per eight bytes, so a member name of nine bytes or more leaves nodes for its prefixes behind, and `TryGetValue` answered `true` on one with `default(T)`. That is a **`NullReferenceException` from arbitrary input** — a document using an eight-byte key that happens to prefix a member name — and on this branch it briefly became a duplicate reported against a member the document never repeated. Nodes now record whether a value was assigned, and a lookup misses on one that carries none. Worth naming in the release notes as a robustness fix in its own right.
* **#176** — the discriminator is a key of the map without being a member of the type, so it matched nothing and fell to the unknown-name path. `UnhandledNameMode.ThrowException` and polymorphism were therefore mutually exclusive — every polymorphic read threw on its own type tag — and a document could repeat the discriminator freely. A key matching no member is now checked against the discriminator's name, or index 0 in an integer-keyed map, before being called unhandled. Both checks are guarded on the type's own mapping carrying a discriminator, not merely on a convention being resolvable — the registry answers with a hierarchy's convention for every base type and interface in it, so the weaker test would let an unmapped key 0 be swallowed on a type that writes no discriminator at all. Reached only once a member lookup has missed, so it costs nothing on the mapped path.

A repeated key that matches nothing at all is still not a duplicate member: that is `UnhandledNameMode`'s question. A null key is refused in both modes and says so rather than claiming a duplicate.

Three things found along the way and deliberately **not** taken here, each wanting its own decision rather than to ride along: a type mapping two members to one CBOR name, which writes a document it cannot read back (#177); the message-rendering asymmetry between the object model and the other targets (#178); and required members declared only on a derived type never being validated on the polymorphic path (#179).

## Tests

`Issues/Issue0169.cs` asserts both modes against every target — object model, dictionary, creator-mapped class, assign-path class, struct, int-keyed map, int-keyed creator type, discriminator — plus the path and message, a repeated unknown name, a null key under `LastWins`, and required members under `LastWins` (satisfied by a repeat, and still missing when absent). The 64-member boundary is covered by a type with 66 members, each duplicated in turn, so the fallback is exercised whatever ordinal a given property is given.

It also covers where a per-converter ordinal is most exposed: a **polymorphic** read on a derived and on an inherited member; **array format**; **sibling objects of one type and a list of them**, where state leaking between reads would refuse the second; and a **creator type with both a constructor argument and an ordinary member**, duplicated on each. Plus the two edges the discriminator work introduced: a key that is the prefix of a member name, and an unmapped index 0 on a type that writes no discriminator. `ByteBufferDictionaryTests` covers the prefix lookup in both directions.

1321 tests pass on net8.0 and net10.0; all four TFMs build, `netstandard2.0` included, and three pre-existing CS8620 warnings on `AddMemberValue` are gone.

## Release

Three things for the notes, on a **minor** bump:

* **Behaviour.** A mapped class without a creator mapping used to take the last occurrence of a repeated member silently and now throws. `DuplicateKeyMode.LastWins` restores it. The README section names this specifically, since someone whose producers emit duplicates gets a working deserialize turned into a throw with nothing in their own code having changed. Note that the default applies to `CborOptions.Default`, which is a process-wide singleton, so this is not confined to options objects the caller constructs.
* **Robustness.** #175 turned a `NullReferenceException` reachable from arbitrary input into an ordinary unknown-key path; #176 makes `UnhandledNameMode.ThrowException` usable with polymorphic types at all.
* **API.** `IObjectConverter` changes on six members — the four `ReadValue` overloads now take `ref MemberReadState`, and `MemberConvertersForRead`/`MemberConvertersForReadByIndex` hold `MemberReadEntry` — plus two new public types, one of them a mutable struct. Source and binary breaking for anything outside this repository implementing or consuming that interface; nothing inside it does, and the source generator only registers `new ObjectConverter<T>(options)`. The two new types are public only because that interface is; if it ever becomes internal, they should follow.