### PR TITLE
Pin the member-level shape #187 asked for, and refresh a stale remark

### DIFF
--- a/src/Dahomey.Cbor.Tests/SemanticTagProbeTests.cs
+++ b/src/Dahomey.Cbor.Tests/SemanticTagProbeTests.cs
@@ -257,11 +257,12 @@ namespace Dahomey.Cbor.Tests
         /// this change rather than a bug on master.
         /// </summary>
         /// <remarks>
-        /// <c>TupleConverter</c> is the only converter that reaches the reader below its
-        /// tag-skipping entry points -- <c>Read</c> opens with <c>ReadSize()</c>, which inspects the
-        /// header directly -- so it relied on the member null probe consuming the tag on its behalf.
-        /// Once that probe stopped consuming, the tag byte's low five bits were read as the array
-        /// size and the arity check fired. Each arity now skips its own tag.
+        /// <c>TupleConverter</c> used to reach the reader below its tag-skipping entry points --
+        /// <c>Read</c> opened with <c>ReadSize()</c>, which inspects the header directly -- so it
+        /// relied on the member null probe consuming the tag on its behalf. Once that probe stopped
+        /// consuming, the tag byte's low five bits were read as the array size and the arity check
+        /// fired. Since #189 each arity opens with <c>ReadBeginArray()</c>, which skips the whole tag
+        /// stack before it checks the major type, so the tag is this converter's own business again.
         /// </remarks>
         [Fact]
         public void ATaggedTupleIsStillReadable()

--- a/src/Dahomey.Cbor.Tests/TupleTests.cs
+++ b/src/Dahomey.Cbor.Tests/TupleTests.cs
@@ -1,3 +1,4 @@
+using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.Tests.Extensions;
 using Xunit;
 
@@ -113,6 +114,45 @@ namespace Dahomey.Cbor.Tests
         public void AnArrayIsStillReadAsATuple()
         {
             Assert.Equal((1, 2, 3), Helper.Read<(int, int, int)>("83010203"));
+        }
+
+        public class TupleMember
+        {
+            [CborProperty("a")]
+            public (int, int) A { get; set; }
+
+            [CborProperty("b")]
+            public int B { get; set; }
+        }
+
+        /// <summary>
+        /// A wrong-shaped member is rejected where it sits, rather than read across the item boundary.
+        /// </summary>
+        /// <remarks>
+        /// The arity check alone did not catch either of these: the byte string's additional value was
+        /// the arity, so the converter read the tuple's items out of whatever followed the head. In
+        /// <c>A261614201026162182A</c> the two content bytes happen to be two items, so the whole
+        /// document read cleanly: <c>a</c> came back as <c>(1, 2)</c> and <c>b</c> as 42, with nothing
+        /// to say the member had been encoded as a byte string. In <c>A2616142182A616207</c> they are
+        /// one item - <c>18 2A</c> is 42 - so the second was taken from past the end of the byte
+        /// string, and the *key* <c>"b"</c> was read as the tuple's second element.
+        /// <para>
+        /// Both now stop at the member, and <see cref="CborException.Path"/> names it: the failure is
+        /// reported at <c>$.a</c>, not at <c>$.a[1]</c> inside a tuple that was never there.
+        /// </para>
+        /// </remarks>
+        [Theory]
+        // {"a": h'0102', "b": 42} -- content bytes that do parse as two items
+        [InlineData("A261614201026162182A")]
+        // {"a": h'182A', "b": 7}  -- content bytes that do not, so the read used to run past the item
+        [InlineData("A2616142182A616207")]
+        public void AWrongShapedMemberIsNotReadAcrossTheItemBoundary(string hexBuffer)
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<TupleMember>(hexBuffer.HexToBytes()));
+
+            Assert.Contains("Expected major type Array", exception.Message);
+            Assert.Equal("$.a", exception.Path);
         }
 
         [Fact]


### PR DESCRIPTION
Follow-up to #189. Test-only — no production code touched.

## The case #187 asked for and #189 left out

The report closed on a specific request: cover `{"a": h'182A', "b": 7}`, "to pin that a wrong-shaped member is rejected rather than read across the item boundary." #189 pins the rejection at the *root*, where a non-array is the whole document. Both of the issue's failure modes are about a wrong-shaped **member**, and neither is caught by the arity check alone — so that is the row that was missing.

`AWrongShapedMemberIsNotReadAcrossTheItemBoundary` is a `[Theory]` over both documents from the report, read into a `TupleMember { (int, int) a; int b; }`. Measured against #189's parent, both fail:

| document | without the converter change |
|---|---|
| `A261614201026162182A` — `{"a": h'0102', "b": 42}` | **no exception at all**: the two content bytes happen to be two items, so a `byte[]` member decodes as a tuple and the rest of the map reads cleanly |
| `A2616142182A616207` — `{"a": h'182A', "b": 7}` | `[7] Invalid major type TextString` at `$.a[1]` — `18 2A` is one item, so the second was taken from past the end of the byte string, eating the key `"b"` |

Both now stop at the member. The test asserts the path as well as the message: `$.a`, not `$.a[1]` inside a tuple that was never there — which is the half of the report that #173's paths made visible.

## The stale remark

`ATaggedTupleIsStillReadable` in `SemanticTagProbeTests` still described `TupleConverter.Read` as opening with `ReadSize()` and each arity as "skipping its own tag". That is the state before #189 — it now opens with `ReadBeginArray()`, which does the skip as part of the major-type check. Reworded to the past tense with the reason it changed, since the test itself is still guarding the same regression.

## Tests

**1651 passed, 42 skipped** on `net10.0` and `net8.0`, 35 in `Generator.Tests`, all four TFMs build — on `285f2d1`, i.e. `master` with #189 merged.

## Not in this PR

Two adjacent defects found while reviewing #189, both filed rather than fixed here:

* #198 — a tuple of more than seven elements cannot be read or written at all, in either direction, and neither failure is a `CborException`
* #199 — `TupleConverter` never consumes the break of an indefinite-length array and never checks it ends, so extra items are silently dropped and an indefinite-length tuple is only readable as the whole document


---
_Generated by [Claude Code](https://claude.ai/code/session_01825HbSG68Uq5S59Mx2oSF5)_