### PR TITLE
Read a data item behind stacked semantic tags, closes #183

### DIFF
--- a/src/Dahomey.Cbor.Tests/Issues/Issue0183.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0183.cs
@@ -1,0 +1,214 @@
+using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using System;
+using System.Buffers;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #183: a data item behind more than one semantic tag was decoded from the wrong bytes.
+    /// No exception — the caller got a plausible wrong number.
+    /// </summary>
+    /// <remarks>
+    /// Two arms both assumed a tag comes alone. <c>GetCurrentDataItemType</c> stepped over the second
+    /// tag with <c>Advance(1)</c> after <c>GetHeader()</c> had already taken that tag's head, so it
+    /// swallowed the head of the tagged item and decoded the next byte as the value; and
+    /// <c>SkipSemanticTag</c> skipped one tag only, leaving the second standing where every caller
+    /// expected the item's own header — <c>SkipDataItem</c> read it as "already skipped" and returned
+    /// with the item still in the buffer, desynchronising the rest of the document.
+    /// <para>
+    /// The depth matters, and not monotonically: the faulty arm consumed two bytes where it should
+    /// have consumed one, so an even number of stacked tags resynchronised by accident and an odd
+    /// number landed mid-item. The theories below therefore run every depth from 0 to 4 rather than
+    /// one "nested" case, and they run it on both routes — straight to a converter, and through
+    /// <see cref="CborValue"/>, which consumes one tag itself before dispatching and so enters at the
+    /// other parity.
+    /// </para>
+    /// <para>
+    /// What is still lost above one tag is the tag itself: <see cref="CborValue.SemanticTag"/> holds
+    /// one, and keeps the outermost. That is the intended shortfall — RFC 8949 §3.4 permits the
+    /// nesting, and a decoder that drops a tag it has nowhere to put is a different thing from one
+    /// that returns the wrong value.
+    /// </para>
+    /// </remarks>
+    public class Issue0183
+    {
+        // 19 012c -- 300, two bytes of argument behind the header, so a one-byte slip is visible in
+        // the value rather than hidden in a single-byte item.
+        private const string Value300 = "19012C";
+
+        // c1 -- tag(1), epoch-based date-time
+        private const string Tag1 = "C1";
+
+        // d8 64 -- tag(100), a tag whose head is two bytes: Advance(1) could never have stepped over
+        // this one whole, however many of them there are.
+        private const string Tag100 = "D864";
+
+        private static readonly DateTime s_epochPlus300Seconds =
+            new DateTime(1970, 1, 1, 0, 5, 0, DateTimeKind.Utc);
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(Tag1)]
+        [InlineData(Tag1 + Tag1)]
+        [InlineData(Tag1 + Tag1 + Tag1)]
+        [InlineData(Tag1 + Tag1 + Tag1 + Tag1)]
+        public void AStackOfTagsDoesNotShiftTheValueReadIntoCborValue(string tags)
+        {
+            CborValue value = Helper.Read<CborValue>(tags + Value300);
+
+            Assert.Equal(300, value.Value<int>());
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(Tag1)]
+        [InlineData(Tag1 + Tag1)]
+        [InlineData(Tag1 + Tag1 + Tag1)]
+        [InlineData(Tag1 + Tag1 + Tag1 + Tag1)]
+        public void AStackOfTagsDoesNotShiftTheValueReadIntoAnInteger(string tags)
+        {
+            // The integer converters never reach GetCurrentDataItemType: they call SkipSemanticTag and
+            // then expect an integer major type. Before the fix the second tag was that major type,
+            // so this route failed loudly where the two above failed silently. Both are wrong.
+            Assert.Equal(300, Helper.Read<int>(tags + Value300));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(Tag1)]
+        [InlineData(Tag1 + Tag1)]
+        [InlineData(Tag1 + Tag1 + Tag1)]
+        [InlineData(Tag1 + Tag1 + Tag1 + Tag1)]
+        public void AStackOfTagsDoesNotShiftADateTime(string tags)
+        {
+            Assert.Equal(s_epochPlus300Seconds, Helper.Read<DateTime>(tags + Value300));
+        }
+
+        /// <summary>
+        /// The original sighting, and the same defect wearing different clothes: the string's <c>74</c>
+        /// header was eaten and its first character — ASCII <c>'2'</c>, <c>0x32</c>, a CBOR negative
+        /// integer of −19 — was decoded as the value, giving epoch − 19s.
+        /// </summary>
+        [Fact]
+        public void AStackOfTagsDoesNotShiftAnRfc3339DateTime()
+        {
+            // c0 c0                                    tag(0) tag(0)
+            //    74 "2020-01-02T03:04:05Z"             RFC 3339 date-time
+            DateTime dateTime = Helper.Read<DateTime>("C0C074323032302D30312D30325430333A30343A30355A");
+
+            Assert.Equal(new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc), dateTime);
+        }
+
+        [Theory]
+        [InlineData(Tag100)]
+        [InlineData(Tag100 + Tag100)]
+        [InlineData(Tag100 + Tag100 + Tag100)]
+        [InlineData(Tag1 + Tag100)]
+        [InlineData(Tag100 + Tag1)]
+        public void ATagWithAMultiByteHeadIsSteppedOverWhole(string tags)
+        {
+            Assert.Equal(300, Helper.Read<int>(tags + Value300));
+            Assert.Equal(300, Helper.Read<CborValue>(tags + Value300).Value<int>());
+        }
+
+        [Theory]
+        [InlineData(Tag1, 1ul)]
+        [InlineData(Tag1 + Tag1, 1ul)]
+        [InlineData(Tag1 + Tag1 + Tag1, 1ul)]
+        [InlineData(Tag100 + Tag1, 100ul)]
+        public void TheOutermostTagOfAStackIsTheOneCborValueKeeps(string tags, ulong expectedTag)
+        {
+            CborValue value = Helper.Read<CborValue>(tags + Value300);
+
+            Assert.Equal(expectedTag, value.SemanticTag);
+        }
+
+        /// <summary>
+        /// What the two arms disagreed about, stated directly: after reporting the type, the reader is
+        /// still standing on the item's own header, whatever the tags in front of it were.
+        /// </summary>
+        [Theory]
+        [InlineData("")]
+        [InlineData(Tag1)]
+        [InlineData(Tag1 + Tag1)]
+        [InlineData(Tag1 + Tag1 + Tag1)]
+        [InlineData(Tag100 + Tag1)]
+        public void GetCurrentDataItemTypeLeavesTheItemsOwnHeaderInPlace(string tags)
+        {
+            OnEveryReaderShape(tags + Value300, (ref CborReader reader) =>
+            {
+                Assert.Equal(CborDataItemType.Unsigned, reader.GetCurrentDataItemType());
+                Assert.Equal(300ul, reader.ReadUInt64());
+                Assert.False(reader.DataAvailable);
+            });
+        }
+
+        /// <summary>
+        /// The skip side of the same assumption: a stacked tag used to leave its item in the buffer,
+        /// so whatever came next was read from the middle of the item that was supposed to be gone.
+        /// </summary>
+        [Theory]
+        [InlineData("")]
+        [InlineData(Tag1)]
+        [InlineData(Tag1 + Tag1)]
+        [InlineData(Tag1 + Tag1 + Tag1)]
+        [InlineData(Tag100 + Tag1)]
+        public void SkipDataItemTakesTheTagsAndTheItemTheyTag(string tags)
+        {
+            // ... 05  -- the item after the tagged one, which a short skip would not reach
+            OnEveryReaderShape(tags + Value300 + "05", (ref CborReader reader) =>
+            {
+                reader.SkipDataItem();
+
+                Assert.Equal(5, reader.ReadInt32());
+                Assert.False(reader.DataAvailable);
+            });
+        }
+
+        public class Holder
+        {
+            public int B { get; set; }
+        }
+
+        /// <summary>
+        /// The skip reached from the object model: an unmapped member is skipped with
+        /// <c>SkipDataItem</c>, so a stacked tag on its value used to eat the member after it.
+        /// </summary>
+        [Fact]
+        public void AStackedTagOnAnUnmappedMemberDoesNotSwallowTheFollowingPair()
+        {
+            // a2                     map(2)
+            //    61 41               "A"
+            //    c1 c1 19 012c       tag(1) tag(1) 300
+            //    61 42               "B"
+            //    01                  1
+            Holder holder = Cbor.Deserialize<Holder>("A26141C1C119012C614201".HexToBytes());
+
+            Assert.Equal(1, holder.B);
+        }
+
+        private delegate void ReaderProbe(ref CborReader reader);
+
+        /// <summary>
+        /// Runs a probe over the three shapes a <see cref="CborReader"/> can be built on. The
+        /// single-segment sequence and the byte-per-segment one take different paths through
+        /// <c>GetBytes</c>, and this defect was about how many bytes were taken.
+        /// </summary>
+        private static void OnEveryReaderShape(string hexBuffer, ReaderProbe probe)
+        {
+            byte[] buffer = hexBuffer.HexToBytes();
+
+            CborReader spanReader = new CborReader(buffer.AsSpan());
+            probe(ref spanReader);
+
+            CborReader sequenceReader = new CborReader(new ReadOnlySequence<byte>(buffer));
+            probe(ref sequenceReader);
+
+            CborReader fragmentedReader = new CborReader(Helper.Fragmentize(buffer));
+            probe(ref fragmentedReader);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0183.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0183.cs
@@ -190,6 +190,33 @@ namespace Dahomey.Cbor.Tests.Issues
             Assert.Equal(1, holder.B);
         }
 
