### PR TITLE
Refuse a mapping that puts two members under one name, closes #177

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ High-performance [CBOR](https://cbor.io/) serialization framework for .Net (C#)
 * Support for structs
 * Support for RFC 8746 typed arrays, opt-in per direction (CborOptions.TypedArrayMode)
 * Duplicate map keys rejected on every decode target, with a last-wins opt-out (CborOptions.DuplicateKeyMode)
+* Ambiguous mappings — two members of a type under one CBOR name — refused when the mapping is built
 
 ## Installation
 ### NuGet
@@ -458,8 +459,25 @@ The **discriminator** is refused when repeated, even though it is a key of the m
 member of the type: two readers disagreeing about which occurrence names the type is how one document
 comes to mean two things.
 
-One case the policy does not reach: **a type mapping two members to the same CBOR name** — two
-``[CborProperty("X")]``, say — writes a document with a repeated key that it then cannot read back.
-The mapping is ambiguous in both directions, since only one of the two members can ever be read from
-key ``X``, so it is worth removing rather than working around; ``DuplicateKeyMode.LastWins`` will read
-such a document if you have one already.
+One case is settled earlier than the decode, because no answer at decode time is right: **a type
+mapping two members to the same CBOR name** used to write a document with a repeated key that it then
+could not read back. The mapping itself is now refused, the first time the type is serialized or
+deserialized, naming the type and the colliding name:
+
+```
+class/struct Aliased maps several fields/properties to the member name 'X'
+```
+
+The mapping is ambiguous in both directions — only one of the two members can ever be read from key
+``X``, and writing both is not representable — so there is nothing for ``DuplicateKeyMode`` to decide.
+``[CborProperty("X")]`` twice is the visible way in; a naming convention that folds two member names
+into one, or a mapping API call that maps a member the conventions already covered, arrives at the
+same place with nothing in the source looking wrong. Whichever route, the fix is to give the two
+members distinct names or to drop one of them.
+
+> **Behaviour change.** Such a type used to serialize, so this is a new exception at first use for a
+> type that "worked". What it wrote was a document whose second member was unreadable — silently
+> discarded before #169, refused as a duplicate key after it — so the type never round-tripped; the
+> exception names the mapping instead of leaving it to be found in the bytes. A document already
+> written by one of these mappings still reads with ``DuplicateKeyMode.LastWins``, against a type
+> whose mapping no longer collides.

--- a/README.md
+++ b/README.md
@@ -470,10 +470,21 @@ class/struct Aliased maps several fields/properties to the member name 'X'
 
 The mapping is ambiguous in both directions — only one of the two members can ever be read from key
 ``X``, and writing both is not representable — so there is nothing for ``DuplicateKeyMode`` to decide.
-``[CborProperty("X")]`` twice is the visible way in; a naming convention that folds two member names
-into one, or a mapping API call that maps a member the conventions already covered, arrives at the
-same place with nothing in the source looking wrong. Whichever route, the fix is to give the two
-members distinct names or to drop one of them.
+``[CborProperty("X")]`` twice is the visible way in. Three others reach the same place with nothing in
+the source looking wrong:
+
+* a **naming convention** that folds two member names into one — ``Id`` and ``ID`` under
+  ``LowerCaseNamingConvention``;
+* a **mapping API call** over a member the conventions already covered — ``MapMember`` after
+  ``AutoMap`` without a ``ClearMemberMappings`` between them, or without a new name;
+* a member that **hides a base member** of the same name with ``new`` rather than ``override``.
+  Reflection reports both declarations whenever their signatures differ, so both are mapped. Hiding
+  that keeps the signature exactly — ``int`` over ``int`` — is folded by reflection itself and maps
+  once, so only a hide that changes the type or turns a property into a field collides.
+
+Give the two members distinct names, or drop one. Where the collision comes from a base type you do
+not own, ``[CborIgnore]`` on the member you do own removes it from the mapping, and
+``ClearMemberMappings()`` followed by explicit ``MapMember`` calls decides the whole mapping by hand.
 
 > **Behaviour change.** Such a type used to serialize, so this is a new exception at first use for a
 > type that "worked". What it wrote was a document whose second member was unreadable — silently

--- a/README.md
+++ b/README.md
@@ -478,11 +478,13 @@ the source looking wrong:
 * a **mapping API call** over a member the conventions already covered — ``MapMember`` after
   ``AutoMap`` without a ``ClearMemberMappings`` between them, or without a new name;
 * a member that **hides a base member** of the same name with ``new`` rather than ``override``, which
-  reports both declarations and so maps both, under the one name. A hidden **field** always collides,
-  whatever its type: field lookup does no folding at all, so ``int`` over ``int`` is two members.
-  A hidden **property** collides only where the two signatures differ — ``string`` over ``object``, or
-  a property over a field — since property lookup folds a hide that keeps the signature exactly.
-  ``override`` never collides.
+  reports both declarations and so maps both, under the one name. Where the hiding member is a
+  **field** this always happens, whatever the two types are: field lookup folds nothing, so ``int``
+  over ``int`` is two members. Where it is a **property**, the pair is folded only when the two are
+  identical *as declared* — which is narrower than it sounds, since a generic base declares
+  ``T Value`` and a derived ``new int Value`` over a ``Base<int>`` differs from it as declared and so
+  collides, despite reading as the same type at the source. ``override`` never collides, and neither
+  does a hierarchy of interfaces, whose members are reported one interface at a time.
 
 Give the two members distinct names, or drop one. Where the collision comes from a base type you do
 not own, ``[CborIgnore]`` on the member you do own removes it from the mapping, and

--- a/README.md
+++ b/README.md
@@ -477,10 +477,12 @@ the source looking wrong:
   ``LowerCaseNamingConvention``;
 * a **mapping API call** over a member the conventions already covered — ``MapMember`` after
   ``AutoMap`` without a ``ClearMemberMappings`` between them, or without a new name;
-* a member that **hides a base member** of the same name with ``new`` rather than ``override``.
-  Reflection reports both declarations whenever their signatures differ, so both are mapped. Hiding
-  that keeps the signature exactly — ``int`` over ``int`` — is folded by reflection itself and maps
-  once, so only a hide that changes the type or turns a property into a field collides.
+* a member that **hides a base member** of the same name with ``new`` rather than ``override``, which
+  reports both declarations and so maps both, under the one name. A hidden **field** always collides,
+  whatever its type: field lookup does no folding at all, so ``int`` over ``int`` is two members.
+  A hidden **property** collides only where the two signatures differ — ``string`` over ``object``, or
+  a property over a field — since property lookup folds a hide that keeps the signature exactly.
+  ``override`` never collides.
 
 Give the two members distinct names, or drop one. Where the collision comes from a base type you do
 not own, ``[CborIgnore]`` on the member you do own removes it from the mapping, and
@@ -492,3 +494,9 @@ not own, ``[CborIgnore]`` on the member you do own removes it from the mapping, 
 > exception names the mapping instead of leaving it to be found in the bytes. A document already
 > written by one of these mappings still reads with ``DuplicateKeyMode.LastWins``, against a type
 > whose mapping no longer collides.
+>
+> The utility type behind the member lookup, ``Dahomey.Cbor.Util.ByteBufferDictionary<T>``, is public,
+> and its ``Add`` changed with it: a key already present is now refused with an ``ArgumentException``
+> rather than silently replacing the entry, as ``Dictionary<TKey, TValue>.Add`` does. The type has
+> neither an indexer nor a removal, so code of your own that relied on ``Add`` overwriting has to keep
+> the keys it has added and build a fresh dictionary instead.

--- a/src/Dahomey.Cbor.Tests/ByteBufferDictionaryTests.cs
+++ b/src/Dahomey.Cbor.Tests/ByteBufferDictionaryTests.cs
@@ -79,20 +79,27 @@ namespace Dahomey.Cbor.Tests
         }
 
         /// <summary>
