### PR TITLE
Read a tuple only from an array, closes #187

### DIFF
--- a/src/Dahomey.Cbor.Tests/TupleTests.cs
+++ b/src/Dahomey.Cbor.Tests/TupleTests.cs
@@ -1,3 +1,4 @@
+using Dahomey.Cbor.Tests.Extensions;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests
@@ -55,6 +56,63 @@ namespace Dahomey.Cbor.Tests
             // 273.15 as [-2, 27315]
             Assert.Equal((-2, 27315), Helper.Read<(int, int)>(hexBuffer));
             Assert.Equal(Helper.Read<(int, int)>(hexBuffer), Helper.Read<(int, int)?>(hexBuffer));
+        }
+
+        /// <summary>
+        /// A tuple is an array, and nothing else decodes as one.
+        /// </summary>
+        /// <remarks>
+        /// <c>ReadSize</c> takes the additional value off whatever header is current and does not ask
+        /// which major type it belongs to, so every one of these used to yield an arity of 3 and read
+        /// as <c>(1, 2, 3)</c>. The last three are the clearest: there is no container at all, just a
+        /// head whose additional value happens to be 3, and the three bytes after it are the next data
+        /// items in the document rather than anything belonging to this one.
+        /// </remarks>
+        [Theory]
+        [InlineData("43010203")]    // bytes(3)
+        [InlineData("63010203")]    // text(3)
+        [InlineData("A3010203")]    // map(3)
+        [InlineData("03010203")]    // unsigned 3
+        [InlineData("23010203")]    // negative -4
+        [InlineData("E3010203")]    // simple value 3
+        // A tag in front changes nothing: the tags are stepped over and the item beneath is still
+        // not an array.
+        [InlineData("C143010203")]
+        [InlineData("C1C1A3010203")]
+        public void ANonArrayIsNotReadAsATuple(string hexBuffer)
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<(int, int, int)>(hexBuffer.HexToBytes()));
+
+            Assert.Contains("Expected major type Array", exception.Message);
+        }
+
+        /// <summary>The check is in every arity, not only the one the report used.</summary>
+        /// <remarks>
+        /// Arities 2 to 7. <c>Tuple8Converter</c> carries the same change and cannot be reached
+        /// through the public API to assert it: the provider hands it the <c>Rest</c> field's type as
+        /// <c>T8</c>, while the converter declares <c>CborConverterBase&lt;(T1, …, T8)&gt;</c>, which
+        /// C# expands to <c>ValueTuple&lt;T1, …, T7, ValueTuple&lt;T8&gt;&gt;</c> - a different type.
+        /// So an 8-element tuple fails while building the converter for a one-element <c>Rest</c>, and
+        /// a 9-element one fails casting the converter it did build.
+        /// </remarks>
+        [Fact]
+        public void ANonArrayIsNotReadAsATupleOfAnyArity()
+        {
+            // 42 0102 -- bytes(2), against the arity-2 converter, and so on up
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int)>("420102".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int)>("43010203".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int)>("4401020304".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int)>("450102030405".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int, int)>("46010203040506".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int, int, int)>("4701020304050607".HexToBytes()));
+        }
+
+        /// <summary>The one document in the table above that is a tuple still reads as one.</summary>
+        [Fact]
+        public void AnArrayIsStillReadAsATuple()
+        {
+            Assert.Equal((1, 2, 3), Helper.Read<(int, int, int)>("83010203"));
         }
 
         [Fact]

