### PR TITLE
Copy before tagging an empty string, closes #172

### DIFF
--- a/src/Dahomey.Cbor.Tests/Issues/Issue0162.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0162.cs
@@ -160,7 +160,8 @@ namespace Dahomey.Cbor.Tests.Issues
         /// <see cref="CborPositive"/> and <see cref="CborNegative"/> hand out shared instances for
         /// small integers, as <see cref="CborSingle"/>, <see cref="CborDouble"/> and
         /// <see cref="CborDecimal"/> do for small whole numbers, <see cref="CborBoolean"/> for both
-        /// values and <see cref="CborValue.Null"/> for null. Assigning <c>SemanticTag</c> to one of
+        /// values, <see cref="CborString"/> for the empty string (missed here and fixed by #172) and
+        /// <see cref="CborValue.Null"/> for null. Assigning <c>SemanticTag</c> to one of
         /// those attaches the tag to every occurrence of that value in the process — including
         /// documents that never carried a tag, and values built in code that were never read at all.
         /// <para>

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0172.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0172.cs
@@ -72,8 +72,9 @@ namespace Dahomey.Cbor.Tests.Issues
         }
 
         /// <summary>
-        /// A non-empty string is constructed fresh per value, so it has nothing to alias and tags in
-        /// place as before.
+        /// A non-empty string is constructed fresh per value, so it has nothing to alias. The override
+        /// is unconditional and copies it anyway — one small allocation per tagged-string read, for a
+        /// result indistinguishable from tagging in place.
         /// </summary>
         [Fact]
         public void ATaggedNonEmptyStringIsUnaffected()

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0172.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0172.cs
@@ -1,0 +1,164 @@
+using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Tests.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #172: reading a semantic tag in front of an empty text string stamped the tag onto the
+    /// process-wide shared <see cref="CborString"/> instance.
+    /// </summary>
+    /// <remarks>
+    /// The same aliasing bug #165 fixed, on the one type that fix left out. <see cref="CborString"/>
+    /// caches a single value rather than a range — <c>(CborString)string.Empty</c> always returns the
+    /// same instance — which was enough for it to be missed as a cache and so to keep inheriting the
+    /// base <c>WithSemanticTag</c>, which tags in place. Every <c>""</c> in the process then carried
+    /// the tag: empty strings written in code, and empty strings decoded from documents that never
+    /// carried one.
+    /// <para>
+    /// Fixed the way the other sharers are: copy first, tag the copy.
+    /// </para>
+    /// </remarks>
+    public class Issue0172
+    {
+        /// <summary>The repro from the issue.</summary>
+        [Fact]
+        public void ATagOnAnEmptyStringDoesNotLeakIntoTheSharedInstance()
+        {
+            // c0    tag(0)
+            //    60 ""
+            CborValue tagged = Cbor.Deserialize<CborValue>("C060".HexToBytes());
+            CborValue fresh = (CborValue)"";
+
+            Assert.Equal(0UL, tagged.SemanticTag);
+            Assert.Null(fresh.SemanticTag);
+            Assert.False(ReferenceEquals(tagged, fresh));
+        }
+
+        /// <summary>
+        /// The consequence that reaches the bytes: an untagged empty string must still serialize as
+        /// <c>60</c>, in a document read after the tagged one and in a value built in code.
+        /// </summary>
+        [Fact]
+        public void AnUntaggedEmptyStringStillWritesUntagged()
+        {
+            CborValue tagged = Cbor.Deserialize<CborValue>("C060".HexToBytes());
+            Assert.Equal(0UL, tagged.SemanticTag);
+
+            // A different document, carrying no tag, whose item is the same empty string.
+            CborArray other = Cbor.Deserialize<CborArray>("8160".HexToBytes());
+            Assert.Null(other[0].SemanticTag);
+            Helper.TestWrite(other, "8160");
+
+            // And a value built in code, which was never read from anything.
+            Helper.TestWrite(new CborArray { "" }, "8160");
+        }
+
+        /// <summary>The tagged value itself round trips, so copying does not lose the tag.</summary>
+        [Fact]
+        public void ATaggedEmptyStringSurvivesARoundTrip()
+        {
+            const string hexBuffer = "C060";
+
+            CborValue value = Cbor.Deserialize<CborValue>(hexBuffer.HexToBytes());
+
+            Assert.Equal(0UL, value.SemanticTag);
+            Assert.Equal("", value.Value<string>());
+            Helper.TestWrite(value, hexBuffer);
+        }
+
+        /// <summary>
+        /// A non-empty string is constructed fresh per value, so it has nothing to alias and tags in
+        /// place as before.
+        /// </summary>
+        [Fact]
+        public void ATaggedNonEmptyStringIsUnaffected()
+        {
+            // c0            tag(0)
+            //    63 666f6f  "foo"
+            const string hexBuffer = "C063666F6F";
+
+            CborValue value = Cbor.Deserialize<CborValue>(hexBuffer.HexToBytes());
+
+            Assert.Equal(0UL, value.SemanticTag);
+            Assert.Equal("foo", value.Value<string>());
+            Helper.TestWrite(value, hexBuffer);
+            Assert.Null(((CborValue)"foo").SemanticTag);
+        }
+
+        /// <summary>
+        /// The guard the issue asks for: every instance any type hands out from a static cache must
+        /// come from a type that overrides <c>WithSemanticTag</c>, so the next type that starts
+        /// caching does not repeat this.
+        /// </summary>
+        /// <remarks>
+        /// Driven off the caches themselves rather than off a list of type names, which is the point:
+        /// a hand-maintained list is exactly what missed <see cref="CborString"/>. Reflection reads
+        /// the static <see cref="CborValue"/>-typed fields of every type in the object model —
+        /// including <see cref="CborValue"/>'s own, which is where the shared null lives — and asserts
+        /// on the runtime type of each cached instance.
+        /// </remarks>
+        [Fact]
+        public void EveryCachedInstanceComesFromATypeThatCopiesBeforeTagging()
+        {
+            List<Type> cachingTypes = CachedInstances()
+                .Select(instance => instance.GetType())
+                .Distinct()
+                .ToList();
+
+            // The sweep is worthless if it finds nothing; CborString is the type this issue is about.
+            Assert.Contains(typeof(CborString), cachingTypes);
+            Assert.True(cachingTypes.Count > 1, "expected several caching types, found " + cachingTypes.Count);
+
+            List<Type> taggingInPlace = cachingTypes.Where(type => !OverridesWithSemanticTag(type)).ToList();
+
+            Assert.True(
+                taggingInPlace.Count == 0,
+                "these types hand out shared instances but tag in place: "
+                    + string.Join(", ", taggingInPlace.Select(type => type.Name)));
+        }
+
+        private static IEnumerable<CborValue> CachedInstances()
+        {
+            IEnumerable<Type> objectModelTypes = typeof(CborValue).Assembly
+                .GetTypes()
+                .Where(type => typeof(CborValue).IsAssignableFrom(type));
+
+            foreach (Type type in objectModelTypes)
+            {
+                FieldInfo[] fields = type.GetFields(
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+
+                foreach (FieldInfo field in fields)
+                {
+                    object value = field.GetValue(null);
+
+                    if (value is CborValue cborValue)
+                    {
+                        yield return cborValue;
+                    }
+                    else if (value is IEnumerable<CborValue> cborValues)
+                    {
+                        foreach (CborValue item in cborValues)
+                        {
+                            yield return item;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static bool OverridesWithSemanticTag(Type type)
+        {
+            MethodInfo method = type.GetMethod(
+                "WithSemanticTag",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+            return method != null && method.DeclaringType == type;
+        }
+    }
+}

--- a/src/Dahomey.Cbor/ObjectModel/CborString.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborString.cs
@@ -15,6 +15,16 @@ namespace Dahomey.Cbor.ObjectModel
             _value = value ?? throw new ArgumentOutOfRangeException(nameof(value));
         }
 
+        /// <summary>
+        /// Copies before tagging: CborString hands out a shared instance for the empty string, so
+        /// tagging in place would attach the tag to every empty string in the process. See
+        /// <see cref="CborValue.WithSemanticTag"/>.
+        /// </summary>
+        internal override CborValue WithSemanticTag(ulong semanticTag)
+        {
+            return new CborString(_value) { SemanticTag = semanticTag };
+        }
+
         public override T Value<T>()
         {
             return Primitive<string, T>.Converter(_value);

--- a/src/Dahomey.Cbor/ObjectModel/CborValue.cs
+++ b/src/Dahomey.Cbor/ObjectModel/CborValue.cs
@@ -23,7 +23,8 @@ namespace Dahomey.Cbor.ObjectModel
         /// Several value types hand out shared instances — <see cref="CborPositive"/> and
         /// <see cref="CborNegative"/> for small integers, <see cref="CborSingle"/>,
         /// <see cref="CborDouble"/> and <see cref="CborDecimal"/> for small whole numbers,
-        /// <see cref="CborBoolean"/> for both values, and <see cref="Null"/>. Assigning
+        /// <see cref="CborBoolean"/> for both values, <see cref="CborString"/> for the empty string,
+        /// and <see cref="Null"/>. Assigning
         /// <see cref="SemanticTag"/> to one of those would attach the tag to every occurrence of that
         /// value in the process, in documents that never carried it and in values built in code. Those
         /// types override this to copy first; the rest, which are constructed fresh per value, tag in

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -63,8 +63,8 @@ namespace Dahomey.Cbor.Serialization.Converters
             CborValue cborValue = ReadCborValue(ref reader);
 
             // WithSemanticTag rather than assigning SemanticTag: small integers, common floats, both
-            // booleans and null are shared instances, and stamping a tag on one of those would tag
-            // every occurrence of that value in the process.
+            // booleans, the empty string and null are shared instances, and stamping a tag on one of
+            // those would tag every occurrence of that value in the process.
             return hasSemanticTag ? cborValue.WithSemanticTag(semanticTag) : cborValue;
         }
 


### PR DESCRIPTION
Closes #172.

`CborString` is the one type that hands out a shared instance without overriding `WithSemanticTag`, so deserializing a tagged empty text string stamped the tag onto the process-wide `_empty` instance:

```
C0 60      tag(0) + empty text string
```

Every `""` in the process then carried tag 0 — empty strings built in code, and empty strings decoded from documents that never carried a tag. Since #165 made the write path emit tags, that is wrong bytes rather than a stray annotation: an untagged `[""]` serialized as `81 C0 60`.

Fixed the way the other sharers are — copy first, tag the copy:

```csharp
internal override CborValue WithSemanticTag(ulong semanticTag)
{
    return new CborString(_value) { SemanticTag = semanticTag };
}
```

Three places enumerate the types that share instances — the doc comment on `CborValue.WithSemanticTag`, the comment in `CborValueConverter.Read`, and the `remarks` on the #165 tests. All three now list the empty string. A hand-maintained list going stale is the root cause of this issue, so fixing only the one nearest the bug would have left the same trap set.

## Tests

`Issues/Issue0172.cs`: the repro from the issue, the bytes (an untagged empty string still writes as `60`, both read after a tagged document and built in code), the tagged round trip, and a non-empty string left unaffected.

Plus the guard the issue asked for — a reflection sweep over every static `CborValue`-typed field in the object model, asserting each cached instance comes from a type that overrides `WithSemanticTag`. It is driven off the caches themselves rather than a list of type names, which is the point. It currently reaches 809 cached instances across 8 types. Its blind spot is worth stating: it only sees instances reachable from static fields at reflection time, so a future lazily-populated cache would be invisible to it. Nothing like that exists today.

Verified red without the fix: 3 of the 5 tests fail, including the sweep. The other two are round-trip and no-regression tests that pass either way.

## Validation

Local: 1326 tests pass on `net10.0` and on `net8.0`, 35 generator tests on `net10.0` and `net8.0`, and a `-c Release` build and test run matching CI.

`net9.0` and `netstandard2.0` were not runnable in the environment this was written in — no .NET 9 runtime is packaged for Ubuntu noble, and `netstandard2.0` is a library target with no test host. Both compile; CI runs `dotnet test` without `-f`, so it is what covers the `net9.0` test run.

## Known, pre-existing, not addressed here

`CborString.Equals` and `GetHashCode` ignore `SemanticTag`, so a tagged `""` and an untagged `""` still collide as map keys. That is consistent with every other sharer type and predates this change.