### PR TITLE
Fix four defects in the CDDL schema emitter

### DIFF
--- a/src/Dahomey.Cbor.Generator/CddlEmitter.cs
+++ b/src/Dahomey.Cbor.Generator/CddlEmitter.cs
@@ -495,17 +495,24 @@ namespace Dahomey.Cbor.Generator
                 attribute.AttributeClass?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
                     == "global::System.FlagsAttribute");
 
-            if (isFlags)
+            // A memberless enum has nothing to name and nothing to enumerate, so both the choice of
+            // names and the choice of values would render empty -- and an empty choice arm (`E =  /
+            // uint`, `E = `) is not parseable CDDL, which no amount of downstream validation can
+            // recover from. Checked ahead of the flags branch, which builds a choice of its own.
+            // `int` rather than the flags branch's `uint`: with no members there is nothing to read a
+            // sign off, and only a cast can produce a value at all, so the signed prelude type is the
+            // one that cannot reject what the serializer writes.
+            if (values.Count == 0)
+            {
+                builder.Append("int");
+            }
+            else if (isFlags)
             {
                 string integerForm = hasNegative ? "int" : "uint";
 
                 builder.Append(options.EnumFormat == "WriteToString"
                     ? string.Join(" / ", names) + " / " + integerForm
                     : integerForm);
-            }
-            else if (values.Count == 0)
-            {
-                builder.Append("int");
             }
             else if (options.EnumFormat == "WriteToString")
             {
@@ -640,26 +647,16 @@ namespace Dahomey.Cbor.Generator
             builder.AppendLine("#nullable enable");
             builder.AppendLine();
 
-            bool hasNamespace = !contextSymbol.ContainingNamespace.IsGlobalNamespace;
-            string indent = hasNamespace ? "    " : string.Empty;
+            // Reopened through the same helper the converter half uses: this file is a second partial
+            // declaration of the user's own context, so an internal, nested or generic context has to
+            // be reopened exactly as it was declared.
+            string indent = Emitter.OpenContextDeclaration(builder, contextSymbol);
 
-            if (hasNamespace)
-            {
-                builder.AppendLine($"namespace {contextSymbol.ContainingNamespace.ToDisplayString()}");
-                builder.AppendLine("{");
-            }
-
-            builder.AppendLine($"{indent}public partial class {contextSymbol.Name}");
-            builder.AppendLine($"{indent}{{");
             builder.AppendLine($"{indent}    /// <summary>RFC 8610 CDDL schema for the types declared on this context.</summary>");
             builder.AppendLine($"{indent}    public const string CddlSchema =");
             builder.AppendLine($"{indent}        @\"{schema.Replace("\"", "\"\"")}\";");
-            builder.AppendLine($"{indent}}}");
 
-            if (hasNamespace)
-            {
-                builder.AppendLine("}");
-            }
+            Emitter.CloseContextDeclaration(builder, contextSymbol, indent);
 
             return builder.ToString();
         }

--- a/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
+++ b/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
@@ -248,6 +248,11 @@ namespace Dahomey.Cbor.Generator
                 case SpecialType.System_String:
                     return "tstr";
 
+                // CharConverter writes a char through CborWriter.WriteChar, which UTF-8 encodes the
+                // single character and writes it as a text string -- not as an integer code point.
+                case SpecialType.System_Char:
+                    return "tstr";
+
                 case SpecialType.System_Object:
                     return "any";
 
@@ -263,10 +268,23 @@ namespace Dahomey.Cbor.Generator
                     };
             }
 
+            // BigInteger has no SpecialType, so it is matched by name -- as TypeCollector.IsPrimitive
+            // does, which is what lets it reach this method at all. CborWriter.WriteBigInteger emits a
+            // basic integer whenever the value fits the ulong-bounded header (which reaches -2^64 on
+            // the negative side) and only falls back to the RFC 8949 section 3.4.3 bignum tags beyond
+            // it, so all three forms belong in the choice. The parentheses matter: RFC 8610's
+            // memberkey production takes a type1, not a type, so a bare `/` choice cannot appear
+            // there -- `{* int / #6.2(bstr) => tstr}` is a parse error, while a parenthesised type is
+            // a type2 and is legal in every position this rendering can land in.
+            if (type.ToDisplayString() == "System.Numerics.BigInteger")
+            {
+                return "(int / #6.2(bstr) / #6.3(bstr))";
+            }
+
             // System.Decimal is deliberately absent: it is written as 0xFC plus 16 bytes, and
             // additional information 28 is reserved and ill-formed under RFC 8949 section 3, so no
