### PR TITLE
Leave the read on the discriminator item itself, closes #202

### DIFF
--- a/src/Dahomey.Cbor.Tests/ObjectFormatTests.cs
+++ b/src/Dahomey.Cbor.Tests/ObjectFormatTests.cs
@@ -336,6 +336,49 @@ namespace Dahomey.Cbor.Tests
             Assert.Equal("foo", obj2.Name);
         }
 
+        /// <summary>
+        /// A document carrying a discriminator, read as the very type that wrote it rather than
+        /// through the base.
+        /// </summary>
+        /// <remarks>
+        /// The Array arm consumes the discriminator without returning to the bookmark, so the read
+        /// has to leave on the item that carried it. It recognised that item by the converter having
+        /// changed - a signal that is missing exactly when the declared type is the discriminated
+        /// one, since the registry hands back the converter the read already started on. The read
+        /// then took the next item for the discriminator's own slot and ran off the end.
+        /// </remarks>
+        [Fact]
+        public void ReadArrayWithDiscrimatorAsTheDiscriminatedType()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<Person5>();
+
+            const string hexBuffer = "83D82767506572736F6E340C63666F6F"; // [39("Person4"), 12, "foo"]
+            Person5 person = Helper.Read<Person5>(hexBuffer, options);
+
+            Assert.NotNull(person);
+            Assert.Equal(12, person.Id);
+            Assert.Equal("foo", person.Name);
+        }
+
+        /// <summary>
+        /// The same case in the map formats, which resolve the discriminator behind a bookmark and
+        /// so were never affected - pinned here so the two cannot drift apart.
+        /// </summary>
+        [Fact]
+        public void ReadMapWithDiscrimatorAsTheDiscriminatedType()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<Person4>();
+
+            const string hexBuffer = "A30067506572736F6E34010C0263666F6F"; // {0: "Person4", 1: 12, 2: "foo"}
+            Person4 person = Helper.Read<Person4>(hexBuffer, options);
+
+            Assert.NotNull(person);
+            Assert.Equal(12, person.Id);
+            Assert.Equal("foo", person.Name);
+        }
+
         [Fact]
         public void WriteArrayWithDiscrimator()
         {

--- a/src/Dahomey.Cbor.Tests/ObjectFormatTests.cs
+++ b/src/Dahomey.Cbor.Tests/ObjectFormatTests.cs
@@ -379,6 +379,54 @@ namespace Dahomey.Cbor.Tests
             Assert.Equal("foo", person.Name);
         }
 
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public abstract class WithId3
+        {
+            [CborProperty(1)]
+            public int Id { get; set; }
+        }
+
+        [CborDiscriminator("Person6")]
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class Person6 : WithId3
+        {
+            [CborProperty(2)]
+            public string Name { get; set; }
+
+            [CborConstructor]
+            public Person6(int id, string name)
+            {
+                Id = id;
+                Name = name;
+            }
+        }
+
+        /// <summary>
+        /// The same array format, read into a type built through a creator rather than a default
+        /// constructor.
+        /// </summary>
+        /// <remarks>
+        /// A creator collects member values and builds the instance after the loop, so the read holds
+        /// no instance while it runs. Every item therefore re-entered the block that resolves the
+        /// type, reached the exit meant for the discriminator's own item, and found the condition it
+        /// keyed on - the converter differing from the declared type - still true, because that is a
+        /// property of the read and not of the item. Every member was skipped, and the object came
+        /// back built from nothing supplied, with no error raised.
+        /// </remarks>
+        [Fact]
+        public void ReadArrayWithDiscrimatorAndCreator()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<Person6>();
+
+            const string hexBuffer = "83D82767506572736F6E360C63666F6F"; // [39("Person6"), 12, "foo"]
+            WithId3 obj = Helper.Read<WithId3>(hexBuffer, options);
+
+            Person6 person = Assert.IsType<Person6>(obj);
+            Assert.Equal(12, person.Id);
+            Assert.Equal("foo", person.Name);
+        }
+
         [Fact]
         public void WriteArrayWithDiscrimator()
         {

--- a/src/Dahomey.Cbor.Tests/ObjectFormatTests.cs
+++ b/src/Dahomey.Cbor.Tests/ObjectFormatTests.cs
@@ -344,8 +344,9 @@ namespace Dahomey.Cbor.Tests
         /// The Array arm consumes the discriminator without returning to the bookmark, so the read
         /// has to leave on the item that carried it. It recognised that item by the converter having
         /// changed - a signal that is missing exactly when the declared type is the discriminated
-        /// one, since the registry hands back the converter the read already started on. The read
-        /// then took the next item for the discriminator's own slot and ran off the end.
+        /// one, since the registry hands back the converter the read already started on. That call
+        /// then read the following item too, spending two on one call: the array declared three
+        /// items and is read with three calls, so the last one found nothing left.
         /// </remarks>
         [Fact]
         public void ReadArrayWithDiscrimatorAsTheDiscriminatedType()
@@ -375,6 +376,42 @@ namespace Dahomey.Cbor.Tests
             Person4 person = Helper.Read<Person4>(hexBuffer, options);
 
             Assert.NotNull(person);
+            Assert.Equal(12, person.Id);
+            Assert.Equal("foo", person.Name);
+        }
+
+        /// <summary>
+        /// An array holding nothing but the discriminator: one declared item, one call, and that
+        /// call has no member to read.
+        /// </summary>
+        [Fact]
+        public void ReadArrayOfDiscrimatorAloneAsTheDiscriminatedType()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<Person5>();
+
+            const string hexBuffer = "81D82767506572736F6E34"; // [39("Person4")]
+            Person5 person = Helper.Read<Person5>(hexBuffer, options);
+
+            Assert.NotNull(person);
+            Assert.Equal(0, person.Id);
+            Assert.Null(person.Name);
+        }
+
+        /// <summary>
+        /// The indefinite-length form, which the defect never reached: its read ends on the break
+        /// marker rather than on a declared count, so spending two items on one call left nothing
+        /// short. Pinned so that leaving on the discriminator's item does not disturb it.
+        /// </summary>
+        [Fact]
+        public void ReadIndefiniteArrayWithDiscrimatorAsTheDiscriminatedType()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<Person5>();
+
+            const string hexBuffer = "9FD82767506572736F6E340C63666F6FFF"; // [_ 39("Person4"), 12, "foo"]
+            Person5 person = Helper.Read<Person5>(hexBuffer, options);
+
             Assert.Equal(12, person.Id);
             Assert.Equal("foo", person.Name);
         }

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -624,6 +624,12 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         private void ReadItem(ref CborReader reader, ref ReaderContext context)
         {
+            // Only the Array arm below consumes what it read to resolve the type; the map arms hand
+            // the reader back to where they found it. So this says "the current item was the
+            // discriminator and is spent", which is what decides whether this call still has a member
+            // to read - see the exit at the end of the block.
+            bool discriminatorConsumed = false;
+
             if (context.obj == null || context.converter == null)
             {
                 if (context.converter == null)
@@ -707,6 +713,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                                         ICreatorMapping? creatorMapping = context.converter.ObjectMapping.CreatorMapping;
                                         context.creatorValuesByIndex = creatorMapping != null ? new() : null;
                                         context.regularValuesByIndex = creatorMapping != null ? new() : null;
+                                        discriminatorConsumed = true;
                                     }
                                     else
                                     {
@@ -759,9 +766,14 @@ namespace Dahomey.Cbor.Serialization.Converters
                     }
                 }
 
