### PR TITLE
Pin a chunked bignum magnitude

### DIFF
--- a/src/Dahomey.Cbor.Tests/BigIntegerTests.cs
+++ b/src/Dahomey.Cbor.Tests/BigIntegerTests.cs
@@ -165,6 +165,37 @@ namespace Dahomey.Cbor.Tests
             Helper.TestRead(hexBuffer, BigInteger.Parse(expectedValue));
         }
 
+        /// <summary>
+        /// A bignum whose magnitude arrives as an RFC 8949 section 3.2.3 indefinite-length byte string.
+        /// </summary>
+        /// <remarks>
+        /// Nothing here reads the chunks: <see cref="CborReader.ReadBigInteger"/> takes the magnitude
+        /// through <c>ReadSizeAndBytes</c>, which learned the encoding in #166, so this combination
+        /// started working the moment those two met and no test of either pins it. An
+        /// indefinite-length string denotes exactly the concatenation of its chunks, so the magnitude
+        /// is the same bytes it would have been in one piece and the value is unchanged -- which is
+        /// what makes it worth a test rather than a decision: a reader that got this wrong would be
+        /// silently returning a different number, not throwing.
+        /// <para>
+        /// The first pair is the shape that matters most: the accumulator joining the chunks grows by
+        /// doubling, so a two-byte chunk followed by a one-byte one leaves three bytes in a four-byte
+        /// array. A magnitude read one byte too long is a different number, not an error.
+        /// </para>
+        /// </remarks>
+        [Theory]
+        // c2 5f 42 0102 41 03 ff  -- tag 2 over the magnitude 01 02 03, in a two-byte and a one-byte chunk
+        [InlineData("C25F4201024103FF", "66051")]
+        [InlineData("C35F4201024103FF", "-66052")]
+        // A magnitude past what a basic integer reaches, split mid-value.
+        [InlineData("C25F44010000004400000000FF", "72057594037927936")]
+        // Zero chunks is an empty magnitude, which is 0 under tag 2 and -1 under tag 3.
+        [InlineData("C25FFF", "0")]
+        [InlineData("C35FFF", "-1")]
+        public void ReadAChunkedBignumMagnitude(string hexBuffer, string expectedValue)
+        {
+            Helper.TestRead(hexBuffer, BigInteger.Parse(expectedValue));
+        }
+
         [Theory]
         // A text string is rejected rather than parsed - see the remarks on ReadBigInteger.
         [InlineData("63616263")]


### PR DESCRIPTION
Five test cases, no production change. They cover a combination that started working when #166 merged and that no test on either side reaches.

## What the combination is

#181 reads a tag 2 or 3 magnitude through `ReadSizeAndBytes` (`CborReader.cs:725`), and #166 taught `ReadSizeAndBytes` RFC 8949 §3.2.3. So a bignum whose magnitude arrives in chunks decodes as of those two meeting — neither PR set out to do it, and neither one's tests notice.

```
C2 5F 42 0102 41 03 FF   ->  66051
```

Same shape as the chunked typed-array payload #166 had to revisit when #157 landed, and worth pinning for the same reason.

## Verified against both sides of the merge

The five vectors were run unchanged on `25ade47`, the last commit before #166:

```
Failed!  - Failed: 5, Passed: 0
  Dahomey.Cbor.CborException : [2] Indefinite-length byte and text strings are not supported.
     at CborReader.ThrowIndefiniteLengthString() in CborReader.cs:line 1372
     at CborReader.ReadBigInteger() in CborReader.cs:line 725
```

and on `b7bd815`, with #166 in:

```
Passed!  - Failed: 0, Passed: 5
```

So this is not a test written from reading the code — the flip is the evidence that the gap was real.

## The vector that carries it

`C2 5F 42 0102 41 03 FF` is the binding one. The accumulator that joins the chunks grows by doubling, so a two-byte chunk followed by a one-byte chunk leaves three bytes in a four-byte array. A magnitude taken one byte too long is silently a different number, not an error — which is what makes this worth a test rather than a comment. The other vectors cover a magnitude past what a basic integer reaches, split mid-value, and the two empty-magnitude cases (`C2 5F FF` is 0, `C3 5F FF` is -1).

Placed in `BigIntegerTests.cs` rather than `ChunkedStringTests.cs`, following #166's own precedent of putting the chunked typed-array case in `TypedArrayTests.cs`.

## Tests

| | |
| --- | --- |
| `Dahomey.Cbor.Tests` net10.0 | 1494 passed |
| `Dahomey.Cbor.Tests` net8.0 | 1494 passed |
| `Dahomey.Cbor.Generator.Tests` | 35 passed |
| Library build | 4 TFMs, 0 errors |

net9.0 builds but has no runtime available locally, so it is covered by CI alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7qXp52mGMyY2ksG4NgWxU


---
_Generated by [Claude Code](https://claude.ai/code/session_01G7qXp52mGMyY2ksG4NgWxU)_