-        /// A key that merely passes through the nodes of a longer one is not a duplicate of it: the
-        /// segments it shares are the way to an entry, not an entry.
+        /// Sharing segments with an existing key is not being a duplicate of it, in either direction:
+        /// a key laid down through the nodes of an entry already there, and an entry already there
+        /// lying on the way to a longer key.
         /// </summary>
+        /// <remarks>
+        /// The longer-then-shorter order is the one <see cref="APrefixThatIsAlsoAKeyIsFound"/> covers.
+        /// Shorter first is what puts an entry on the path the longer key must extend, so it is the
+        /// order that would trip a duplicate check looking at the nodes it passes rather than the one
+        /// it lands on.
+        /// </remarks>
         [Fact]
-        public void AddingAPrefixOfAnExistingKeyIsNotADuplicate()
+        public void SharingSegmentsWithAnExistingKeyIsNotADuplicate()
         {
             ByteBufferDictionary<int> dictionary = new ByteBufferDictionary<int>();
-            dictionary.Add(Encoding.UTF8.GetBytes("PropertyAlpha"), 12);
             dictionary.Add(Encoding.UTF8.GetBytes("Property"), 13);
+            dictionary.Add(Encoding.UTF8.GetBytes("PropertyAlpha"), 12);
 
-            Assert.True(dictionary.TryGetValue(Encoding.UTF8.GetBytes("PropertyAlpha"), out int alpha));
-            Assert.Equal(12, alpha);
             Assert.True(dictionary.TryGetValue(Encoding.UTF8.GetBytes("Property"), out int property));
             Assert.Equal(13, property);
+            Assert.True(dictionary.TryGetValue(Encoding.UTF8.GetBytes("PropertyAlpha"), out int alpha));
+            Assert.Equal(12, alpha);
         }
 
         /// <summary>And a prefix that was itself added is found, being an entry in its own right.</summary>

--- a/src/Dahomey.Cbor.Tests/ByteBufferDictionaryTests.cs
+++ b/src/Dahomey.Cbor.Tests/ByteBufferDictionaryTests.cs
@@ -1,4 +1,5 @@
 ﻿using Dahomey.Cbor.Util;
+using System;
 using System.Text;
 using Xunit;
 
@@ -48,6 +49,50 @@ namespace Dahomey.Cbor.Tests
             Assert.False(dictionary.TryGetValue(Encoding.UTF8.GetBytes("Property"), out int _));
             Assert.True(dictionary.TryGetValue(Encoding.UTF8.GetBytes("PropertyAlpha"), out int found));
             Assert.Equal(12, found);
+        }
+
+        /// <summary>
+        /// Adding a key twice is refused rather than silently replacing the first entry.
+        /// </summary>
+        /// <remarks>
+        /// Every caller builds a lookup once from keys it believes distinct, so a repeat is a mistake
+        /// upstream — two members mapped to one CBOR name, issue #177 — and the entry it overwrote was
+        /// a member that could then never be read.
+        /// </remarks>
+        [Theory]
+        [InlineData("short1")]
+        [InlineData("eightchr")]
+        [InlineData("longervaluethaneightbytes")]
+        public void AddingTheSameKeyTwiceThrows(string key)
+        {
+            ByteBufferDictionary<int> dictionary = new ByteBufferDictionary<int>();
+            dictionary.Add(Encoding.UTF8.GetBytes(key), 12);
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(
+                () => dictionary.Add(Encoding.UTF8.GetBytes(key), 13));
+
+            Assert.Contains(key, ex.Message);
+
+            // and the entry that was there is the one that is still there
+            Assert.True(dictionary.TryGetValue(Encoding.UTF8.GetBytes(key), out int found));
+            Assert.Equal(12, found);
+        }
+
+        /// <summary>
+        /// A key that merely passes through the nodes of a longer one is not a duplicate of it: the
+        /// segments it shares are the way to an entry, not an entry.
+        /// </summary>
+        [Fact]
+        public void AddingAPrefixOfAnExistingKeyIsNotADuplicate()
+        {
+            ByteBufferDictionary<int> dictionary = new ByteBufferDictionary<int>();
+            dictionary.Add(Encoding.UTF8.GetBytes("PropertyAlpha"), 12);
+            dictionary.Add(Encoding.UTF8.GetBytes("Property"), 13);
+
+            Assert.True(dictionary.TryGetValue(Encoding.UTF8.GetBytes("PropertyAlpha"), out int alpha));
+            Assert.Equal(12, alpha);
+            Assert.True(dictionary.TryGetValue(Encoding.UTF8.GetBytes("Property"), out int property));
+            Assert.Equal(13, property);
         }
 
         /// <summary>And a prefix that was itself added is found, being an entry in its own right.</summary>

--- a/src/Dahomey.Cbor.Tests/ClassMemberModifierTests.cs
+++ b/src/Dahomey.Cbor.Tests/ClassMemberModifierTests.cs
@@ -227,6 +227,17 @@ namespace Dahomey.Cbor.Tests
             public static int WhatEver = 12;
         }
 
+        /// <summary>
+        /// <see cref="ObjectMapping{T}.AutoMap"/> takes the members the conventions reach — here the
+        /// readonly instance field — and the explicit calls add the ones they skip: a const and a
+        /// static field.
+        /// </summary>
+        /// <remarks>
+        /// <c>Name</c> is deliberately not mapped a second time. It used to be, and the expected
+        /// document carried the key twice as a result; a mapping that puts two members under one name
+        /// is now refused when it is built (issue #177), so mapping over what AutoMap already covered
+        /// throws rather than writing a document this type cannot read back.
+        /// </remarks>
         [Fact]
         public void TestWriteByApi()
         {
@@ -238,12 +249,11 @@ namespace Dahomey.Cbor.Tests
                     typeof(Tree)
                         .GetField(nameof(Tree.Id), BindingFlags.Public | BindingFlags.Static),
                     typeof(string));
-                objectMapping.MapMember(tree => tree.Name);
                 objectMapping.MapMember(tree => Tree.WhatEver);
             });
 
             Tree obj = new Tree();
-            const string hexBuffer = "A4644E616D65694C656D6F6E547265656249646A547265652E636C617373644E616D65694C656D6F6E547265656857686174457665720C";
+            const string hexBuffer = "A3644E616D65694C656D6F6E547265656249646A547265652E636C6173736857686174457665720C";
             Helper.TestWrite(obj, hexBuffer, null, options);
         }
     }

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0177.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0177.cs
@@ -1,5 +1,6 @@
 using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.Serialization.Conventions;
