### PR TITLE
Bound nesting depth on the skip path too, closes #185

### DIFF
--- a/src/Dahomey.Cbor.Tests/MaxDepthTests.cs
+++ b/src/Dahomey.Cbor.Tests/MaxDepthTests.cs
@@ -292,5 +292,140 @@ namespace Dahomey.Cbor.Tests
             // 500 siblings, each 2 deep, inside one array: nowhere near the limit of 8.
             Helper.Write(manySiblings, new CborOptions { MaxDepth = 8 });
         }
+
+        // ---- the skip path ----
+
+        public class Holder
+        {
+            public int B { get; set; }
+        }
+
+        /// <summary>
+        /// A map of two members: <c>"A"</c>, whose value is <paramref name="depth"/> nested arrays, and
+        /// <c>"B"</c>, whose value is 1.
+        /// </summary>
+        private static byte[] UnmappedNesting(int depth)
+        {
+            byte[] nested = NestedArrays(depth);
+            byte[] buffer = new byte[4 + nested.Length + 3];
+
+            buffer[0] = 0xA2;                       // map(2)
+            buffer[1] = 0x61; buffer[2] = 0x41;     // "A"
+            nested.CopyTo(buffer, 3);
+            buffer[3 + nested.Length] = 0x61;       // "B"
+            buffer[4 + nested.Length] = 0x42;
+            buffer[5 + nested.Length] = 0x01;       // 1
+
+            return buffer;
+        }
+
+        /// <summary>
+        /// Nesting reached through a member the target type does not declare is bounded too.
+        /// </summary>
+        /// <remarks>
+        /// <c>ObjectConverter</c> hands an unhandled name's value to <c>CborReader.SkipDataItem</c>,
+        /// which recurses through the same arrays and maps a read would — so a document that is refused
+        /// as a value has to be refused as a skip, or the bound is a bound on the shape of the target
+        /// type rather than on the document. At 100 000 levels this took the process down with an
+        /// uncatchable <c>StackOverflowException</c>, which is why the modest depth below is the case
+        /// that can be asserted at all: a test cannot survive the one that mattered.
+        /// </remarks>
+        [Fact]
+        public void NestingInsideASkippedMemberIsBounded()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Holder>(UnmappedNesting(100)));
+
+            Assert.Contains("nesting depth", exception.Message);
+        }
+
+        [Fact]
+        public void RaisingMaxDepthAllowsADeeperSkippedMember()
+        {
+            byte[] buffer = UnmappedNesting(100);
+
+            Assert.Throws<CborException>(() => Cbor.Deserialize<Holder>(buffer));
+
+            Holder holder = Cbor.Deserialize<Holder>(buffer, new CborOptions { MaxDepth = 500 });
+
+            Assert.Equal(1, holder.B);
+        }
+
+        /// <summary>An unmapped member within the limit is skipped, and the read carries on past it.</summary>
+        [Fact]
+        public void AShallowSkippedMemberIsUnaffected()
+        {
+            Holder holder = Cbor.Deserialize<Holder>(UnmappedNesting(8));
+
+            Assert.Equal(1, holder.B);
+        }
+
+        /// <summary>
+        /// The skip path releases depth like the read path, or a document with enough unmapped members
+        /// would trip the limit on the tenth shallow one rather than on anything deep.
+        /// </summary>
+        [Fact]
+        public void SkippedSiblingsDoNotAccumulateDepth()
+        {
+            using ByteBufferWriter bufferWriter = new ByteBufferWriter();
+            CborWriter writer = new CborWriter(bufferWriter);
+
+            writer.WriteBeginMap(201);
+
+            for (int i = 0; i < 200; i++)
+            {
+                writer.WriteString($"unmapped{i}");
+                writer.WriteBeginArray(1);
+                writer.WriteBeginArray(1);
+                writer.WriteInt32(0);
+            }
+
+            writer.WriteString("B");
+            writer.WriteInt32(1);
+
+            // 200 unmapped members, each 2 deep, inside one map: 3 levels against a limit of 8.
+            Holder holder = Cbor.Deserialize<Holder>(
+                bufferWriter.WrittenSpan.ToArray(), new CborOptions { MaxDepth = 8 });
+
+            Assert.Equal(1, holder.B);
+        }
+
+        /// <summary>
+        /// Read depth and skip depth are one budget, not two. A skipped member nested inside mapped
+        /// objects starts from the depth already spent getting to it.
+        /// </summary>
+        [Fact]
+        public void SkipDepthContinuesFromTheDepthAlreadyRead()
+        {
+            // A ref struct cannot be captured, so no Assert.Throws lambda.
+            CborException? thrown = null;
+
+            try
+            {
+                CborReader reader = new CborReader(NestedArrays(20), maxDepth: 8);
+                reader.SkipDataItem();
+            }
+            catch (CborException exception)
+            {
+                thrown = exception;
+            }
+
+            Assert.NotNull(thrown);
+            Assert.Contains("nesting depth", thrown!.Message);
+        }
+
+        [Fact]
+        public void SkippingWithinTheLimitConsumesTheWholeItem()
+        {
+            byte[] buffer = new byte[NestedArrays(4).Length + 1];
+            NestedArrays(4).CopyTo(buffer, 0);
+            buffer[buffer.Length - 1] = 0x01;   // a second item, after the nested one
+
+            CborReader reader = new CborReader(buffer, maxDepth: 8);
+
+            reader.SkipDataItem();
+
+            Assert.Equal(1, reader.ReadInt32());
+        }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -1229,9 +1229,18 @@ namespace Dahomey.Cbor.Serialization
             Advance(size);
         }
 
