### PR TITLE
Narrow the derived-type tracking check to the polymorphic read

### DIFF
--- a/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberReadState.cs
@@ -21,8 +21,9 @@ namespace Dahomey.Cbor.Serialization.Converters
     public struct MemberReadState
     {
         /// <summary>
-        /// Null when the type has no required members, which is what keeps the set off the common
-        /// path. Not merged with the duplicate tracking below: this one holds member converters,
+        /// Null while nothing requires tracking - neither the declared type nor, once a discriminator
+        /// has settled it, the resolved one - which is what keeps the set off the common path. Not
+        /// merged with the duplicate tracking below: this one holds member converters,
         /// because the required check compares against another converter's member list, and it is
         /// populated whatever <see cref="DuplicateKeyMode"/> is in force.
         /// </summary>

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -733,8 +733,10 @@ namespace Dahomey.Cbor.Serialization.Converters
                     // resolved type had nothing tracking it, and the check at the end of Read, which
                     // iterates the resolved converter's list, was skipped entirely. Enabled here
                     // because this is the point the converter is settled and no member has been read
-                    // yet.
-                    if (context.converter.RequiredMemberConvertersForRead.Count != 0)
+                    // yet. Only when the discriminator moved the read off this converter: where it did
+                    // not, the constructor asked this same question of this same list already.
+                    if (context.converter != this
+                        && context.converter.RequiredMemberConvertersForRead.Count != 0)
                     {
                         context.readState.TrackRequiredMembers();
                     }


### PR DESCRIPTION
Two follow-ups from reviewing #190, now that it has merged. No behaviour change — the fix it landed is correct and stays exactly as effective.

## The check ran on every object read

`ReadItem` enables required-member tracking from the *resolved* converter, which is what #190 fixed. But it asked the question at the first item of **every** object read, including the common case where the discriminator left the read on this same converter — the case the constructor already settled from this same list, in `Read`:

```csharp
readState = new MemberReadState(
    trackRequiredMembers: _requiredMemberConvertersForRead.Count != 0,
    ...)
```

So a non-polymorphic read paid two interface calls per object (`RequiredMemberConvertersForRead`, then `.Count`) to re-derive a boolean it already had. On a path the rest of the file works hard to keep cheap — the ordinal bitmask, the `HashSet` left null — that is worth not spending.

Guarded on `context.converter != this`. `ReadItem` is an instance method of the converter `Read` was called on, so that condition is exactly "the discriminator moved the read elsewhere", which is the only case the constructor could not have seen.

## A comment that no longer described the field

`MemberReadState._requiredMembersRead` still documented null as meaning the declared type requires nothing. Since #190 it means neither the declared type nor the resolved one does — the set can now start existing partway through a read.

## Verification

Both TFMs I can run locally: **1657 passed, 0 failed, 42 skipped** on `net10.0` and `net8.0`. All four TFMs build. The 42 skipped are pre-existing on `master`.

I also confirmed the guard does not narrow what #190 catches. Reverting the production code and keeping the tests fails the same three cases as before, one per object format, and the three `RequiredTests` cases that read *through* the derived type — where `context.converter == this` — still pass, since the constructor covers them.

Beyond #190's own tests, I probed three paths it does not cover and found the fix already handles them all: a derived type with a `[CborConstructor]` (the `CreatorMapping` path), a derived type read as a nested member, and the interaction with `DuplicateKeyMode.Reject`. Each was red before #190 and green after. Those probes are not included here — they were written to check the fix, and the three formats are already pinned.

## Not addressed

`Dahomey.Cbor.Generator` does not handle `[CborRequired]` at all — no occurrence in `Emitter.cs` — so there is no twin defect there, but the feature is simply absent from generated converters. That may deserve its own issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqpD95muWWyn6p2nh4WgT5)_