+using Dahomey.Cbor.Serialization.Converters;
 using System;
 using Xunit;
 
@@ -83,6 +84,15 @@ namespace Dahomey.Cbor.Tests.Issues
         public class BaseWithAnInt { public int Value { get; set; } }
         public class HidesWithTheSameSignature : BaseWithAnInt { public new int Value { get; set; } }
 
+        public class GenericBase<T> { public T Value { get; set; } }
+
+        /// <summary>
+        /// Identical to the hidden property at the source — <c>int</c> over a <c>GenericBase&lt;int&gt;</c>
+        /// — and still two members, because the folding compares the declarations rather than what the
+        /// type arguments make of them.
+        /// </summary>
+        public class HidesAGenericBaseMember : GenericBase<int> { public new int Value { get; set; } }
+
         [CborDiscriminator("collides")]
         public class CollidesWithDiscriminator
         {
@@ -120,11 +130,17 @@ namespace Dahomey.Cbor.Tests.Issues
         /// members that can be deserialized, so it cannot see a collision between members that are
         /// only written. Every test below that names a route into the collision pins the validation
         /// through this, leaving the two late-arrival tests to pin the other.
+        /// <para>
+        /// The clause is taken from the production constant rather than repeated here. An assertion
+        /// that a message lacks a literal can only fail open: reword the message alone and this keeps
+        /// passing while no longer distinguishing anything, with the two positive tests going red as
+        /// the only hint — and repairing those would leave this permanently vacuous.
+        /// </para>
         /// </remarks>
         private static CborException AssertRefusedByValidation(Action action)
         {
             CborException exception = AssertThrowsCborException(action);
-            Assert.DoesNotContain("after it was validated", exception.Message);
+            Assert.DoesNotContain(MemberMappingErrors.AddedAfterValidation, exception.Message);
             return exception;
         }
 
@@ -217,6 +233,24 @@ namespace Dahomey.Cbor.Tests.Issues
             Assert.Contains("'Value'", property.Message);
         }
 
+        /// <summary>
+        /// A property hiding one declared with a type parameter is not folded, however identical the
+        /// two look once the type argument is substituted.
+        /// </summary>
+        /// <remarks>
+        /// This is the shape that makes the folding rule worth stating precisely rather than as
+        /// "same signature": <c>int</c> over <c>GenericBase&lt;int&gt;.Value</c> reads as a hide that
+        /// keeps the signature, and is not one — the base declares <c>T</c>.
+        /// </remarks>
+        [Fact]
+        public void HidingAGenericBaseMemberIsRefused()
+        {
+            CborException ex = AssertRefusedByValidation(() => Helper.Write(new HidesAGenericBaseMember()));
+
+            Assert.Contains(nameof(HidesAGenericBaseMember), ex.Message);
+            Assert.Contains("'Value'", ex.Message);
+        }
+
         /// <summary>The signature-preserving case reflection folds for us, mapped once and written.</summary>
         [Fact]
         public void HidingWithTheSameSignatureIsUnaffected()
@@ -273,7 +307,7 @@ namespace Dahomey.Cbor.Tests.Issues
 
             Assert.Contains(nameof(DistinctNames), ex.Message);
             Assert.Contains("'X'", ex.Message);
-            Assert.Contains("after it was validated", ex.Message);
+            Assert.Contains(MemberMappingErrors.AddedAfterValidation, ex.Message);
         }
 
         /// <summary>
@@ -295,7 +329,7 @@ namespace Dahomey.Cbor.Tests.Issues
 
             Assert.Contains(nameof(DistinctIndexes), ex.Message);
             Assert.Contains("MemberIndex", ex.Message);
-            Assert.Contains("after it was validated", ex.Message);
+            Assert.Contains(MemberMappingErrors.AddedAfterValidation, ex.Message);
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0177.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0177.cs
@@ -60,6 +60,20 @@ namespace Dahomey.Cbor.Tests.Issues
             [CborProperty("X")] public int First { get; set; }
         }
 
+        /// <summary>Two members that are written and never read: the read lookup never sees either.</summary>
+        public class SerializeOnlyCollision
+        {
+            [CborProperty("X")] public int First => 1;
+            [CborProperty("X")] public int Second => 2;
+        }
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        public class DistinctIndexes
+        {
+            [CborProperty(1)] public int First { get; set; }
+            [CborProperty(2)] public int Second { get; set; }
+        }
+
         public class BaseWithAField { public int Value; }
         public class HidesAField : BaseWithAField { public new int Value; }
 
@@ -96,12 +110,30 @@ namespace Dahomey.Cbor.Tests.Issues
                 $"Expected a {nameof(CborException)} somewhere in the exception chain, got: {exception}");
         }
 