-                if (_objectMapping.ObjectFormat == CborObjectFormat.Array && context.converter != this)
+                if (discriminatorConsumed)
                 {
-                    // discrimnator read with no ReturnToBoomark, must exit here
+                    // The discriminator was this item, and reading it left the reader on the next one
+                    // with no bookmark to return to, so there is no member here to read. Asking
+                    // whether the converter had changed instead answered this correctly only while
+                    // the resolved type differed from the declared one: a document read as the very
+                    // type that wrote it resolves to the converter the read started on, and the read
+                    // went on to take the following item for the discriminator's own slot.
                     return;
                 }
             }


### PR DESCRIPTION
Closes #202.

In `CborObjectFormat.Array` the discriminator is consumed where it is found — unlike the two map arms, which resolve behind a bookmark and hand the reader back untouched. The call that read it therefore has no member left to read and must leave:

```csharp
if (_objectMapping.ObjectFormat == CborObjectFormat.Array && context.converter != this)
{
    // discrimnator read with no ReturnToBoomark, must exit here
    return;
}
```

`context.converter != this` stands in for "the discriminator was this item". But that describes the *read* — which type it resolved to — while the exit is a question about the *item*. The two answers coincide only in the case the tests happened to cover, and they come apart in two ways.

**The resolved type is the declared one.** Read a document as the very type that wrote it and `Lookup(actualType)` hands back the converter the read already started on, so the condition is false, the exit is skipped, and that call goes on to read the following item as well. Members still land in the right slots — the index is advanced past the discriminator either way — but one call has spent two items, and a definite-length array is read with exactly as many calls as it declared items. The shortage surfaces at the end, as a call with nothing left to read. This is #202.