+        /// <summary>
+        /// The depth of the stack is not a limit on correctness, and reading it does not grow the call
+        /// stack with it.
+        /// </summary>
+        /// <remarks>
+        /// <c>GetCurrentDataItemType</c> recursed once per tag, and stepping over the stack in a loop
+        /// is what removes that. The frames were the risk rather than the observed failure: at this
+        /// depth the old code returned a wrong value (1, not 300) rather than overflowing, so what this
+        /// pins is the value, with the loop as the reason it holds at any length. A tag is not nesting,
+        /// so <see cref="CborOptions.MaxDepth"/> never bounded this — only the loop does.
+        /// </remarks>
+        [Fact]
+        public void ALongStackOfTagsIsReadWithoutRecursion()
+        {
+            const int tagCount = 200_000;
+
+            byte[] buffer = new byte[tagCount + 3];
+            buffer.AsSpan(0, tagCount).Fill(0xC1);
+            Value300.HexToBytes().CopyTo(buffer.AsSpan(tagCount));
+
+            CborReader reader = new CborReader(buffer.AsSpan());
+
+            Assert.Equal(CborDataItemType.Unsigned, reader.GetCurrentDataItemType());
+            Assert.Equal(300ul, reader.ReadUInt64());
+            Assert.False(reader.DataAvailable);
+        }
+
         private delegate void ReaderProbe(ref CborReader reader);
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/SemanticTagProbeTests.cs
+++ b/src/Dahomey.Cbor.Tests/SemanticTagProbeTests.cs
@@ -381,26 +381,40 @@ namespace Dahomey.Cbor.Tests
         }
 
         /// <summary>