--- a/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
@@ -39,15 +39,16 @@
 
         public override (T1, T2) Read(ref CborReader reader)
         {
-            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
-            // the reader below its tag-skipping entry points. Skip them here so a tagged tuple
-            // stays readable; the tags themselves carry no information this converter needs.
-            // A loop rather than one skip: since #183 SkipSemanticTag consumes a whole stack, and
-            // stopping at the first would leave this the one converter that does not - a tag 4
-            // decimal fraction under an outer tag reads as a two-element array everywhere else.
-            while (reader.TryReadSemanticTag(out _))
-            {
-            }
+            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
+            // value off whatever header is current without asking which major type it belongs to, so
+            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
+            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
+            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
+            // and which this converter needs, being the only one that reaches the reader below its
+            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
+            // fraction under an outer tag reads as a two-element array here as it does everywhere
+            // else.
+            reader.ReadBeginArray();
 
             int size = reader.ReadSize();
 
@@ -100,15 +101,16 @@
 
         public override (T1, T2, T3) Read(ref CborReader reader)
         {
-            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
-            // the reader below its tag-skipping entry points. Skip them here so a tagged tuple
-            // stays readable; the tags themselves carry no information this converter needs.
-            // A loop rather than one skip: since #183 SkipSemanticTag consumes a whole stack, and
-            // stopping at the first would leave this the one converter that does not - a tag 4
-            // decimal fraction under an outer tag reads as a two-element array everywhere else.
-            while (reader.TryReadSemanticTag(out _))
-            {
-            }
+            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
+            // value off whatever header is current without asking which major type it belongs to, so
+            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
+            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
+            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
+            // and which this converter needs, being the only one that reaches the reader below its
+            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
+            // fraction under an outer tag reads as a two-element array here as it does everywhere
+            // else.
+            reader.ReadBeginArray();
 
             int size = reader.ReadSize();
 
@@ -170,15 +172,16 @@
 
         public override (T1, T2, T3, T4) Read(ref CborReader reader)
         {
-            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
-            // the reader below its tag-skipping entry points. Skip them here so a tagged tuple
-            // stays readable; the tags themselves carry no information this converter needs.
-            // A loop rather than one skip: since #183 SkipSemanticTag consumes a whole stack, and
-            // stopping at the first would leave this the one converter that does not - a tag 4
-            // decimal fraction under an outer tag reads as a two-element array everywhere else.
-            while (reader.TryReadSemanticTag(out _))
-            {
-            }
+            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
+            // value off whatever header is current without asking which major type it belongs to, so
+            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
+            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
+            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
+            // and which this converter needs, being the only one that reaches the reader below its
+            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
+            // fraction under an outer tag reads as a two-element array here as it does everywhere
+            // else.
+            reader.ReadBeginArray();
 
             int size = reader.ReadSize();
 
@@ -249,15 +252,16 @@
 
         public override (T1, T2, T3, T4, T5) Read(ref CborReader reader)
         {
-            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
-            // the reader below its tag-skipping entry points. Skip them here so a tagged tuple
-            // stays readable; the tags themselves carry no information this converter needs.
-            // A loop rather than one skip: since #183 SkipSemanticTag consumes a whole stack, and
-            // stopping at the first would leave this the one converter that does not - a tag 4
-            // decimal fraction under an outer tag reads as a two-element array everywhere else.
-            while (reader.TryReadSemanticTag(out _))
-            {
-            }
+            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
+            // value off whatever header is current without asking which major type it belongs to, so
+            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
+            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
+            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
+            // and which this converter needs, being the only one that reaches the reader below its
+            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
+            // fraction under an outer tag reads as a two-element array here as it does everywhere
+            // else.
+            reader.ReadBeginArray();
 
             int size = reader.ReadSize();
 
@@ -337,15 +341,16 @@
 
         public override (T1, T2, T3, T4, T5, T6) Read(ref CborReader reader)
         {
-            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
-            // the reader below its tag-skipping entry points. Skip them here so a tagged tuple
-            // stays readable; the tags themselves carry no information this converter needs.
-            // A loop rather than one skip: since #183 SkipSemanticTag consumes a whole stack, and
-            // stopping at the first would leave this the one converter that does not - a tag 4
-            // decimal fraction under an outer tag reads as a two-element array everywhere else.
-            while (reader.TryReadSemanticTag(out _))
-            {
-            }
+            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
+            // value off whatever header is current without asking which major type it belongs to, so
+            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
+            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
+            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
+            // and which this converter needs, being the only one that reaches the reader below its
+            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
+            // fraction under an outer tag reads as a two-element array here as it does everywhere
+            // else.
+            reader.ReadBeginArray();
 
             int size = reader.ReadSize();
 
@@ -434,15 +439,16 @@
 
         public override (T1, T2, T3, T4, T5, T6, T7) Read(ref CborReader reader)
         {
-            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
-            // the reader below its tag-skipping entry points. Skip them here so a tagged tuple
-            // stays readable; the tags themselves carry no information this converter needs.
-            // A loop rather than one skip: since #183 SkipSemanticTag consumes a whole stack, and
-            // stopping at the first would leave this the one converter that does not - a tag 4
-            // decimal fraction under an outer tag reads as a two-element array everywhere else.
-            while (reader.TryReadSemanticTag(out _))
-            {
-            }
+            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
+            // value off whatever header is current without asking which major type it belongs to, so
+            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
+            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
+            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
+            // and which this converter needs, being the only one that reaches the reader below its
+            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
+            // fraction under an outer tag reads as a two-element array here as it does everywhere
+            // else.
+            reader.ReadBeginArray();
 
             int size = reader.ReadSize();
 
@@ -539,15 +545,16 @@
         }
         public override (T1, T2, T3, T4, T5, T6, T7, T8) Read(ref CborReader reader)
         {
-            // ReadSize does not skip a semantic tag, and this is the only converter that reaches
-            // the reader below its tag-skipping entry points. Skip them here so a tagged tuple
-            // stays readable; the tags themselves carry no information this converter needs.
-            // A loop rather than one skip: since #183 SkipSemanticTag consumes a whole stack, and
-            // stopping at the first would leave this the one converter that does not - a tag 4
-            // decimal fraction under an outer tag reads as a two-element array everywhere else.
-            while (reader.TryReadSemanticTag(out _))
-            {
-            }
+            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
+            // value off whatever header is current without asking which major type it belongs to, so
+            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
+            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
+            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
+            // and which this converter needs, being the only one that reaches the reader below its
+            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
+            // fraction under an outer tag reads as a two-element array here as it does everywhere
+            // else.
+            reader.ReadBeginArray();
 
             int size = reader.ReadSize();
 


### PR DESCRIPTION
Closes #187.

Every arity now goes through `ReadBeginArray()` before `ReadSize()`, which is where every other array reader gets the major-type check.

`ReadBeginArray` is also `SkipSemanticTag(); Expect(...)`, so it subsumes the hand-rolled `while (reader.TryReadSemanticTag(out _))` loop this replaces — the tag-stack behaviour from #184 is unchanged, and `ReadTupleThroughATagStack` and `ReadADecimalFractionAsATupleThroughATagStack` still pass untouched.

## Tests

Ten new cases, **nine of which fail without the change**:

* `ANonArrayIsNotReadAsATuple` — the report's six documents (`43`, `63`, `A3`, `03`, `23`) plus `E3` (simple value 3), and two with a tag in front, since the tags are stepped over and the item beneath is still not an array
* `ANonArrayIsNotReadAsATupleOfAnyArity` — arities 2 to 7, so this is not a fix to one converter
* `AnArrayIsStillReadAsATuple` — the one row of the report's table that is a tuple; passes before and after

The message is `Expected major type Array (4)`, and with #173 it carries the path, so a tuple inside an object reports where it was.

## One thing this does not fix, found while writing the arity test

**A tuple of more than seven elements does not work at all, and did not before this.** `TupleConverterProvider` hands `Tuple8Converter` the `Rest` field's type as `T8`, while the converter declares `CborConverterBase<(T1, …, T8)>` — which C# expands to `ValueTuple<T1, …, T7, ValueTuple<T8>>`, a different type from the one being constructed. Measured on `1fdc7fc`:

| tuple | result |
|---|---|
| 7 elements | ok |
| 8 elements | `TargetInvocationException: Tuples of length 1 are not supported` — the provider recursing into a one-element `Rest` |
| 9 elements | `InvalidCastException: Unable to cast … Tuple8Converter<…,ValueTuple<int,int>> to ICborConverter<ValueTuple<…,ValueTuple<int,int>>>` |

Both directions, read and write. Neither is a `CborException`, so a caller's `catch` misses them as well.

I have kept it out of this PR because it is a different defect with a different fix, and left `Tuple8Converter` carrying the major-type check for when it becomes reachable — it is the one arity the tests cannot assert, which the test remark says. Happy to take it as its own PR; say the word and I will file the issue with the table above.

**1461 tests green on net10.0**, all four TFMs build.

---

_Generated by [Claude Code](https://claude.ai/code)_