**The read holds no instance.** A creator builds the instance after the loop, so `context.obj` stays null for the whole read and *every* item re-enters the block that resolves the type and reaches the exit. There the condition is still true, because it never described the item. Every member is skipped and the object comes back built from nothing supplied — `[39("Person6"), 12, "foo"]` deserializes to `Id = 0, Name = null`, **with no error raised**. Found while reviewing this change; silent, so worse than #202.

Both fall out of the same repair: the arm already knows the answer at the point it consumes the item, so this tracks it directly, per item, rather than inferring it afterwards from the state of the read. The map arms never set the flag and keep their behaviour exactly.

`context.converter != this` implies the flag in the Array arm, so every case that exited before still exits.

## Tests

Five in `ObjectFormatTests`, beside the existing `ReadArrayWithDiscrimator`. **Three fail without the change:**

* `ReadArrayWithDiscrimatorAsTheDiscriminatedType` — `Unexpected end of buffer ... "$[3]"`. Reads `[39("Person4"), 12, "foo"]` as `Person5`: the same document the neighbouring test reads through `WithId2`, and the one `WriteArrayWithDiscrimator` asserts is written.
* `ReadArrayOfDiscrimatorAloneAsTheDiscriminatedType` — `[39("Person4")]`, the smallest form of the same shortage: one declared item, one call, no member for it to read.
* `ReadArrayWithDiscrimatorAndCreator` — the silent case, asserting the members actually arrive rather than that no exception is thrown.

Two pass before and after, pinning what the change must not disturb:

* `ReadMapWithDiscrimatorAsTheDiscriminatedType` — the map formats resolve behind a bookmark and were never affected.
* `ReadIndefiniteArrayWithDiscrimatorAsTheDiscriminatedType` — the indefinite-length form ends on a break marker rather than a count, so spending two items on one call left nothing short and the read was correct all along. It is the evidence that values were never misplaced, only that the calls ran out.

The first gap was already in reach of the suite: `ReadArrayWithDiscrimator` reads through the base *with* a discriminator, and reads the derived type directly *without* one. Only the two together was missing.

I also confirmed that a required member declared on the derived type is still enforced on this path, read directly and through the base alike, so the guard merged in #201 does not leave it untracked.

**1666 passed, 0 failed, 42 skipped** on `net10.0` and `net8.0`, rebased onto master with #201, #200 and #191; all four TFMs build; generator tests green. The 42 skipped are pre-existing on `master`.

## Noticed while testing, not addressed here

A missing required member reports `Required property '' not found in JSON.` — an empty name — in both `IntKeyMap` and `Array`, since `MemberName` is only populated for string-keyed maps. Pre-existing and independent of this change (`IntKeyMap` is untouched by it and reports the same), so it wants its own issue rather than a fix smuggled in here.