-        /// Nested semantic tags do not work, on this branch or on master, and this change neither
-        /// fixes nor worsens them.
+        /// Nested semantic tags read the value they tag. Every tag but the outermost is dropped, since
+        /// only a converter that reads its own tag has anywhere to put one.
         /// </summary>
         /// <remarks>
-        /// A read entry point opens with a single <c>SkipSemanticTag()</c>, so the second tag arrives
-        /// where a data item is expected. The message is asserted rather than just the type: it is
-        /// what says the failure is the second tag being met as a value, so a future change that makes
-        /// nested tags work, or that breaks the first tag instead, cannot leave this test green.
+        /// A read entry point opens with <c>SkipSemanticTag()</c>, which steps over the whole stack.
+        /// It used to step over one, so the second tag arrived where a data item was expected and this
+        /// threw <c>Invalid major type SemanticTag</c> — the tolerable half of issue #183, whose other
+        /// half returned a wrong value in silence. See <see cref="Issues.Issue0183"/>.
         /// </remarks>
         [Fact]
-        public void NestedSemanticTagsAreNotSupported()
+        public void NestedSemanticTagsReadTheValueTheyTag()
         {
             // a1                  map(1)
             //    65 56616c7565    "Value"
             //    c1 c0            tag(1) tag(0)
             //    01               1
-            CborException exception = Assert.Throws<CborException>(
-                () => Cbor.Deserialize<IntHolder>("A16556616C7565C1C001".HexToBytes()));
+            IntHolder holder = Cbor.Deserialize<IntHolder>("A16556616C7565C1C001".HexToBytes());
 
-            Assert.Equal("[9] Invalid major type SemanticTag. Failed to deserialize from \"$.Value\".", exception.Message);
+            Assert.Equal(1, holder.Value);
+        }
+
+        /// <summary>
+        /// A converter reading its own tag still gets the outermost one, and the tags behind it do not
+        /// disturb the value. This is the one place where "the stack is skipped" and "the tag reaches
+        /// its converter" have to hold at once.
+        /// </summary>
+        [Fact]
+        public void AConverterReadingItsOwnTagGetsTheOutermostOfANestedStack()
+        {
+            // c1 c0 01  -- tag(1) tag(0) 1
+            Tagged tagged = Cbor.Deserialize<Tagged>("C1C001".HexToBytes());
+
+            Assert.Equal(1ul, tagged.Tag);
+            Assert.Equal(1, tagged.Value);
         }
     }
 }

