### PR TITLE
Validate required members declared on a derived type, closes #179

### DIFF
--- a/src/Dahomey.Cbor.Tests/RequiredTests.cs
+++ b/src/Dahomey.Cbor.Tests/RequiredTests.cs
@@ -1,4 +1,5 @@
 ﻿using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Tests.Extensions;
 using System;
 using Xunit;
 
@@ -98,6 +99,196 @@ namespace Dahomey.Cbor.Tests
             };
 
             Helper.TestWrite(obj, expectedExceptionType, options);
+        }
+
+        // ---- required members declared on a derived type ----
+
+        public abstract class Base
+        {
+            public int X { get; set; }
+        }
+
+        [CborDiscriminator("derived")]
+        public class Derived : Base
+        {
+            [CborRequired]
+            public int Y { get; set; }
+        }
+
+        [CborDiscriminator("plain")]
+        public class Plain : Base
+        {
+            public int Z { get; set; }
+        }
+
+        public abstract class RequiringBase
+        {
+            [CborRequired]
+            public int X { get; set; }
+        }
+
+        [CborDiscriminator("requiringDerived")]
+        public class RequiringDerived : RequiringBase
+        {
+            [CborRequired]
+            public int Y { get; set; }
+        }
+
+        private static CborOptions PolymorphicOptions()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<Derived>();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<Plain>();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<RequiringDerived>();
+            return options;
+        }
+
+        /// <summary>
+        /// A requirement declared only on a derived type holds when the document is read through the
+        /// base, which is the only way a polymorphic document is ever read.
+        /// </summary>
+        /// <remarks>
+        /// Whether tracking ran was decided from the <em>declared</em> type's required members, while
+        /// the check at the end iterates the <em>resolved</em> converter's - so a base declaring none
+        /// switched tracking off and the check never ran. Asserting the same document through
+        /// <c>Derived</c> as well is the point: the requirement used to hold or not depending on which
+        /// static type the caller named, which is what <c>[CborRequired]</c> exists to make impossible.
+        /// </remarks>
+        [Fact]
+        public void ARequiredMemberOfADerivedTypeIsEnforcedThroughTheBase()
+        {
+            // {"_t": "derived", "X": 1}
+            const string hexBuffer = "A2625F746764657269766564615801";
+
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Base>(hexBuffer.HexToBytes(), PolymorphicOptions()));
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Derived>(hexBuffer.HexToBytes(), PolymorphicOptions()));
+        }
+
+        [Fact]
+        public void SupplyingTheDerivedTypesRequiredMemberIsEnough()
+        {
+            // {"_t": "derived", "X": 1, "Y": 2}
+            const string hexBuffer = "A3625F746764657269766564615801615902";
+
+            Base value = Cbor.Deserialize<Base>(hexBuffer.HexToBytes(), PolymorphicOptions());
+
+            Derived derived = Assert.IsType<Derived>(value);
+            Assert.Equal(1, derived.X);
+            Assert.Equal(2, derived.Y);
+        }
+
+        /// <summary>
+        /// A sibling that requires nothing is unaffected — tracking is turned on from the resolved
+        /// type, so it is not paid for by every subtype of a hierarchy that has one demanding member.
+        /// </summary>
+        [Fact]
+        public void ASiblingWithoutRequiredMembersStillReads()
+        {
+            // {"_t": "plain", "X": 1}
+            const string hexBuffer = "A2625F7465706C61696E615801";
+
+            Base value = Cbor.Deserialize<Base>(hexBuffer.HexToBytes(), PolymorphicOptions());
+
+            Assert.Equal(1, Assert.IsType<Plain>(value).X);
+        }
+
+        /// <summary>
+        /// Both lists are enforced when the base requires something as well, so turning tracking on
+        /// from the resolved type has not replaced the declared type's requirements with it.
+        /// </summary>
+        [Theory]
+        // {"_t": "requiringDerived", "Y": 2}   -- X, declared on the base, is missing
+        [InlineData("A2625F7470726571756972696E6744657269766564615902")]
+        // {"_t": "requiringDerived", "X": 1}   -- Y, declared on the derived type, is missing
+        [InlineData("A2625F7470726571756972696E6744657269766564615801")]
+        public void AMissingRequirementOfEitherTypeIsRefused(string hexBuffer)
+        {
+            Assert.Throws<CborException>(() => Cbor.Deserialize<RequiringBase>(hexBuffer.HexToBytes(), PolymorphicOptions()));
+        }
+
+        // The other two object formats resolve the discriminator on different arms of the same
+        // switch, and the Array arm leaves the read early once it has - so each needs its own case
+        // rather than being taken as covered by the map above.
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        public abstract class IntKeyBase
+        {
+            [CborProperty(1)]
+            public int X { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        [CborDiscriminator("intDerived")]
+        public class IntKeyDerived : IntKeyBase
+        {
+            [CborProperty(2)]
+            [CborRequired]
+            public int Y { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public abstract class ArrayBase
+        {
+            [CborProperty(1)]
+            public int X { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        [CborDiscriminator("arrDerived")]
+        public class ArrayDerived : ArrayBase
+        {
+            [CborProperty(2)]
+            [CborRequired]
+            public int Y { get; set; }
+        }
+
+        [Fact]
+        public void ARequiredMemberOfADerivedTypeIsEnforcedInIntKeyMapFormat()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<IntKeyDerived>();
+
+            // {0: "intDerived", 1: 1}      -- key 0 is the discriminator's slot; 2 is missing
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<IntKeyBase>("A2006A696E74446572697665640101".HexToBytes(), options));
+
+            // {0: "intDerived", 1: 1, 2: 2}
+            IntKeyBase value = Cbor.Deserialize<IntKeyBase>(
+                "A3006A696E744465726976656401010202".HexToBytes(), options);
+
+            Assert.Equal(2, Assert.IsType<IntKeyDerived>(value).Y);
+        }
+
+        [Fact]
+        public void ARequiredMemberOfADerivedTypeIsEnforcedInArrayFormat()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<ArrayDerived>();
+
+            // [39("arrDerived"), 1]        -- item 0 is the discriminator's slot; item 2 is missing
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<ArrayBase>("82D8276A6172724465726976656401".HexToBytes(), options));
+
+            // [39("arrDerived"), 1, 2]
+            ArrayBase value = Cbor.Deserialize<ArrayBase>(
+                "83D8276A617272446572697665640102".HexToBytes(), options);
+
+            Assert.Equal(2, Assert.IsType<ArrayDerived>(value).Y);
+        }
+
+        [Fact]
+        public void SupplyingBothRequirementsReads()
+        {
+            // {"_t": "requiringDerived", "X": 1, "Y": 2}
+            const string hexBuffer = "A3625F7470726571756972696E6744657269766564615801615902";
+
+            RequiringBase value = Cbor.Deserialize<RequiringBase>(hexBuffer.HexToBytes(), PolymorphicOptions());
+
+            RequiringDerived derived = Assert.IsType<RequiringDerived>(value);
+            Assert.Equal(1, derived.X);
+            Assert.Equal(2, derived.Y);
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
@@ -26,7 +26,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// because the required check compares against another converter's member list, and it is
         /// populated whatever <see cref="DuplicateKeyMode"/> is in force.
         /// </summary>
-        private readonly HashSet<IMemberConverter>? _requiredMembersRead;
+        private HashSet<IMemberConverter>? _requiredMembersRead;
 
         private readonly bool _rejectDuplicates;
 
@@ -63,6 +63,25 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         /// <summary>Whether required members are being tracked at all.</summary>
         public readonly bool TracksRequiredMembers => _requiredMembersRead != null;
+
+        /// <summary>
+        /// Turns tracking on for a read that started without it.
+        /// </summary>
+        /// <remarks>
+        /// The constructor can only consult the <em>declared</em> type's required members, and on a
+        /// polymorphic read the list that is checked is the resolved type's - a type deriving from a
+        /// base that requires nothing may require something of its own. Called once the discriminator
+        /// has settled which converter this object is being read by, which is before its first member
+        /// is read, so nothing can already have been missed.
+        /// <para>
+        /// Idempotent, and never turns tracking off: a declared type's requirements are the derived
+        /// type's as well, so the set only ever needs to start existing.
+        /// </para>
+        /// </remarks>
+        public void TrackRequiredMembers()
+        {
+            _requiredMembersRead ??= new HashSet<IMemberConverter>();
+        }
 
         public readonly bool WasRead(IMemberConverter memberConverter)
         {

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -684,6 +684,17 @@ namespace Dahomey.Cbor.Serialization.Converters
                     {
                         context.converter = this;
                     }
+
+                    // The read state was built from this converter's required members, which on a
+                    // polymorphic read is the declared type's - so a member required only by the
+                    // resolved type had nothing tracking it, and the check at the end of Read, which
+                    // iterates the resolved converter's list, was skipped entirely. Enabled here
+                    // because this is the point the converter is settled and no member has been read
+                    // yet.
+                    if (context.converter.RequiredMemberConvertersForRead.Count != 0)
+                    {
+                        context.readState.TrackRequiredMembers();
+                    }
                 }
 
                 // Settled once, on the first item, and not revisited: every member of this object is


### PR DESCRIPTION
Closes #179.

Tracking is enabled where the discriminator settles which converter the object is being read by, rather than only from the declared type's list in the constructor. As the issue says, #174 is what makes this a small change: it pinned down that the converter is settled once, on the first item, before any member is read — so that is a point at which turning tracking on cannot already have missed something.

```csharp
if (context.converter.RequiredMemberConvertersForRead.Count != 0)
{
    context.readState.TrackRequiredMembers();
}
```

`MemberReadState.TrackRequiredMembers` is idempotent and only ever turns tracking *on*: a declared type's requirements are the derived type's as well, so the set only needs to start existing. The constructor argument stays as it was, so a type with no discriminator allocates exactly as before, and a hierarchy where only one subtype demands anything does not make every sibling pay for it.

## Tests

Five new, in `RequiredTests`. **Three fail without the change — one per object format:**

* `ARequiredMemberOfADerivedTypeIsEnforcedThroughTheBase` — `StringKeyMap`, the issue's repro, asserted through `Base` *and* through `Derived`, since the defect was that those two disagreed
* `ARequiredMemberOfADerivedTypeIsEnforcedInIntKeyMapFormat` — `{0: "intDerived", 1: 1}`
* `ARequiredMemberOfADerivedTypeIsEnforcedInArrayFormat` — `[39("arrDerived"), 1]`

The three formats resolve the discriminator on different arms of the same switch, and the `Array` arm returns from `ReadItem` early once it has, so none of them is covered by taking the others on trust. Each also asserts the complete document still reads.

**Two pin what the change must not do**, and pass before and after:

* `ASiblingWithoutRequiredMembersStillReads` — `Plain`, a subtype of the same base requiring nothing
* `AMissingRequirementOfEitherTypeIsRefused` / `SupplyingBothRequirementsReads` — a base that requires something of its own, so the resolved type's list is added to rather than substituted for it

## Scope

Read path only. Nothing about writing, about `RequirementPolicy`, or about which members a type has changes; the existing `TestRead`/`TestWrite` theories are untouched and still pass.

Not addressed here: #177 is the neighbouring question of whether a mapping should be refused at build time, which is a decision rather than a fix and belongs on its own.

**1459 tests green on net10.0**, all four TFMs build.

---

_Generated by [Claude Code](https://claude.ai/code)_