-            // conforming decoder can read it and no CDDL can describe it. Guid, DateTimeOffset and
-            // char have no scalar converter either. Nor does System.Half: the only place the library
+            // conforming decoder can read it and no CDDL can describe it. Guid and DateTimeOffset
+            // have no scalar converter either. Nor does System.Half: the only place the library
             // references it is the RFC 8746 typed-array element path, which writes `#6.84(bstr)` --
             // a different representation entirely, not this method's concern. Each falls through to
             // CBOR1011 rather than asserting a row no converter backs.

--- a/src/Dahomey.Cbor.Generator/Emitter.cs
+++ b/src/Dahomey.Cbor.Generator/Emitter.cs
@@ -30,6 +30,30 @@ namespace Dahomey.Cbor.Generator
             builder.AppendLine("using Dahomey.Cbor.Serialization.Converters.Mappings;");
             builder.AppendLine();
 
+            string indent = OpenContextDeclaration(builder, contextSymbol);
+
+            EmitTypedAccessors(builder, indent, ordered, roots);
+            EmitConfigure(builder, indent, options, ordered);
+            EmitRegisterHelper(builder, indent);
+
+            CloseContextDeclaration(builder, contextSymbol, indent);
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Writes the namespace, the containing-type chain and the context's own partial declaration,
+        /// and returns the indent its members belong at. <see cref="CloseContextDeclaration"/> closes
+        /// exactly what this opened.
+        /// </summary>
+        /// <remarks>
+        /// Shared with <see cref="CddlEmitter"/>, which reopens the same user type in a second file.
+        /// Both halves have to reopen it identically: a hardcoded <c>public partial class Name</c> is
+        /// CS0262 against an internal context, CS0264 against a generic one, and lands a stray
+        /// top-level type beside a nested one.
+        /// </remarks>
+        public static string OpenContextDeclaration(StringBuilder builder, INamedTypeSymbol contextSymbol)
+        {
             bool hasNamespace = !contextSymbol.ContainingNamespace.IsGlobalNamespace;
             string indent = hasNamespace ? "    " : string.Empty;
 
@@ -42,16 +66,7 @@ namespace Dahomey.Cbor.Generator
             // A nested context needs every containing type reopened as a partial, or the generated
             // half lands as a top-level type and Configure is never implemented -- which surfaces as
             // CS0534 on the user's own class, naming nothing to do with generators.
-            List<INamedTypeSymbol> containers = new List<INamedTypeSymbol>();
-
-            for (INamedTypeSymbol? container = contextSymbol.ContainingType;
-                 container is not null;
-                 container = container.ContainingType)
-            {
-                containers.Insert(0, container);
-            }
-
-            foreach (INamedTypeSymbol container in containers)
+            foreach (INamedTypeSymbol container in Containers(contextSymbol))
             {
                 builder.AppendLine($"{indent}{Accessibility(container)} partial {Keyword(container)} {NameWithTypeParameters(container)}");
                 builder.AppendLine($"{indent}{{");
@@ -63,24 +78,43 @@ namespace Dahomey.Cbor.Generator
             builder.AppendLine($"{indent}{Accessibility(contextSymbol)} partial class {NameWithTypeParameters(contextSymbol)}");
             builder.AppendLine($"{indent}{{");
 
-            EmitTypedAccessors(builder, indent, ordered, roots);
-            EmitConfigure(builder, indent, options, ordered);
-            EmitRegisterHelper(builder, indent);
+            return indent;
+        }
 
+        /// <summary>
+        /// Closes the braces <see cref="OpenContextDeclaration"/> opened, given the indent it returned.
+        /// </summary>
+        public static void CloseContextDeclaration(StringBuilder builder, INamedTypeSymbol contextSymbol, string indent)
+        {
             builder.AppendLine($"{indent}}}");
 
-            for (int i = containers.Count - 1; i >= 0; i--)
+            for (int i = Containers(contextSymbol).Count - 1; i >= 0; i--)
             {
                 indent = indent.Substring(4);
                 builder.AppendLine($"{indent}}}");
             }
 
-            if (hasNamespace)
+            if (!contextSymbol.ContainingNamespace.IsGlobalNamespace)
             {
                 builder.AppendLine("}");
             }
+        }
 
-            return builder.ToString();
+        /// <summary>
+        /// The containing-type chain, outermost first.
+        /// </summary>
+        private static List<INamedTypeSymbol> Containers(INamedTypeSymbol contextSymbol)
+        {
+            List<INamedTypeSymbol> containers = new List<INamedTypeSymbol>();
+
+            for (INamedTypeSymbol? container = contextSymbol.ContainingType;
+                 container is not null;
+                 container = container.ContainingType)
+            {
+                containers.Insert(0, container);
+            }
+
+            return containers;
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlContextDeclarationTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlContextDeclarationTests.cs
@@ -1,0 +1,112 @@
+using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
+using System.Linq;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Cddl
+{
+    /// <summary>
+    /// The CDDL schema is a second partial declaration of the user's own context, so it has to reopen
+    /// that context exactly as it was declared. These cases cannot be written as ordinary fixtures:
+    /// each one's symptom is that the test project stops compiling.
+    /// </summary>
+    public class CddlContextDeclarationTests
+    {
+        private const string Preamble = @"
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+
+namespace Harness
+{
+";
+
+        /// <summary>
+        /// A hardcoded <c>public</c> against an internal context is CS0262 -- and since the attribute
+        /// is opt-in on a context that already compiles, that is a working project broken by adding
+        /// it.
+        /// </summary>
+        [Fact]
+        public void InternalContextIsReopenedWithItsDeclaredAccessibility()
+        {
+            ImmutableArray<Diagnostic> errors = CddlGeneratorHarness.RunAndGetCompilationErrors(Preamble + @"
+    public class Person { public int Age { get; set; } }
+
+    [CborSerializable(typeof(Person))]
+    [CborCddlSchema]
+    internal partial class HarnessContext : CborSerializerContext { }
+}
+");
+
+            Assert.Empty(errors);
+        }
+
+        /// <summary>
+        /// A nested context needs every containing type reopened, or the schema half lands as a new
+        /// top-level type: no error, and <c>Outer.HarnessContext.CddlSchema</c> simply does not exist.
+        /// Asserting on the emitted text as well as on the absence of errors is what catches that,
+        /// since a stray top-level type compiles perfectly well.
+        /// </summary>
+        [Fact]
+        public void NestedContextIsReopenedInsideItsContainingType()
+        {
+            const string Source = Preamble + @"
+    public class Person { public int Age { get; set; } }
+
+    public partial class Outer
+    {
+        [CborSerializable(typeof(Person))]
+        [CborCddlSchema]
+        public partial class HarnessContext : CborSerializerContext { }
+    }
+}
+";
+
+            Assert.Empty(CddlGeneratorHarness.RunAndGetCompilationErrors(Source));
+
+            // The schema file specifically, not every generated source: the converter half reopens
+            // Outer correctly on its own, so searching the concatenation would pass either way.
+            Assert.Contains("partial class Outer", CddlGeneratorHarness.RunAndGetCddlSource(Source));
+        }
+
+        /// <summary>
+        /// A generic context reopened without its type parameters is CS0264. Asserted on the emitted
+        /// text rather than on compiler errors: a generic context is unusable for other reasons -- the
+        /// generator's own <c>Default&lt;T&gt;</c> entry point takes a closed type -- so the CS0264 the
+        /// hardcoded name produced is not the only thing wrong with this shape, and pinning the text is
+        /// what keeps the assertion about this file.
+        /// </summary>
+        [Fact]
+        public void GenericContextIsReopenedWithItsTypeParameters()
+        {
+            string generated = CddlGeneratorHarness.RunAndGetCddlSource(Preamble + @"
+    public class Person { public int Age { get; set; } }
+
+    [CborSerializable(typeof(Person))]
+    [CborCddlSchema]
+    public partial class HarnessContext<T> : CborSerializerContext { }
+}
+");
+
+            Assert.Contains("partial class HarnessContext<T>", generated);
+        }
+
+        /// <summary>
+        /// The ordinary case, so that an assertion of "no errors" above is worth something: the same
+        /// harness over a plain public top-level context has to be clean too.
+        /// </summary>
+        [Fact]
+        public void PublicTopLevelContextStillCompiles()
+        {
+            ImmutableArray<Diagnostic> errors = CddlGeneratorHarness.RunAndGetCompilationErrors(Preamble + @"
+    public class Person { public int Age { get; set; } }
+
+    [CborSerializable(typeof(Person))]
+    [CborCddlSchema]
+    public partial class HarnessContext : CborSerializerContext { }
+}
+");
+
+            Assert.Empty(errors);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlDiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlDiagnosticTests.cs
@@ -135,22 +135,9 @@ namespace Harness
             Assert.Equal(DiagnosticSeverity.Error, reported.Severity);
         }
 
-        /// <summary>char has no scalar CBOR converter either.</summary>
-        [Fact]
-        public void CharHasNoCddlRepresentation()
-        {
-            ImmutableArray<Diagnostic> diagnostics = CddlGeneratorHarness.Run(Preamble + @"
-    public class Letter { public char Value { get; set; } }
-
-    [CborSerializable(typeof(Letter))]
-    [CborCddlSchema]
-    public partial class HarnessContext : CborSerializerContext { }
-}
-");
-
-            Diagnostic reported = Assert.Single(diagnostics, d => d.Id == "CBOR1011");
-            Assert.Equal(DiagnosticSeverity.Error, reported.Severity);
-        }
+        // char and BigInteger are deliberately absent from this file: both have concrete converters
+        // (CharConverter and BigIntegerConverter), so both render rather than raising CBOR1011.
+        // CddlScalarMappingTests pins what they render as.
 
         /// <summary>
         /// DateTimeOffset has no scalar converter either -- only System.DateTime does, via

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlFlagsEnumTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlFlagsEnumTests.cs
@@ -65,6 +65,35 @@ namespace Dahomey.Cbor.Tests.Cddl
     {
     }
 
+    /// <summary>
+    /// A <c>[Flags]</c> enum with no declared members: legal C#, and the one shape where the flags
+    /// branch's choice of names has no arms to render. It has to reach the memberless fallback ahead
+    /// of the flags branch, because <c>E =  / uint</c> is not parseable CDDL -- and an unparseable
+    /// schema is the one defect gem validation cannot report, since it never gets past the parse.
+    /// </summary>
+    [Flags]
+    public enum CddlEmptyFlags
+    {
+    }
+
+    public class CddlEmptyFlagsHolder
+    {
+        public CddlEmptyFlags Value { get; set; }
+    }
+
+    [CborSerializable(typeof(CddlEmptyFlagsHolder))]
+    [CborCddlSchema]
+    public partial class CddlEmptyFlagsContext : CborSerializerContext
+    {
+    }
+
+    [CborSerializable(typeof(CddlEmptyFlagsHolder))]
+    [CborCddlSchema]
+    [CborSourceGenerationOptions(EnumFormat = ValueFormat.WriteToString)]
+    public partial class CddlEmptyFlagsStringContext : CborSerializerContext
+    {
+    }
+
     public class CddlFlagsEnumTests
     {
         private static readonly CddlFlagsContext IntContext =
@@ -92,6 +121,35 @@ namespace Dahomey.Cbor.Tests.Cddl
         public void FlagsEnumWithANegativeMemberRendersTheSignedIntegerForm()
         {
             Assert.Contains("CddlSignedFlags = int", CddlSignedFlagsContext.CddlSchema);
+        }
+
+        /// <summary>
+        /// Both formats, because only the WriteToString one used to render an empty choice arm --
+        /// and the assertion is the same either way, since a memberless enum has nothing to name.
+        /// </summary>
+        [Fact]
+        public void MemberlessFlagsEnumRendersTheSignedIntegerFormInBothFormats()
+        {
+            Assert.Contains("CddlEmptyFlags = int", CddlEmptyFlagsContext.CddlSchema);
+            Assert.Contains("CddlEmptyFlags = int", CddlEmptyFlagsStringContext.CddlSchema);
+        }
+
+        /// <summary>
+        /// The point of the fix: the emitted text has to survive the gem's parser at all. A cast is
+        /// the only way to give a memberless enum a value, and it is written as a plain integer.
+        /// </summary>
+        [CddlFact]
+        public void MemberlessFlagsEnumSchemaParsesAndAdmitsACastValue()
+        {
+            CddlEmptyFlagsHolder value = new CddlEmptyFlagsHolder { Value = (CddlEmptyFlags)3 };
+
+            byte[] cbor = Helper.Write(
+                value, CborSerializerContext.Default<CddlEmptyFlagsContext>().Options).HexToBytes();
+
+            CddlResult result = CddlTool.Validate(
+                CddlEmptyFlagsContext.CddlSchema, "CddlEmptyFlagsHolder", cbor);
+
+            Assert.True(result.Ok, result.Output);
         }
 
         [CddlFact]

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlGeneratorHarness.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlGeneratorHarness.cs
@@ -64,15 +64,7 @@ namespace Dahomey.Cbor.Tests.Cddl
         /// </remarks>
         public static string RunAndGetCddlSchema(string source)
         {
-            GeneratorDriver driver = CSharpGeneratorDriver
-                .Create(new CborSourceGenerator())
-                .RunGenerators(Compile(source));
-
-            string generated = driver.GetRunResult().Results
-                .SelectMany(result => result.GeneratedSources)
-                .Where(candidate => candidate.HintName.EndsWith(".CddlSchema.g.cs", StringComparison.Ordinal))
-                .Select(candidate => candidate.SourceText.ToString())
-                .Single();
+            string generated = RunAndGetCddlSource(source);
 
             // EmitSource writes `public const string CddlSchema =` followed by a verbatim string and
             // nothing else after it, so the last `";` in that one file closes the schema. Doubled
@@ -81,6 +73,51 @@ namespace Dahomey.Cbor.Tests.Cddl
             int end = generated.LastIndexOf("\";", StringComparison.Ordinal);
 
             return generated.Substring(start, end - start).Replace("\"\"", "\"").Replace("\r\n", "\n");
+        }
+
+        /// <summary>
+        /// The C# of the schema file alone -- the <c>.CddlSchema.g.cs</c> the CDDL emitter adds, not
+        /// the converter half <see cref="Emitter"/> adds beside it.
+        /// </summary>
+        /// <remarks>
+        /// Which file the text came from is the whole assertion for anything about how the context is
+        /// reopened: the converter half already reopens containing types correctly, so a test that
+        /// searched the concatenation of every generated source would pass on its output alone and say
+        /// nothing about this one.
+        /// </remarks>
+        public static string RunAndGetCddlSource(string source)
+        {
+            GeneratorDriver driver = CSharpGeneratorDriver
+                .Create(new CborSourceGenerator())
+                .RunGenerators(Compile(source));
+
+            return driver.GetRunResult().Results
+                .SelectMany(result => result.GeneratedSources)
+                .Where(candidate => candidate.HintName.EndsWith(".CddlSchema.g.cs", StringComparison.Ordinal))
+                .Select(candidate => candidate.SourceText.ToString())
+                .Single();
+        }
+
+        /// <summary>
+        /// Runs the generator and hands back the errors the C# compiler raises over the source
+        /// <em>plus</em> everything the generator added.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Run"/> reports what the generator itself says, which is silent about the
+        /// failure mode where the emitted code is well-formed on its own but does not agree with the
+        /// user's declaration -- a partial reopened with the wrong accessibility (CS0262) or without
+        /// its type parameters (CS0264). Those only surface once the two halves are compiled
+        /// together, which is what this does.
+        /// </remarks>
+        public static ImmutableArray<Diagnostic> RunAndGetCompilationErrors(string source)
+        {
+            CSharpGeneratorDriver
+                .Create(new CborSourceGenerator())
+                .RunGeneratorsAndUpdateCompilation(Compile(source), out Compilation updated, out _);
+
+            return updated.GetDiagnostics()
+                .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                .ToImmutableArray();
         }
 
         private static CSharpCompilation Compile(string source)

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlScalarMappingTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlScalarMappingTests.cs
@@ -1,0 +1,117 @@
+using System.Numerics;
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Cddl
+{
+    /// <summary>
+    /// The two scalars whose CDDL is neither a prelude name nor a range, and which reach
+    /// <c>CddlTypeReference.RenderPrimitive</c> by a route of their own: <c>char</c> is a
+    /// <c>SpecialType</c> that renders as text rather than as a number, and <c>BigInteger</c> has no
+    /// <c>SpecialType</c> at all and is matched by name.
+    /// </summary>
+    public class CddlScalars
+    {
+        public char Initial { get; set; }
+        public BigInteger Big { get; set; }
+    }
+
+    [CborSerializable(typeof(CddlScalars))]
+    [CborCddlSchema]
+    public partial class CddlScalarsContext : CborSerializerContext
+    {
+    }
+
+    public class CddlScalarMappingTests
+    {
+        private static readonly CddlScalarsContext Context =
+            CborSerializerContext.Default<CddlScalarsContext>();
+
+        /// <summary>
+        /// <c>CharConverter.Write</c> calls <c>CborWriter.WriteChar</c>, which UTF-8 encodes the one
+        /// character and writes it as a text string -- not as an integer code point, which is the
+        /// mapping a reader of the type alone would expect.
+        /// </summary>
+        [Fact]
+        public void CharIsATextString()
+        {
+            Assert.Contains("\"Initial\": tstr,", CddlScalarsContext.CddlSchema.Replace("\r\n", "\n"));
+        }
+
+        /// <summary>
+        /// All three forms, because <c>CborWriter.WriteBigInteger</c> emits a basic integer whenever
+        /// the value fits the ulong-bounded header and only tags beyond it -- so a schema naming just
+        /// the bignum tags would reject the common case, and one naming just <c>int</c> would reject
+        /// the large one. Parenthesised so the choice is a <c>type2</c>, legal in a memberkey too.
+        /// </summary>
+        [Fact]
+        public void BigIntegerIsTheBasicIntegerOrEitherBignumTag()
+        {
+            Assert.Contains(
+                "\"Big\": (int / #6.2(bstr) / #6.3(bstr)),",
+                CddlScalarsContext.CddlSchema.Replace("\r\n", "\n"));
+        }
+
+        [CddlFact]
+        public void SerializerOutputValidatesAgainstTheSchema()
+        {
+            CddlScalars value = new CddlScalars { Initial = 'A', Big = new BigInteger(42) };
+
+            byte[] cbor = Helper.Write(value, Context.Options).HexToBytes();
+
+            CddlResult result = CddlTool.Validate(CddlScalarsContext.CddlSchema, "CddlScalars", cbor);
+
+            Assert.True(result.Ok, result.Output);
+        }
+
+        /// <summary>
+        /// The arm that the basic-integer case never reaches: <c>ulong.MaxValue + 1</c> is the first
+        /// value <c>WriteBigInteger</c> cannot fit in a header, so it is written as tag 2 over a byte
+        /// string. This is what makes the three-arm choice load-bearing rather than defensive.
+        /// </summary>
+        [CddlFact]
+        public void BignumTaggedOutputValidatesAgainstTheSchema()
+        {
+            CddlScalars value = new CddlScalars
+            {
+                Initial = 'A',
+                Big = new BigInteger(ulong.MaxValue) + BigInteger.One,
+            };
+
+            string hex = Helper.Write(value, Context.Options);
+
+            // Sanity on the premise: c2 is tag 2 (unsigned bignum). Without this the test would still
+            // pass if the writer had quietly emitted a basic integer, proving nothing about the tags.
+            Assert.Contains("C2", hex);
+
+            CddlResult result = CddlTool.Validate(
+                CddlScalarsContext.CddlSchema, "CddlScalars", hex.HexToBytes());
+
+            Assert.True(result.Ok, result.Output);
+        }
+
+        /// <summary>
+        /// A negative magnitude past the header bound takes the tag 3 arm.
+        /// </summary>
+        [CddlFact]
+        public void NegativeBignumTaggedOutputValidatesAgainstTheSchema()
+        {
+            CddlScalars value = new CddlScalars
+            {
+                Initial = 'A',
+                Big = BigInteger.MinusOne - (new BigInteger(ulong.MaxValue) + BigInteger.One),
+            };
+
+            string hex = Helper.Write(value, Context.Options);
+
+            Assert.Contains("C3", hex);
+
+            CddlResult result = CddlTool.Validate(
+                CddlScalarsContext.CddlSchema, "CddlScalars", hex.HexToBytes());
+
+            Assert.True(result.Ok, result.Output);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -395,6 +395,23 @@ namespace Dahomey.Cbor.Tests
                 return new Cddl.CddlRuleNamingOtherHolder { Value = new N.Other.Inner { Value = 2 } };
             }
 
+            if (type == typeof(Cddl.CddlScalars))
+            {
+                // A BigInteger past the ulong-bounded header, so the corpus covers the tag 2 bignum
+                // path rather than only the basic-integer one a small value would take.
+                return new Cddl.CddlScalars
+                {
+                    Initial = 'A',
+                    Big = new System.Numerics.BigInteger(ulong.MaxValue) + System.Numerics.BigInteger.One,
+                };
+            }
+
+            if (type == typeof(Cddl.CddlEmptyFlagsHolder))
+            {
+                // A memberless enum has no name to take a value from; a cast is the only way.
+                return new Cddl.CddlEmptyFlagsHolder { Value = (Cddl.CddlEmptyFlags)3 };
+            }
+
             if (type == typeof(GeneratedOptionHolder))
             {
                 return new GeneratedOptionHolder


### PR DESCRIPTION
Follow-up to the review on #159, now that it is merged. Four defects in the CDDL emitter, each with a test that fails without its fix.

## Reopen the context as it was declared

`CddlEmitter.EmitSource` hardcoded `public partial class <SimpleName>` at namespace level. The schema file is a second partial declaration of the user's own context, so it has to reopen it exactly as declared — `Emitter.Emit` already did this correctly, walking the containing-type chain and emitting the declared accessibility and type parameters.

Three shapes broke: an `internal` context is CS0262, a generic one is CS0264, and a nested one gets a stray top-level type — no error, but `Outer.Inner.CddlSchema` simply does not exist. Since `[CborCddlSchema]` is opt-in on a context that already compiles, adding the attribute broke a working project.

`Emitter`'s header logic is extracted into `OpenContextDeclaration`/`CloseContextDeclaration` and both emit targets now share it, so the two halves cannot drift apart again.

## Render `char` instead of rejecting it

The fall-through comment claimed `char` has no scalar converter. It does: `PrimitiveConverterProvider` maps `TypeCode.Char` to `CharConverter`, which calls `CborWriter.WriteChar` — the character UTF-8 encoded as a text string. `TypeCollector.IsPrimitive` accepts `System_Char` too, so a `char` member reached `RenderPrimitive`, found no case, and became a `CBOR1011` build error on a member that serializes fine.

The diagnostic test that pinned the old behaviour asserted the same false premise, so it is replaced rather than kept.

## Render `BigInteger`

`TypeCollector.IsPrimitive` opts `BigInteger` in by name — it has no `SpecialType` — but `RenderPrimitive` switched on `SpecialType` alone, so it fell through to `CBOR1011`. Unlike `decimal`, it was absent from the documented exclusions and untested either way.

`CborWriter.WriteBigInteger` emits a basic integer while the value fits the `ulong`-bounded header, which reaches -2^64 on the negative side, and only falls back to the RFC 8949 §3.4.3 bignum tags beyond it. All three forms therefore belong in the choice: `(int / #6.2(bstr) / #6.3(bstr))`. The parentheses are load-bearing — RFC 8610's `memberkey` production takes a `type1`, not a `type`, so a bare choice cannot appear as a map key.

## Guard the memberless enum ahead of the flags branch

The `values.Count == 0` fallback guarded only the non-flags path, so a `[Flags]` enum with no members under `EnumFormat = WriteToString` rendered an empty choice arm: `E =  / uint`. That is the one defect the gem-based validation cannot report, because it never gets past the parse.

## Verification

- 1672 tests pass on net10.0 and net8.0, 0 skipped, with the `cddl` gem installed and `CDDL_REQUIRED=1` so no schema test skips itself.
- 35 generator tests pass; all four TFMs build.
- Each new test was run against the unfixed emitter and confirmed to fail: `char` and `BigInteger` as `CBOR1011` build errors, `EveryEmittedSchemaParses` on the unparseable flags rule, and the three context-declaration tests. `PublicTopLevelContextStillCompiles` is the deliberate control and passes either way.

Two lower-likelihood findings from the review are **not** addressed here, as each needs a design call: `QualifiedSimpleName` flattens namespace and containing-type chains with the same `-` separator, so the collision-breaking name can itself collide; and rule names are raw C# type names while RFC 8610's `id` production is ASCII-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)