--- a/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
+++ b/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
@@ -739,19 +739,19 @@ namespace Dahomey.Cbor.Tests
         public void ATypedArrayConverterIsNoMoreLenientAboutNestedTagsThanAnArrayConverter()
         {
             // int[] goes through TypedArrayConverter and string[] through ArrayConverter. What matters
-            // is that they agree: reading an array skips a tag twice, once in ReadNull and once in
-            // ReadBeginArray, so two stacked tags are accepted and three are not. Consuming the tag in
-            // TypedArrayConverter.Read as well would let the typed path take a third, accepting a
-            // nesting the plain path rejects.
+            // is that they agree, whatever the depth: ReadBeginArray skips the whole stack of tags in
+            // front of the array, so neither path has a nesting limit for the other to disagree with.
+            // Consuming a tag in TypedArrayConverter.Read as well would take one the plain path leaves
+            // for the array's own converter, which is the disagreement this pins.
             CborOptions options = TypedArrayOptions();
 
             // D827 tag(39) C1 tag(1) 820102 [1, 2]
             Assert.Equal(new[] { 1, 2 }, Helper.Read<int[]>("D827C1820102", options));
             Assert.Equal(new[] { "a", "b" }, Helper.Read<string[]>("D827C18261616162", options));
 
-            // D827 tag(39) C1 tag(1) C1 tag(1) 820102 [1, 2] -- one tag too many for either
-            AssertThrowsCborException(() => Helper.Read<int[]>("D827C1C1820102", options));
-            AssertThrowsCborException(() => Helper.Read<string[]>("D827C1C18261616162", options));
+            // D827 tag(39) C1 tag(1) C1 tag(1) 820102 [1, 2] -- deeper, and still the same on both
+            Assert.Equal(new[] { 1, 2 }, Helper.Read<int[]>("D827C1C1820102", options));
+            Assert.Equal(new[] { "a", "b" }, Helper.Read<string[]>("D827C1C18261616162", options));
         }
 
         [Fact]

