### PR TITLE
Render a duplicate map key the same way for every decode target, closes #178

### DIFF
--- a/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
+++ b/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
@@ -210,5 +210,52 @@ namespace Dahomey.Cbor.Tests
             Assert.Contains("Duplicate map key", exception.Message);
             Assert.DoesNotContain(key, exception.Message);
         }
+
+        /// <summary>
+        /// One duplicated key reads the same way whatever it was being decoded into.
+        /// </summary>
+        /// <remarks>
+        /// The object model handed <c>MapKeyErrors</c> a <see cref="CborValue"/>, whose
+        /// <c>ToString()</c> quotes a text value - and <c>TextTruncation.Ellipsize</c> then escaped
+        /// those quotes as though they had come from the document, since it cannot know they were
+        /// added by the description. So <c>{"a": 1, "a": 2}</c> reported <c>\"a\"</c> into a
+        /// <c>CborObject</c> and <c>a</c> into a <c>Dictionary</c>, which makes the message hard to
+        /// match on and undercuts the point of routing every target through one helper.
+        /// </remarks>
+        [Fact]
+        public void TheKeyIsRenderedTheSameWayForEveryDecodeTarget()
+        {
+            // a2 6161 01 6161 02  -- {"a": 1, "a": 2}
+            const string hexBuffer = "A2616101616102";
+
+            string objectModel = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<CborObject>(hexBuffer.HexToBytes())).Message;
+            string dictionary = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<string, int>>(hexBuffer.HexToBytes())).Message;
+
+            Assert.Contains("Duplicate map key: a", objectModel);
+            Assert.Contains("Duplicate map key: a", dictionary);
+            Assert.DoesNotContain("\\", objectModel);
+
+            // a2 6141 01 6141 02  -- {"A": 1, "A": 2}, the same shape into a mapped class
+            string mappedClass = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<DuplicateHolder>("A2614101614102".HexToBytes())).Message;
+
+            Assert.Contains("Duplicate map key: A", mappedClass);
+        }
+
+        /// <summary>
+        /// A key with no quoting of its own is unchanged: only the string case is unwrapped, so a
+        /// number key still renders as the object model renders it.
+        /// </summary>
+        [Fact]
+        public void ANonTextKeyIsStillRenderedByItsOwnToString()
+        {
+            // a2 01 01 01 02  -- {1: 1, 1: 2}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<CborObject>("A20101 0102".Replace(" ", "").HexToBytes()));
+
+            Assert.Contains("Duplicate map key: 1", exception.Message);
+        }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/MapKeyErrors.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MapKeyErrors.cs
@@ -1,3 +1,4 @@
+using Dahomey.Cbor.ObjectModel;
 using Dahomey.Cbor.Util;
 
 namespace Dahomey.Cbor.Serialization.Converters
@@ -33,9 +34,26 @@ namespace Dahomey.Cbor.Serialization.Converters
             return $"Map key rejected: {Describe(key)} - {reason}";
         }
 
+        /// <remarks>
+        /// A text key is described by its text, whatever it arrived as. <see cref="CborString"/>
+        /// quotes itself in <c>ToString()</c>, so the object model handed this the six characters
+        /// <c>"a"</c> where every other decode target hands it the one character <c>a</c> - and
+        /// <see cref="TextTruncation.Ellipsize"/> then escaped those quotes as document text, since
+        /// it cannot know they were added by the description rather than present in the key. The same
+        /// document then read differently depending on what it was being read into, which is the
+        /// thing routing every target through one helper was meant to prevent.
+        /// <para>
+        /// Only the string case is unwrapped. A number, a boolean or a container key has no quoting
+        /// of its own to undo, and <c>CborValue.ToString()</c> is the right rendering for it.
+        /// </para>
+        /// </remarks>
         private static string Describe(object key)
         {
-            return TextTruncation.Ellipsize(key.ToString() ?? string.Empty);
+            string text = key is CborString cborString
+                ? cborString.Value<string>()
+                : key.ToString() ?? string.Empty;
+
+            return TextTruncation.Ellipsize(text);
         }
     }
 }


### PR DESCRIPTION
Closes #178, the rendering half.

`MapKeyErrors.Describe` unwraps a `CborString` to its text, so one duplicated key reads one way whatever it was being decoded into:

```
Duplicate map key: a        // CborObject, Dictionary<string, int>
Duplicate map key: A        // mapped class
```

Only the string case is unwrapped, and the second test pins why: a number, a boolean or a container key has no quoting of its own to undo, so `{1: 1, 1: 2}` still reports `Duplicate map key: 1` from `CborValue.ToString()`. Putting the unwrap in `Describe` rather than at the `CborValueConverter` call site keeps the one-helper property the issue is about — `Rejected` gets it too, and a fifth target would inherit it.

## Tests

Two new. `TheKeyIsRenderedTheSameWayForEveryDecodeTarget` fails without the change; `ANonTextKeyIsStillRenderedByItsOwnToString` passes before and after and is there to stop the unwrap widening.

The existing `ALongDuplicateKeyIsTruncatedInTheMessage` still passes, so truncation is unaffected — the text is shorter by two characters and goes through `Ellipsize` exactly as before.

## The other half, deliberately not here

> Worth noting alongside: the object model contributes no path segment either, so a duplicate at the root of a `CborObject` reports `$` where a dictionary reports `$.a`.

Agreed that it is the same cause, and I have left it out because it is a different kind of change. `AbstractDictionaryConverter.Read` catches around `reader.ReadMap`, describes the key it was on, and calls `PrependPathMember`; mirroring that in `CborValueConverter` is maybe fifteen lines and needs the key kept on `MapReaderContext`. But it would add a segment to **every** failure inside the object model, not only a duplicate — so `exception.Path` changes for existing callers reading into a `CborObject`, which is worth deciding as its own thing rather than riding along with a message fix.

Happy to take it. Two questions I would want settled first, since both are visible in `Path`:

1. A map **key** that fails to read has no name yet — the dictionary converter reports the index there. Same for the object model?
2. A `CborArray` contributes no index either, so `$` would still be reported for a failure inside one. Doing keys without indexes leaves the object model half-pathed, which may be worse than consistently unpathed.

**1453 tests green on net10.0**, all four TFMs build.

---

_Generated by [Claude Code](https://claude.ai/code)_