+        /// <remarks>
+        /// Guarded by <see cref="EnterNestedItem"/> for the same reason <see cref="ReadArray"/> is, and
+        /// against the same budget: skipping recurses through <see cref="SkipDataItem"/> exactly as
+        /// reading does, so nesting reached by way of a member the target type does not declare costs
+        /// the same stack as nesting the type asks for. Counting the two separately would let a
+        /// document spend <see cref="MaxDepth"/> twice.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SkipArray()
         {
+            EnterNestedItem();
+
             int size = ReadSize();
 
             while (size > 0 || size < 0 && !IsBreak())
@@ -1241,11 +1250,15 @@ namespace Dahomey.Cbor.Serialization
             }
 
             _state = CborReaderState.Start;
+            _depth--;
         }
 
+        /// <inheritdoc cref="SkipArray"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SkipMap()
         {
+            EnterNestedItem();
+
             int size = ReadSize();
 
             while (size > 0 || size < 0 && !IsBreak())
@@ -1256,6 +1269,7 @@ namespace Dahomey.Cbor.Serialization
             }
 
             _state = CborReaderState.Start;
+            _depth--;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Closes #185.

`CborOptions.MaxDepth` guarded `ReadArray`/`ReadMap` and not `SkipArray`/`SkipMap`, which recurse through `SkipDataItem` exactly as the read path does. `SkipArray` and `SkipMap` now enter and leave the same guard.

## The budget is shared, not doubled

`EnterNestedItem` increments the reader's own `_depth`, so a skipped item nested inside mapped objects starts from the depth already spent reaching it. That is the point rather than an implementation detail: giving the skip path a counter of its own would let a document spend `MaxDepth` on the read path and `MaxDepth` again below a member the type does not declare, which is the same stack.

The decrement is not in a `finally`, matching `ReadArray`/`ReadMap` and for the reason already recorded there — a reader that has thrown is a single-use `ref struct` the caller discards, so the depth left behind is unobservable, and a handler would make these ineligible for inlining.

## Tests

Six new, in `MaxDepthTests`. **Three fail without the change:**

* `NestingInsideASkippedMemberIsBounded` — the issue's repro, `{"A": [[[…0…]]], "B": 1}` into a type declaring only `B`
* `RaisingMaxDepthAllowsADeeperSkippedMember` — and the same document reads at `MaxDepth = 500`, so this bounds rather than refuses
* `SkipDepthContinuesFromTheDepthAlreadyRead` — `SkipDataItem` directly on a reader built with `maxDepth: 8`

**Three pin what the guard must not break**, and pass before and after:

* `AShallowSkippedMemberIsUnaffected` — an ordinary unmapped member still skips
* `SkippedSiblingsDoNotAccumulateDepth` — 200 unmapped members, each 2 deep, against a limit of 8; this is what fails if the decrement is dropped
* `SkippingWithinTheLimitConsumesTheWholeItem` — the item after a skipped one still reads, so the guard has not desynchronised the buffer

The 100 000-level case from the issue is asserted at 100. A test cannot survive the document that motivated the fix, which is the same reason `MaxDepth` existed in the first place — that is stated in the test remark so nobody reads the modest depth as the interesting case.

## Scope

Only the two skip methods change. `SkipSemanticTag` is a loop rather than recursion, so a long tag chain never grew the stack and is unaffected; `SkipSizeAndBytes` does not recurse. `CborDataItemScanner` carries its own `CborScanLimits.MaxDepth` and is untouched.

**1457 tests green on net10.0**, all four TFMs build.

---

_Generated by [Claude Code](https://claude.ai/code)_