--- a/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
+++ b/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
@@ -738,11 +738,16 @@ namespace Dahomey.Cbor.Tests
         [Fact]
         public void ATypedArrayConverterIsNoMoreLenientAboutNestedTagsThanAnArrayConverter()
         {
-            // int[] goes through TypedArrayConverter and string[] through ArrayConverter. What matters
-            // is that they agree, whatever the depth: ReadBeginArray skips the whole stack of tags in
-            // front of the array, so neither path has a nesting limit for the other to disagree with.
-            // Consuming a tag in TypedArrayConverter.Read as well would take one the plain path leaves
-            // for the array's own converter, which is the disagreement this pins.
+            // int[] goes through TypedArrayConverter and string[] through ArrayConverter, and what
+            // matters is that they agree at every depth.
+            //
+            // This used to be a tripwire on TypedArrayConverter's ReturnToBookmark: skipping was
+            // limited to one tag, so a typed path that kept a declined tag consumed accepted a nesting
+            // the plain path rejected, and dropping the restore failed this test. It no longer does -
+            // SkipSemanticTag steps over the whole stack, so the restore cannot change what either
+            // path reads and nothing here can detect its removal. Measured, not assumed: with both
+            // ReturnToBookmark calls commented out the suite is green on this branch and red on the
+            // commit before it. What remains pinned is the agreement itself.
             CborOptions options = TypedArrayOptions();
 
             // D827 tag(39) C1 tag(1) 820102 [1, 2]

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -195,7 +195,13 @@ namespace Dahomey.Cbor.Serialization
                     return CborDataItemType.Map;
 
                 case CborMajorType.SemanticTag:
-                    Advance(1);
+                    // Unreachable: SkipSemanticTag above consumes the whole stack. Kept consuming the
+                    // tag by reading its argument rather than by byte count, because the byte count is
+                    // what this arm used to get wrong - Advance(1) skipped the head of the tagged item
+                    // on top of the tag head GetHeader had already taken, and could not have been
+                    // right anyway for a multi-byte tag head such as D8 64.
+                    ReadInteger();
+                    _state = CborReaderState.Data;
                     return GetCurrentDataItemType();
 
                 case CborMajorType.Primitive:
@@ -1022,14 +1028,35 @@ namespace Dahomey.Cbor.Serialization
             return majorType;
         }
 
+        /// <summary>
+        /// Steps over every semantic tag in front of the next data item, leaving the reader on the
+        /// item's own header.
+        /// </summary>
+        /// <remarks>
+        /// A loop rather than a single skip because RFC 8949 §3.4 lets tags stack - tag 1 over a
+        /// bignum is <c>C1 C2 ...</c> - and a caller that does not care about tags cares even less
+        /// about how many there were. Stopping after one left the second tag standing where the item's
+        /// header was expected, which every caller then misread in its own way: the integer reads
+        /// rejected it as a major type, and <see cref="SkipDataItem"/> treated the item as already
+        /// skipped and returned with it still in the buffer, desynchronising everything after it.
+        /// <para>
+        /// The tag is consumed by reading its argument, not by advancing a fixed number of bytes, so
+        /// a multi-byte tag head such as <c>D8 64</c> is stepped over whole.
+        /// </para>
+        /// <para>
+        /// Every tag but the outermost is lost, since nothing here has anywhere to put it - a
+        /// converter that wants its tag reads it with <see cref="TryReadSemanticTag"/> before the
+        /// value, and <see cref="ObjectModel.CborValue.SemanticTag"/> holds one tag. A lost tag is the
+        /// intended shortfall; a value decoded from the wrong bytes was not.
+        /// </para>
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SkipSemanticTag()
         {
-            if (Accept(CborMajorType.SemanticTag))
+            while (Accept(CborMajorType.SemanticTag))
             {
                 ReadInteger();
                 _state = CborReaderState.Data;
-                return;
             }
         }
 