+        /// <summary>
+        /// Asserts the refusal came from the validation of the whole mapping, rather than from the
+        /// read lookup that catches what arrives after it.
+        /// </summary>
+        /// <remarks>
+        /// The two report the same kind of failure, so without this a test cannot say which one
+        /// answered — and they are not interchangeable: the read lookup is only ever offered the
+        /// members that can be deserialized, so it cannot see a collision between members that are
+        /// only written. Every test below that names a route into the collision pins the validation
+        /// through this, leaving the two late-arrival tests to pin the other.
+        /// </remarks>
+        private static CborException AssertRefusedByValidation(Action action)
+        {
+            CborException exception = AssertThrowsCborException(action);
+            Assert.DoesNotContain("after it was validated", exception.Message);
+            return exception;
+        }
+
         [Fact]
         public void WritingRefusesTheMapping()
         {
             TwoMembersOneName obj = new TwoMembersOneName { First = 1, Second = 2 };
 
-            CborException ex = AssertThrowsCborException(() => Helper.Write(obj));
+            CborException ex = AssertRefusedByValidation(() => Helper.Write(obj));
 
             Assert.Contains(nameof(TwoMembersOneName), ex.Message);
             Assert.Contains("'X'", ex.Message);
@@ -120,9 +152,9 @@ namespace Dahomey.Cbor.Tests.Issues
 
             CborOptions options = new CborOptions();
 
-            CborException first = AssertThrowsCborException(
+            CborException first = AssertRefusedByValidation(
                 () => Helper.Read<TwoMembersOneName>(hexBuffer, options));
-            CborException second = AssertThrowsCborException(
+            CborException second = AssertRefusedByValidation(
                 () => Helper.Read<TwoMembersOneName>(hexBuffer, options));
 
             Assert.Contains("'X'", first.Message);
@@ -138,7 +170,7 @@ namespace Dahomey.Cbor.Tests.Issues
         {
             FoldedByNamingConvention obj = new FoldedByNamingConvention();
 
-            CborException ex = AssertThrowsCborException(() => Helper.Write(obj));
+            CborException ex = AssertRefusedByValidation(() => Helper.Write(obj));
 
             Assert.Contains(nameof(FoldedByNamingConvention), ex.Message);
             Assert.Contains("'id'", ex.Message);
@@ -155,7 +187,7 @@ namespace Dahomey.Cbor.Tests.Issues
                 objectMapping.MapMember(o => o.First);
             });
 
-            CborException ex = AssertThrowsCborException(
+            CborException ex = AssertRefusedByValidation(
                 () => Helper.Write(new DistinctNames(), options));
 
             Assert.Contains("'X'", ex.Message);
@@ -167,17 +199,19 @@ namespace Dahomey.Cbor.Tests.Issues
         /// source at all.
         /// </summary>
         /// <remarks>
-        /// Reflection returns both declarations whenever their signatures differ, so both are mapped,
-        /// under the one name. Only a hiding member whose signature matches the hidden one exactly is
-        /// filtered out by reflection itself, which is why <see cref="HidesWithTheSameSignature"/>
-        /// maps once and is written normally. Refusing is what the other two shapes wrote before:
-        /// the key twice, the hidden member unreadable.
+        /// Reflection reports both declarations, so both are mapped, under the one name. The two
+        /// lookups differ in how much they fold: <c>GetProperties</c> drops a hiding property whose
+        /// signature matches the hidden one exactly, which is why
+        /// <see cref="HidesWithTheSameSignature"/> maps once and is written normally, while
+        /// <c>GetFields</c> folds nothing at all — <see cref="HidesAField"/> is <c>int</c> over
+        /// <c>int</c> and still collides. Refusing is what these shapes wrote before: the key twice,
+        /// the hidden member unreadable.
         /// </remarks>
         [Fact]
         public void AMemberHidingABaseMemberIsRefused()
         {
-            CborException field = AssertThrowsCborException(() => Helper.Write(new HidesAField()));
-            CborException property = AssertThrowsCborException(() => Helper.Write(new HidesAProperty()));
+            CborException field = AssertRefusedByValidation(() => Helper.Write(new HidesAField()));
+            CborException property = AssertRefusedByValidation(() => Helper.Write(new HidesAProperty()));
 
             Assert.Contains("'Value'", field.Message);
             Assert.Contains("'Value'", property.Message);
@@ -194,10 +228,31 @@ namespace Dahomey.Cbor.Tests.Issues
         }
 
         /// <summary>
+        /// A collision between members that are written but never read is seen by the validation and
+        /// by nothing else, so it is the shape that says the validation is load-bearing.
+        /// </summary>
+        /// <remarks>
+        /// The read lookup refuses a key it already holds, which catches a collision that arrives too
+        /// late for the validation — but it is only ever offered the members that can be deserialized.
+        /// Get-only properties, readonly fields, consts and statics are written and never read, so
+        /// they never reach it. Without the validation this writes <c>{"X": 1, "X": 2}</c> and says
+        /// nothing, which is the bug the issue opened on.
+        /// </remarks>
+        [Fact]
+        public void ASerializeOnlyCollisionIsRefused()
+        {
+            CborException ex = AssertRefusedByValidation(() => Helper.Write(new SerializeOnlyCollision()));
+
+            Assert.Contains(nameof(SerializeOnlyCollision), ex.Message);
+            Assert.Contains("'X'", ex.Message);
+        }
+
+        /// <summary>
         /// A member added to the mapping after something has already initialized it arrives past the
-        /// check, at the read lookup, which refuses the key on its own terms. It reports the same way:
-        /// the library's own exception type and the same sentence, not the raw
-        /// <see cref="System.ArgumentException"/> of the container that caught it.
+        /// check, at the read lookup, which refuses the key on its own terms. It reports as the same
+        /// kind of failure — the library's own exception type, not the raw
+        /// <see cref="System.ArgumentException"/> of the container that caught it — and says that it
+        /// arrived late, which is what tells the two mechanisms apart.
         /// </summary>
         [Fact]
         public void ACollisionAddedAfterValidationReportsTheSameWay()
@@ -218,6 +273,29 @@ namespace Dahomey.Cbor.Tests.Issues
 
             Assert.Contains(nameof(DistinctNames), ex.Message);
             Assert.Contains("'X'", ex.Message);
+            Assert.Contains("after it was validated", ex.Message);
+        }
+
+        /// <summary>
+        /// The same, in an integer-keyed format, where it is an index that repeats rather than a name.
+        /// </summary>
+        [Fact]
+        public void ACollisionAddedAfterValidationReportsTheSameWayOnAnIndex()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<DistinctIndexes>(objectMapping =>
+            {
+                objectMapping.AutoMap();
+                _ = objectMapping.MemberMappings.Count;
+                objectMapping.MapMember(o => o.First);
+            });
+
+            CborException ex = AssertThrowsCborException(
+                () => Helper.Write(new DistinctIndexes(), options));
+
+            Assert.Contains(nameof(DistinctIndexes), ex.Message);
+            Assert.Contains("MemberIndex", ex.Message);
+            Assert.Contains("after it was validated", ex.Message);
         }
 
         /// <summary>
@@ -230,7 +308,7 @@ namespace Dahomey.Cbor.Tests.Issues
             CborOptions options = new CborOptions();
             options.Registry.DiscriminatorConventionRegistry.RegisterType<CollidesWithDiscriminator>();
 
-            CborException ex = AssertThrowsCborException(
+            CborException ex = AssertRefusedByValidation(
                 () => Helper.Write(new CollidesWithDiscriminator(), options));
 
             Assert.Contains("'_t'", ex.Message);
@@ -272,7 +350,7 @@ namespace Dahomey.Cbor.Tests.Issues
         [Fact]
         public void TwoMembersUnderOneIndexAreStillRefused()
         {
-            CborException ex = AssertThrowsCborException(
+            CborException ex = AssertRefusedByValidation(
                 () => Helper.Write(new TwoMembersOneIndex()));
 
             Assert.Contains(nameof(TwoMembersOneIndex), ex.Message);

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0177.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0177.cs
@@ -18,10 +18,11 @@ namespace Dahomey.Cbor.Tests.Issues
     /// already, but it is a way to live with the mapping rather than an answer to it.
     /// <para>
     /// Refusing at build time is a new failure at first use for a type that "worked" before, which is
-    /// the point: the alternative is a document that silently drops a member. The check covers every
-    /// route to the collision, since the attribute is only the most visible one — a naming convention
-    /// that folds two member names into one, or a mapping API call that maps a member twice, arrives
-    /// at the same place with nothing in the source looking wrong.
+    /// the point: the alternative is a document that silently drops a member. The check is on the
+    /// mapped name, so it covers every route to the collision rather than the attribute alone: a
+    /// naming convention that folds two member names into one, a mapping API call that maps a member
+    /// twice, and a member that hides a base member of the same name all arrive at the same place with
+    /// nothing in the source looking wrong.
     /// </para>
     /// </remarks>
     public class Issue0177
@@ -51,6 +52,27 @@ namespace Dahomey.Cbor.Tests.Issues
         {
             [CborProperty(0)] public int First { get; set; }
             [CborProperty(0)] public int Second { get; set; }
+        }
+
+        /// <summary>The type <see cref="TwoMembersOneName"/> becomes once the collision is removed.</summary>
+        public class OneMemberOneName
+        {
+            [CborProperty("X")] public int First { get; set; }
+        }
+
+        public class BaseWithAField { public int Value; }
+        public class HidesAField : BaseWithAField { public new int Value; }
+
+        public class BaseWithAProperty { public object Value { get; set; } }
+        public class HidesAProperty : BaseWithAProperty { public new string Value { get; set; } }
+
+        public class BaseWithAnInt { public int Value { get; set; } }
+        public class HidesWithTheSameSignature : BaseWithAnInt { public new int Value { get; set; } }
+
+        [CborDiscriminator("collides")]
+        public class CollidesWithDiscriminator
+        {
+            [CborProperty("_t")] public int NotTheDiscriminator { get; set; }
         }
 
         /// <summary>
@@ -137,6 +159,97 @@ namespace Dahomey.Cbor.Tests.Issues
                 () => Helper.Write(new DistinctNames(), options));
 
             Assert.Contains("'X'", ex.Message);
+        }
+
+        /// <summary>
+        /// A member that hides a base member of the same name — <c>new</c> rather than
+        /// <c>override</c> — is a fourth route, and the one with nothing attribute-shaped in the
+        /// source at all.
+        /// </summary>
+        /// <remarks>
+        /// Reflection returns both declarations whenever their signatures differ, so both are mapped,
+        /// under the one name. Only a hiding member whose signature matches the hidden one exactly is
+        /// filtered out by reflection itself, which is why <see cref="HidesWithTheSameSignature"/>
+        /// maps once and is written normally. Refusing is what the other two shapes wrote before:
+        /// the key twice, the hidden member unreadable.
+        /// </remarks>
+        [Fact]
+        public void AMemberHidingABaseMemberIsRefused()
+        {
+            CborException field = AssertThrowsCborException(() => Helper.Write(new HidesAField()));
+            CborException property = AssertThrowsCborException(() => Helper.Write(new HidesAProperty()));
+
+            Assert.Contains("'Value'", field.Message);
+            Assert.Contains("'Value'", property.Message);
+        }
+
+        /// <summary>The signature-preserving case reflection folds for us, mapped once and written.</summary>
+        [Fact]
+        public void HidingWithTheSameSignatureIsUnaffected()
+        {
+            HidesWithTheSameSignature obj = new HidesWithTheSameSignature { Value = 1 };
+
+            // a1 65 56616c7565 01  -- {"Value": 1}
+            Helper.TestWrite(obj, "A16556616C756501");
+        }
+
+        /// <summary>
+        /// A member added to the mapping after something has already initialized it arrives past the
+        /// check, at the read lookup, which refuses the key on its own terms. It reports the same way:
+        /// the library's own exception type and the same sentence, not the raw
+        /// <see cref="System.ArgumentException"/> of the container that caught it.
+        /// </summary>
+        [Fact]
+        public void ACollisionAddedAfterValidationReportsTheSameWay()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<DistinctNames>(objectMapping =>
+            {
+                objectMapping.AutoMap();
+
+                // reading the mappings initializes them, so the validation has already run
+                _ = objectMapping.MemberMappings.Count;
+
+                objectMapping.MapMember(o => o.First);
+            });
+
+            CborException ex = AssertThrowsCborException(
+                () => Helper.Write(new DistinctNames(), options));
+
+            Assert.Contains(nameof(DistinctNames), ex.Message);
+            Assert.Contains("'X'", ex.Message);
+        }
+
+        /// <summary>
+        /// The discriminator is a key of the map rather than a member of the type, and a member mapped
+        /// onto its name collides with it exactly as two members collide with each other.
+        /// </summary>
+        [Fact]
+        public void AMemberMappedOntoTheDiscriminatorNameIsRefused()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<CollidesWithDiscriminator>();
+
+            CborException ex = AssertThrowsCborException(
+                () => Helper.Write(new CollidesWithDiscriminator(), options));
+
+            Assert.Contains("'_t'", ex.Message);
+        }
+
+        /// <summary>
+        /// The migration path the documentation offers: a document one of these mappings already wrote
+        /// still reads with <see cref="DuplicateKeyMode.LastWins"/>, against a type whose mapping no
+        /// longer collides. Last occurrence wins, which is what the assign path did before #169.
+        /// </summary>
+        [Fact]
+        public void ALegacyDocumentStillReadsWithLastWins()
+        {
+            CborOptions options = new CborOptions { DuplicateKeyMode = DuplicateKeyMode.LastWins };
+
+            // a2 6158 01 6158 02  -- {"X": 1, "X": 2}, written before the mapping was untangled
+            OneMemberOneName obj = Helper.Read<OneMemberOneName>("A2615801615802", options);
+
+            Assert.Equal(2, obj.First);
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0177.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0177.cs
@@ -1,0 +1,169 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization.Conventions;
+using System;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #177: a type mapping two members to one CBOR name wrote a document with the key repeated
+    /// — one it could not read back — and nothing said so. The mapping is now refused when it is
+    /// built, naming the type and the colliding name.
+    /// </summary>
+    /// <remarks>
+    /// The ambiguity runs both ways and no reading of it is right: only one of the two members can
+    /// ever be read from the key, and writing both is not representable. #169 made the resulting
+    /// document a hard error on the way in, which left the library unable to read what it had just
+    /// written; <see cref="DuplicateKeyMode.LastWins"/> reads such a document for anyone holding one
+    /// already, but it is a way to live with the mapping rather than an answer to it.
+    /// <para>
+    /// Refusing at build time is a new failure at first use for a type that "worked" before, which is
+    /// the point: the alternative is a document that silently drops a member. The check covers every
+    /// route to the collision, since the attribute is only the most visible one — a naming convention
+    /// that folds two member names into one, or a mapping API call that maps a member twice, arrives
+    /// at the same place with nothing in the source looking wrong.
+    /// </para>
+    /// </remarks>
+    public class Issue0177
+    {
+        public class TwoMembersOneName
+        {
+            [CborProperty("X")] public int First { get; set; }
+            [CborProperty("X")] public int Second { get; set; }
+        }
+
+        /// <summary>Both members carry a name of their own; the convention is what folds them together.</summary>
+        [CborNamingConvention(typeof(LowerCaseNamingConvention))]
+        public class FoldedByNamingConvention
+        {
+            public int Id { get; set; }
+            public int ID { get; set; }
+        }
+
+        public class DistinctNames
+        {
+            [CborProperty("X")] public int First { get; set; }
+            [CborProperty("Y")] public int Second { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        public class TwoMembersOneIndex
+        {
+            [CborProperty(0)] public int First { get; set; }
+            [CborProperty(0)] public int Second { get; set; }
+        }
+
+        /// <summary>
+        /// Converters are built through <see cref="Activator"/>, so a <see cref="CborException"/>
+        /// raised while building a mapping arrives wrapped in a
+        /// <see cref="System.Reflection.TargetInvocationException"/>.
+        /// </summary>
+        private static CborException AssertThrowsCborException(Action action)
+        {
+            Exception exception = Assert.ThrowsAny<Exception>(action);
+
+            for (Exception current = exception; current != null; current = current.InnerException)
+            {
+                if (current is CborException cborException)
+                {
+                    return cborException;
+                }
+            }
+
+            throw new Xunit.Sdk.XunitException(
+                $"Expected a {nameof(CborException)} somewhere in the exception chain, got: {exception}");
+        }
+
+        [Fact]
+        public void WritingRefusesTheMapping()
+        {
+            TwoMembersOneName obj = new TwoMembersOneName { First = 1, Second = 2 };
+
+            CborException ex = AssertThrowsCborException(() => Helper.Write(obj));
+
+            Assert.Contains(nameof(TwoMembersOneName), ex.Message);
+            Assert.Contains("'X'", ex.Message);
+        }
+
+        /// <summary>
+        /// The mapping is refused whichever direction reaches it first, and a second attempt is
+        /// refused the same way: initialization is only recorded once it has passed validation, so the
+        /// type does not come out of a failed build looking usable.
+        /// </summary>
+        [Fact]
+        public void ReadingRefusesTheMapping()
+        {
+            // a2 6158 01 6158 02  -- {"X": 1, "X": 2}, what the mapping used to write
+            const string hexBuffer = "A2615801615802";
+
+            CborOptions options = new CborOptions();
+
+            CborException first = AssertThrowsCborException(
+                () => Helper.Read<TwoMembersOneName>(hexBuffer, options));
+            CborException second = AssertThrowsCborException(
+                () => Helper.Read<TwoMembersOneName>(hexBuffer, options));
+
+            Assert.Contains("'X'", first.Message);
+            Assert.Equal(first.Message, second.Message);
+        }
+
+        /// <summary>
+        /// The route the issue calls out as the one nothing in the source looks wrong for: two members
+        /// named distinctly in C#, mapped onto one name by the convention.
+        /// </summary>
+        [Fact]
+        public void ANamingConventionFoldingTwoMembersIsRefused()
+        {
+            FoldedByNamingConvention obj = new FoldedByNamingConvention();
+
+            CborException ex = AssertThrowsCborException(() => Helper.Write(obj));
+
+            Assert.Contains(nameof(FoldedByNamingConvention), ex.Message);
+            Assert.Contains("'id'", ex.Message);
+        }
+
+        /// <summary>And mapping a member twice through the mapping API, which names it only once.</summary>
+        [Fact]
+        public void MappingTheSameMemberTwiceByApiIsRefused()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<DistinctNames>(objectMapping =>
+            {
+                objectMapping.AutoMap();
+                objectMapping.MapMember(o => o.First);
+            });
+
+            CborException ex = AssertThrowsCborException(
+                () => Helper.Write(new DistinctNames(), options));
+
+            Assert.Contains("'X'", ex.Message);
+        }
+
+        /// <summary>
+        /// Distinct names are left alone. The check is on the mapped name rather than the member name,
+        /// so this is the side of it that would go unnoticed if it were wrong.
+        /// </summary>
+        [Fact]
+        public void DistinctNamesAreUnaffected()
+        {
+            DistinctNames obj = new DistinctNames { First = 1, Second = 2 };
+
+            // a2 6158 01 6159 02  -- {"X": 1, "Y": 2}
+            Helper.TestWrite(obj, "A2615801615902");
+        }
+
+        /// <summary>
+        /// The integer-keyed formats already refused two members under one index. That check is
+        /// untouched — this asserts the name check did not displace it.
+        /// </summary>
+        [Fact]
+        public void TwoMembersUnderOneIndexAreStillRefused()
+        {
+            CborException ex = AssertThrowsCborException(
+                () => Helper.Write(new TwoMembersOneIndex()));
+
+            Assert.Contains(nameof(TwoMembersOneIndex), ex.Message);
+            Assert.Contains("MemberIndex", ex.Message);
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
@@ -1,5 +1,6 @@
 ﻿using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.Serialization.Conventions;
+using Dahomey.Cbor.Serialization.Converters;
 using Dahomey.Cbor.Util;
 using System;
 using System.Collections.Generic;
@@ -359,7 +360,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
                         if (duplicatedName != null)
                         {
-                            throw new CborException($"class/struct {ObjectType.Name} maps several fields/properties to the member name '{duplicatedName}'");
+                            throw new CborException(MemberMappingErrors.DuplicateMemberName(ObjectType, duplicatedName));
                         }
                     }
                     break;
@@ -376,7 +377,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
                         if (indexDuplicates)
                         {
-                            throw new CborException($"class/struct {ObjectType.Name} holds duplicated MemberIndex fields/properties");
+                            throw new CborException(MemberMappingErrors.DuplicateMemberIndex(ObjectType));
                         }
 
                         _memberMappings = _memberMappings
@@ -397,7 +398,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
                         if (indexDuplicates)
                         {
-                            throw new CborException($"class/struct {ObjectType.Name} holds duplicated MemberIndex fields/properties");
+                            throw new CborException(MemberMappingErrors.DuplicateMemberIndex(ObjectType));
                         }
 
                         _memberMappings = _memberMappings

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
@@ -347,6 +347,20 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                         {
                             throw new CborException($"expecting all fields/properties to get a member name in class/struct {ObjectType.Name}");
                         }
+
+                        // Two members under one name is ambiguous in both directions: the write emits
+                        // the key twice, producing a document this very type refuses to read back,
+                        // and the read can only ever reach one of the two members. Refusing the
+                        // mapping names the type and the name; letting it build names neither, and
+                        // shows up as a duplicate key in a document nobody wrote by hand.
+                        string? duplicatedName = _memberMappings
+                            .GroupBy(m => converter is null ? m.MemberName : m.GetMemberNameForConverter(converter), StringComparer.Ordinal)
+                            .FirstOrDefault(g => g.Count() > 1)?.Key;
+
+                        if (duplicatedName != null)
+                        {
+                            throw new CborException($"class/struct {ObjectType.Name} maps several fields/properties to the member name '{duplicatedName}'");
+                        }
                     }
                     break;
                 case CborObjectFormat.IntKeyMap:

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberMappingErrors.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberMappingErrors.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// Messages for a type whose mapping puts two members under one key, so that the two places that
+    /// can catch it word it the same.
+    /// </summary>
+    /// <remarks>
+    /// Validating the whole mapping catches this, and the read lookup catches what arrives after that
+    /// validation has already run. They report the same failure and should say the same thing about
+    /// it, differing only by <see cref="AddedAfterValidation"/> - which is what lets a caller, or a
+    /// test, tell which one answered. Keeping the wording in one place is what stops a reword of one
+    /// from silently parting company with the other.
+    /// </remarks>
+    internal static class MemberMappingErrors
+    {
+        /// <summary>
+        /// Appended when the collision reached the read lookup rather than the validation, meaning a
+        /// member was mapped after something had already initialized the mapping.
+        /// </summary>
+        /// <remarks>
+        /// Worth saying because the two have different fixes: one is two members declared under one
+        /// name, the other is a <c>MapMember</c> call over a member the conventions already covered.
+        /// </remarks>
+        public const string AddedAfterValidation =
+            ". The collision was added to the mapping after it was validated.";
+
+        public static string DuplicateMemberName(Type objectType, string? memberName)
+        {
+            return $"class/struct {objectType.Name} maps several fields/properties to the member name '{memberName}'";
+        }
+
+        public static string DuplicateMemberIndex(Type objectType)
+        {
+            return $"class/struct {objectType.Name} holds duplicated MemberIndex fields/properties";
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -247,8 +247,8 @@ namespace Dahomey.Cbor.Serialization.Converters
                                 catch (ArgumentException)
                                 {
                                     throw new CborException(
-                                        $"class/struct {typeof(T).Name} maps several fields/properties to the member name "
-                                        + $"'{memberMapping.MemberName}', added to the mapping after it was validated");
+                                        MemberMappingErrors.DuplicateMemberName(typeof(T), memberMapping.MemberName)
+                                        + MemberMappingErrors.AddedAfterValidation);
                                 }
 
                                 _nextReadOrdinal++;
@@ -268,8 +268,8 @@ namespace Dahomey.Cbor.Serialization.Converters
                                 catch (ArgumentException)
                                 {
                                     throw new CborException(
-                                        $"class/struct {typeof(T).Name} holds duplicated MemberIndex fields/properties, "
-                                        + "added to the mapping after it was validated");
+                                        MemberMappingErrors.DuplicateMemberIndex(typeof(T))
+                                        + MemberMappingErrors.AddedAfterValidation);
                                 }
 
                                 _nextReadOrdinal++;

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -222,32 +222,59 @@ namespace Dahomey.Cbor.Serialization.Converters
                     // exactly that before this loop began. A collision reaching here is therefore a
                     // member added to the mapping after its validation ran - mapping over a member
                     // AutoMap already covered, once something has read MemberMappings - which is the
-                    // same mistake arriving late. It gets the same exception type and the same
-                    // sentence rather than the raw ArgumentException of the container that caught it.
-                    try
+                    // same mistake arriving late, and is reported as the same kind of failure rather
+                    // than as the raw ArgumentException of the container that caught it. The clause
+                    // naming the lateness is what tells the two apart: the validator sees the whole
+                    // mapping and refuses any collision in it, while this sees only the members that
+                    // can be read, so a collision between members that are written but never read
+                    // reaches the validator alone.
+                    //
+                    // Only the Add is guarded. IMemberConverter is a public interface an implementer
+                    // outside this library can supply, and an ArgumentException out of one of its
+                    // getters is not this failure - naming it a duplicate key would be a diagnosis
+                    // the catch has no grounds for.
+                    switch (_objectMapping.ObjectFormat)
                     {
-                        switch (_objectMapping.ObjectFormat)
-                        {
-                            case CborObjectFormat.StringKeyMap:
-                                _memberConvertersForRead.Add(
-                                    memberConverter.MemberName, new MemberReadEntry(memberConverter, _nextReadOrdinal++));
-                                break;
-                            case CborObjectFormat.IntKeyMap:
-                            case CborObjectFormat.Array:
-                                if (memberConverter.MemberIndex.HasValue)
+                        case CborObjectFormat.StringKeyMap:
+                            {
+                                ReadOnlySpan<byte> memberName = memberConverter.MemberName;
+                                MemberReadEntry entry = new MemberReadEntry(memberConverter, _nextReadOrdinal);
+
+                                try
                                 {
-                                    _memberConvertersForReadByIndex.Add(
-                                        memberConverter.MemberIndex.Value, new MemberReadEntry(memberConverter, _nextReadOrdinal++));
+                                    _memberConvertersForRead.Add(memberName, entry);
                                 }
-                                break;
-                        }
-                    }
-                    catch (ArgumentException)
-                    {
-                        throw new CborException(
-                            _objectMapping.ObjectFormat == CborObjectFormat.StringKeyMap
-                                ? $"class/struct {typeof(T).Name} maps several fields/properties to the member name '{memberMapping.MemberName}'"
-                                : $"class/struct {typeof(T).Name} holds duplicated MemberIndex fields/properties");
+                                catch (ArgumentException)
+                                {
+                                    throw new CborException(
+                                        $"class/struct {typeof(T).Name} maps several fields/properties to the member name "
+                                        + $"'{memberMapping.MemberName}', added to the mapping after it was validated");
+                                }
+
+                                _nextReadOrdinal++;
+                            }
+                            break;
+                        case CborObjectFormat.IntKeyMap:
+                        case CborObjectFormat.Array:
+                            if (memberConverter.MemberIndex.HasValue)
+                            {
+                                int memberIndex = memberConverter.MemberIndex.Value;
+                                MemberReadEntry entry = new MemberReadEntry(memberConverter, _nextReadOrdinal);
+
+                                try
+                                {
+                                    _memberConvertersForReadByIndex.Add(memberIndex, entry);
+                                }
+                                catch (ArgumentException)
+                                {
+                                    throw new CborException(
+                                        $"class/struct {typeof(T).Name} holds duplicated MemberIndex fields/properties, "
+                                        + "added to the mapping after it was validated");
+                                }
+
+                                _nextReadOrdinal++;
+                            }
+                            break;
                     }
 
                     if (memberConverter.RequirementPolicy == RequirementPolicy.AllowNull

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -218,20 +218,36 @@ namespace Dahomey.Cbor.Serialization.Converters
 
                 if (memberMapping.CanBeDeserialized || isCreatorMember)
                 {
-                    switch (_objectMapping.ObjectFormat)
+                    // Both lookups refuse a key they already hold, and the mapping was validated for
+                    // exactly that before this loop began. A collision reaching here is therefore a
+                    // member added to the mapping after its validation ran - mapping over a member
+                    // AutoMap already covered, once something has read MemberMappings - which is the
+                    // same mistake arriving late. It gets the same exception type and the same
+                    // sentence rather than the raw ArgumentException of the container that caught it.
+                    try
                     {
-                        case CborObjectFormat.StringKeyMap:
-                            _memberConvertersForRead.Add(
-                                memberConverter.MemberName, new MemberReadEntry(memberConverter, _nextReadOrdinal++));
-                            break;
-                        case CborObjectFormat.IntKeyMap:
-                        case CborObjectFormat.Array:
-                            if (memberConverter.MemberIndex.HasValue)
-                            {
-                                _memberConvertersForReadByIndex.Add(
-                                    memberConverter.MemberIndex.Value, new MemberReadEntry(memberConverter, _nextReadOrdinal++));
-                            }
-                            break;
+                        switch (_objectMapping.ObjectFormat)
+                        {
+                            case CborObjectFormat.StringKeyMap:
+                                _memberConvertersForRead.Add(
+                                    memberConverter.MemberName, new MemberReadEntry(memberConverter, _nextReadOrdinal++));
+                                break;
+                            case CborObjectFormat.IntKeyMap:
+                            case CborObjectFormat.Array:
+                                if (memberConverter.MemberIndex.HasValue)
+                                {
+                                    _memberConvertersForReadByIndex.Add(
+                                        memberConverter.MemberIndex.Value, new MemberReadEntry(memberConverter, _nextReadOrdinal++));
+                                }
+                                break;
+                        }
+                    }
+                    catch (ArgumentException)
+                    {
+                        throw new CborException(
+                            _objectMapping.ObjectFormat == CborObjectFormat.StringKeyMap
+                                ? $"class/struct {typeof(T).Name} maps several fields/properties to the member name '{memberMapping.MemberName}'"
+                                : $"class/struct {typeof(T).Name} holds duplicated MemberIndex fields/properties");
                     }
 
                     if (memberConverter.RequirementPolicy == RequirementPolicy.AllowNull

--- a/src/Dahomey.Cbor/Util/ByteBufferDictionary.cs
+++ b/src/Dahomey.Cbor/Util/ByteBufferDictionary.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Dahomey.Cbor.Util
 {
@@ -127,6 +128,15 @@ namespace Dahomey.Cbor.Util
             next = new NodeCollection()
         };
 
+        /// <summary>Adds an entry, refusing a key that is already present.</summary>
+        /// <exception cref="ArgumentException">An entry with the same key was already added.</exception>
+        /// <remarks>
+        /// Overwriting is what <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/>'s
+        /// indexer is for, and this type offers no indexer: every caller here builds a lookup once
+        /// from a set of keys it believes distinct, so a repeat is a mistake upstream - two members
+        /// mapped to one CBOR name, say - and the entry it silently replaced is a member that could
+        /// then never be read. Refusing names the collision where it is made instead.
+        /// </remarks>
         public void Add(ReadOnlySpan<byte> key, T value)
         {
             int len = key.Length;
@@ -151,6 +161,12 @@ namespace Dahomey.Cbor.Util
                 }
 
                 last = node;
+            }
+
+            if (last.hasValue)
+            {
+                throw new ArgumentException(
+                    $"An entry with the same key already exists: {Encoding.UTF8.GetString(key.ToArray())}", nameof(key));
             }
 
             last.value = value;


### PR DESCRIPTION
Closes #177.

## What was wrong

A type mapping two members to the same CBOR name wrote a document with the key repeated — both members written, one key — and nothing said so:

```csharp
public class Aliased
{
    [CborProperty("X")] public int First { get; set; }
    [CborProperty("X")] public int Second { get; set; }
}
```

Reading is where it showed: before #169 the last occurrence won, so `Second` was set and `First` silently kept its default; after #169 the document is refused as a duplicate key, so the library no longer read back what it had just written.

No answer at decode time is right, because the mapping is ambiguous in both directions: only one of the two members can ever be read from key `X`, and writing both is not representable. `DuplicateKeyMode.LastWins` is a way to live with such a document, not an answer to the mapping. So the mapping is refused where it is made.

## The two halves

**The mapping is refused when it is built.** `ObjectMapping.ValidateMemberNamesAndindexes` now checks the mapped names of a `StringKeyMap` type for a collision, as it already did the indexes of the integer-keyed formats, and names the type and the colliding name:

```
class/struct Aliased maps several fields/properties to the member name 'X'
```

The check is on the *mapped* name rather than the member name, so it covers every route to the collision, not only the visible one:

* `[CborProperty("X")]` on two members;
* a **naming convention** that folds two member names into one — `Id` and `ID` under `LowerCaseNamingConvention`;
* a **mapping API call** over a member the conventions already covered — `MapMember` after `AutoMap` with no `ClearMemberMappings` between them and no new name;
* a member that **hides a base member** of the same name with `new` rather than `override`. A hidden **field** always collides, whatever its type: field lookup does no folding, so `int` over `int` is two members. A hidden **property** collides only where the signatures differ — `string` over `object`, or a property over a field — since property lookup folds a hide that keeps the signature exactly. `override` never collides.

**`ByteBufferDictionary.Add` refuses a duplicate key** instead of overwriting the existing entry. That was the enabling half — the read lookup silently lost a member rather than reporting the collision — and it now throws the way a dictionary `Add` does. `NodeCollection.Add` already refused internally; it was the public `Add` that overwrote.

## The two refusals are not interchangeable

A collision can reach the read lookup rather than the validation, by being added to the mapping after something has already initialized it. `ObjectConverter` reports that as the same kind of failure — a `CborException`, not the container's raw `ArgumentException` — with a clause saying it arrived late:

```
class/struct DistinctNames maps several fields/properties to the member name 'X', added to the mapping after it was validated
```

That clause is not decoration. The read lookup is only ever offered members that **can be deserialized**, so a collision between members that are only ever written — get-only properties, readonly fields, consts, statics — reaches the validation and nothing else. Giving both paths the same sentence would leave the suite unable to say which one answered, and that shape untested behind the confusion. Every route test asserts the message *lacks* the clause; the two late-arrival tests assert it carries it.

The catch guards the `Add` call alone rather than the surrounding switch: `IMemberConverter` is a public interface an implementer outside this library can supply, and an `ArgumentException` out of one of its getters is not this failure.

## Behaviour change

This is a new exception at first use for a type that "worked" before, which is the point: what it worked at was writing a document it could not read. It is deliberate rather than riding along with #169, as the issue asked. A document already written by such a mapping still reads with `DuplicateKeyMode.LastWins`, against a type whose mapping no longer collides.

`Dahomey.Cbor.Util.ByteBufferDictionary<T>` is public, and its `Add` refusing a duplicate is a behaviour change for any caller outside this library — noted in the README callout alongside the mapping half.

The README's duplicate-key section ended on "one case the policy does not reach"; that case is now handled, so the paragraph is rewritten with the four routes, the remedies — including `[CborIgnore]` on the member you own where the collision comes from a base type you do not — and the callout.

## An existing test asserted the bug

`ClassMemberModifierTests.TestWriteByApi` mapped `Name` a second time over `AutoMap` and expected a 4-entry document with `"Name"` twice. It now maps only what `AutoMap` does not reach — a const and a static field, which is what the test was for — and expects 3 entries.

Worth flagging as a deliberate consequence: `MapMember` over an already-mapped member now throws unless it is given a new name, so tweaking one auto-mapped member's `IgnoreIfDefault`/`Required`/`LengthMode` in place is no longer available — `ClearMemberMappings()` and mapping by hand is. Making `MapMember` return the existing mapping instead would preserve it; that is a design call beyond this fix, so it is left alone rather than decided here.

## Tests

New `Issues/Issue0177.cs`: refusal on write and on read, refusal repeated on a second attempt, all four routes into the collision, a serialize-only collision (the shape only the validation can see), hiding that preserves a property signature left unaffected, a late collision on a name and on an index, a member mapped onto the discriminator's name, the `LastWins` migration path the README promises, distinct names left alone, and duplicate indexes still refused by the check that was already there.

Both halves are mutation-checked: disabling the validation fails 7 of the 13 issue tests, disabling the dictionary's refusal fails the string-keyed late-arrival test and the three `ByteBufferDictionary` cases. `ByteBufferDictionaryTests` also gains the shorter-key-first ordering the existing prefix test did not cover.

Build green on all four TFMs; 1381 tests pass on `net10.0` and on `net8.0`, and the 35 generator tests pass. `net9.0` and `netstandard2.0` are covered by CI only — no runtime for the former is available in this container, and the latter is a library target with no test host.

## Not done here

The source generator has no matching compile-time diagnostic: a `[CborSerializable]` type with two members under one name still compiles clean and fails when the context is constructed. The generator is the other place mappings are made, so that is the natural counterpart — worth a follow-up issue rather than widening this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaEQe6TTZzscBLaNV5MByY