@@ -1061,7 +1088,9 @@ namespace Dahomey.Cbor.Serialization
                     break;
 
                 case CborMajorType.SemanticTag:
-                    // Impossible - already skipped
+                    // Impossible - SkipSemanticTag above takes the whole stack. It used to take one,
+                    // which made this arm reachable for a nested tag and this method return with the
+                    // tagged item unread, leaving the buffer one item out of step.
                     break;
 
                 case CborMajorType.Primitive:

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractCollectionConverter.cs
@@ -65,8 +65,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                     }
                 }
 
-                // Some other tag, which CBOR says to ignore. Hand it back so the ReadNull below skips
-                // exactly one, as it did before typed arrays existed.
+                // Some other tag, which CBOR says to ignore. Hand it back so this converter takes only
+                // the tag it claims. It used to matter to the result - the ReadNull below skipped one
+                // tag, and this one had to be among them - but SkipSemanticTag now steps over the
+                // whole stack, so the restore no longer changes what is read. See
+                // TypedArrayConverter.Read.
                 reader.ReturnToBookmark(bookmark);
             }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/TypedArrayConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TypedArrayConverter.cs
@@ -75,8 +75,15 @@ namespace Dahomey.Cbor.Serialization.Converters
                 }
 
                 // Some other tag, which CBOR says to ignore. Hand it back rather than keeping it
-                // consumed: base.Read skips exactly one tag, so returning it here leaves this converter
-                // exactly as lenient about nesting as ArrayConverter, no more.
+                // consumed, so this converter takes only the tag it claims and leaves the rest to the
+                // reader.
+                //
+                // This no longer changes what is decoded. It did when SkipSemanticTag stepped over one
+                // tag: keeping this one consumed spent the single skip base.Read had, so the typed
+                // path accepted one more level of nesting than ArrayConverter. SkipSemanticTag now
+                // steps over the whole stack, so both paths read the same document at any depth with
+                // or without this restore, and no test can tell it is here. Kept because a converter
+                // that declines a tag should not have eaten it.
                 reader.ReturnToBookmark(bookmark);
             }
 


### PR DESCRIPTION
Closes #183.

A data item under more than one semantic tag was decoded from the wrong bytes, and no error was raised — the caller got a plausible wrong number. Two arms of `CborReader` assumed a tag comes alone.

## What was wrong

**`GetCurrentDataItemType`** stepped over the second tag with `Advance(1)`, after `GetHeader()` had already consumed that tag's head. It therefore swallowed the head of the tagged item and decoded the next byte as the value. The arm consumed two bytes where it should have consumed one, so an even number of stacked tags resynchronised by accident and an odd number landed mid-item — which is why the defect looked intermittent:

| document | `CborValue` before | after |
|---|---|---|
| `C1C1 19012C` | 300 | 300 |
| `C1C1C1 19012C` | **1** | 300 |

`C0 C0` over an RFC 3339 string — the original sighting — read the ASCII `'2'` (`0x32`, a CBOR negative integer of −19) as the value and returned epoch − 19s.

**`SkipSemanticTag`** skipped one tag only, leaving the second standing where every caller expected the item's own header. The integer reads rejected it as a major type (loud, but wrong), and `SkipDataItem` read it as "already skipped" and returned with the item still in the buffer, putting everything after it one item out of step — silent, and reachable from the object model whenever an unmapped member's value carries stacked tags.

## The fix

Both arms now consume a tag by reading its argument rather than by byte count, so a multi-byte tag head such as `D8 64` is stepped over whole — something `Advance(1)` could never do — and `SkipSemanticTag` loops over the stack instead of taking one. That puts the whole read path on one rule, and takes the recursion a long tag stack used to drive through `GetCurrentDataItemType` off the behavioural path.

Every tag but the outermost is still dropped: `CborValue.SemanticTag` holds one, and a converter that wants its own tag reads it with `TryReadSemanticTag` before the value. That is the intended shortfall, as the issue notes — a value decoded from the wrong bytes was not.

## Scope note

Fixing `GetCurrentDataItemType` alone — the issue's literal suggestion — leaves `SkipDataItem` desynchronising the buffer on the same documents, which is the same silent-wrong-value failure the issue is about. Hence the second change. Say the word if you would rather land only the narrow arm.

## What skipping the whole stack made inert

`TypedArrayConverter` and `AbstractCollectionConverter` hand back a tag they decline to handle, and both comments explained that restore as feeding a skip that took exactly one tag. That is no longer what happens: with the whole stack skipped, neither path reads a document differently with or without the restore. Measured, not assumed — with both `ReturnToBookmark` calls commented out the suite is green on this branch and red on the commit before it, on the typed-array agreement test, which was the tripwire.

The calls are kept, on the grounds that a converter declining a tag should not have eaten it, but the comments now say plainly that they are no longer load-bearing, and the agreement test records what stopped being detectable rather than claiming a guard it no longer provides. If you would rather drop the two `ReturnToBookmark` calls outright, that is a one-line change either way — I left the decision to you.

## Behaviour change to note in release notes

A document that used to throw `Invalid major type SemanticTag` now decodes. Anyone relying on that exception to reject stacked tags is affected.

## Tests

`Issues/Issue0183.cs` covers stacked tags at depths 0–4 (the parity matters, so every depth runs rather than one "nested" case), on both routes — straight to a converter and through `CborValue`, which consumes a tag itself and so enters at the other parity — plus a multi-byte tag head, the RFC 3339 sighting, `GetCurrentDataItemType` leaving the item's header in place, `SkipDataItem` reaching the item after the tagged one, and the object-model route through an unmapped member. Reader probes run on all three reader shapes (span, single-segment sequence, byte-per-segment sequence). 17 of its 37 cases fail on the base commit.

One of those pins the length of the stack. `GetCurrentDataItemType` recursed once per tag, which the loop removes; the frames were the risk rather than the observed failure — at 200,000 tags the old code returned 1 instead of 300 rather than overflowing — so the test pins the value, with the loop as the reason it holds at any length. `MaxDepth` never covered this, a tag being nesting to nobody.

Two existing tests pinned the old limit and now assert the value instead: `NestedSemanticTagsAreNotSupported` (renamed to `NestedSemanticTagsReadTheValueTheyTag`, joined by a case checking a tag-reading converter still gets the outermost tag), and the depth assertions in `ATypedArrayConverterIsNoMoreLenientAboutNestedTagsThanAnArrayConverter`.

Full suite green on net8.0 and net10.0: 1364 tests, plus 35 generator tests.

## Adjacent, not fixed here

- `CborDataItemScanner` charges one nesting level per tag (`ScanItem`'s `case 6` passes `remainingDepth - 1`, in both the span and sequence variants), so it reports `TooDeep` on a stack the reader now reads happily. The asymmetry predates this PR — the reader was unbounded here before too, just recursively — but the new test pins the reader side, so the two components are now on record as disagreeing about the same document.
- `SkipDataItem` → `SkipArray`/`SkipMap` recurse without going through `EnterNestedItem`, so `MaxDepth` does not bound them and an unmapped member holding deeply nested arrays is still an unbounded-recursion path.
- An RFC 8746 typed array behind another tag (`C1 D84E 48…`) is still rejected: the collection converters inspect exactly one tag, and the whole-stack skip then swallows the typed-array tag. Unchanged by this PR, but the obvious next case now that "tags stack" is the stated rule.