### PR TITLE
Name a key the same way in the path as in the message, part of #178

### DIFF
--- a/src/Dahomey.Cbor.Tests/CborValueKeyedPathTests.cs
+++ b/src/Dahomey.Cbor.Tests/CborValueKeyedPathTests.cs
@@ -1,0 +1,120 @@
+using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Tests.Extensions;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// How a dictionary keyed by <see cref="CborValue"/> names its keys in
+    /// <see cref="CborException.Path"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is the one decode target that names a key twice in a single exception:
+    /// <c>AbstractDictionaryConverter</c> describes it once for the message and again for the path
+    /// segment. #191 unwrapped a <see cref="CborString"/> for the message only, so the two disagreed -
+    /// <c>Duplicate map key: a</c> reported at <c>$['\"a\"']</c>, which is #178's defect inside one
+    /// message. Both now name the key through <c>MapKeyErrors.KeyText</c>.
+    /// <para>
+    /// The path is the wider half of that fix: it is built for every failure under such a dictionary,
+    /// not only for a duplicate, so most of what these tests pin has nothing to do with duplicate keys.
+    /// </para>
+    /// </remarks>
+    public class CborValueKeyedPathTests
+    {
+        /// <summary>
+        /// The duplicate that motivated the change: message and path name the key the same way.
+        /// </summary>
+        [Fact]
+        public void ThePathNamesTheKeyTheSameWayTheMessageDoes()
+        {
+            // a2 6161 01 6161 02  -- {"a": 1, "a": 2}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<CborValue, int>>("A2616101616102".HexToBytes()));
+
+            Assert.Contains("Duplicate map key: a", exception.Message);
+            Assert.Equal("$.a", exception.Path);
+        }
+
+        /// <summary>
+        /// A failure that is not a duplicate is pathed the same way, since the path segment is built
+        /// for any failure under the entry rather than for duplicates specifically.
+        /// </summary>
+        [Fact]
+        public void AValueThatFailsToReadIsPathedByTheKeyText()
+        {
+            // a1 6161 6178  -- {"a": "x"}, into a dictionary whose values are ints
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<CborValue, int>>("A161616178".HexToBytes()));
+
+            Assert.Equal("$.a", exception.Path);
+        }
+
+        /// <summary>
+        /// The same document read into a <c>string</c>-keyed dictionary reports the same path, which is
+        /// the property the change is for: the key names the position, not the type it was read into.
+        /// </summary>
+        [Fact]
+        public void ACborValueKeyAndAStringKeyAgreeOnThePath()
+        {
+            const string hexBuffer = "A161616178"; // a1 6161 6178  -- {"a": "x"}
+
+            string? cborValueKeyed = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<CborValue, int>>(hexBuffer.HexToBytes())).Path;
+            string? stringKeyed = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<string, int>>(hexBuffer.HexToBytes())).Path;
+
+            Assert.Equal(stringKeyed, cborValueKeyed);
+        }
+
+        /// <summary>
+        /// Segments compose, so the quoting was previously paid once per level. This is the case the
+        /// change improves most: two levels deep read <c>$['\"x\"']['\"a\"']</c> before it.
+        /// </summary>
+        [Fact]
+        public void NestedCborValueKeysComposeIntoAPlainPath()
+        {
+            // a1 6178 a1 6161 6179  -- {"x": {"a": "y"}}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<CborValue, Dictionary<CborValue, int>>>(
+                    "A16178A161616179".HexToBytes()));
+
+            Assert.Equal("$.x.a", exception.Path);
+        }
+
+        /// <summary>
+        /// An empty text key is bracketed rather than rendered as nothing, so it stays distinguishable
+        /// from a key that could not be named at all - which is reported by index instead.
+        /// </summary>
+        [Fact]
+        public void AnEmptyTextKeyIsPathedAsTheEmptyString()
+        {
+            // a1 60 6178  -- {"": "x"}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<CborValue, int>>("A1606178".HexToBytes()));
+
+            Assert.Equal("$['']", exception.Path);
+        }
+
+        /// <summary>
+        /// A key with no quoting of its own is still pathed by its own <c>ToString</c>: only the string
+        /// case is unwrapped.
+        /// </summary>
+        /// <remarks>
+        /// The cost of unwrapping, and the reason this is pinned: a text key <c>"[1]"</c> now paths
+        /// identically to the array key <c>[1]</c> asserted here, where before the quoting told them
+        /// apart. That is the same trade #191 accepted for the message, where the text key <c>"1"</c>
+        /// and the integer key <c>1</c> both render <c>1</c> - taken here so the path agrees with the
+        /// message rather than being independently unambiguous.
+        /// </remarks>
+        [Fact]
+        public void ANonTextKeyIsPathedByItsOwnToString()
+        {
+            // a1 8101 6178  -- {[1]: "x"}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<CborValue, int>>("A181016178".HexToBytes()));
+
+            Assert.Equal("$['[1]']", exception.Path);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
+++ b/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
@@ -257,27 +257,5 @@ namespace Dahomey.Cbor.Tests
 
             Assert.Contains("Duplicate map key: 1", exception.Message);
         }
-
-        /// <summary>
-        /// The path a duplicate is reported at names the key the same way the message does.
-        /// </summary>
-        /// <remarks>
-        /// A <c>Dictionary&lt;CborValue, TV&gt;</c> is the fourth decode target, and the only one that
-        /// names its key twice in one exception: <c>AbstractDictionaryConverter</c> describes the key
-        /// for the message and again for the path segment. Those were two renderings - the message
-        /// unwrapped a <see cref="CborString"/> and the path did not - so one key read
-        /// <c>Duplicate map key: a</c> at <c>$['\"a\"']</c>, which is the defect #178 is about, one
-        /// step smaller and inside a single message.
-        /// </remarks>
-        [Fact]
-        public void ThePathNamesTheKeyTheSameWayTheMessageDoes()
-        {
-            // a2 6161 01 6161 02  -- {"a": 1, "a": 2}
-            CborException exception = Assert.Throws<CborException>(
-                () => Cbor.Deserialize<Dictionary<CborValue, int>>("A2616101616102".HexToBytes()));
-
-            Assert.Contains("Duplicate map key: a", exception.Message);
-            Assert.Equal("$.a", exception.Path);
-        }
     }
 }

--- a/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
+++ b/src/Dahomey.Cbor.Tests/DuplicateMapKeyTests.cs
@@ -257,5 +257,27 @@ namespace Dahomey.Cbor.Tests
 
             Assert.Contains("Duplicate map key: 1", exception.Message);
         }
+
+        /// <summary>
+        /// The path a duplicate is reported at names the key the same way the message does.
+        /// </summary>
+        /// <remarks>
+        /// A <c>Dictionary&lt;CborValue, TV&gt;</c> is the fourth decode target, and the only one that
+        /// names its key twice in one exception: <c>AbstractDictionaryConverter</c> describes the key
+        /// for the message and again for the path segment. Those were two renderings - the message
+        /// unwrapped a <see cref="CborString"/> and the path did not - so one key read
+        /// <c>Duplicate map key: a</c> at <c>$['\"a\"']</c>, which is the defect #178 is about, one
+        /// step smaller and inside a single message.
+        /// </remarks>
+        [Fact]
+        public void ThePathNamesTheKeyTheSameWayTheMessageDoes()
+        {
+            // a2 6161 01 6161 02  -- {"a": 1, "a": 2}
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Dictionary<CborValue, int>>("A2616101616102".HexToBytes()));
+
+            Assert.Contains("Duplicate map key: a", exception.Message);
+            Assert.Equal("$.a", exception.Path);
+        }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/AbstractDictionaryConverter.cs
@@ -190,12 +190,17 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// than to an empty name, which would be indistinguishable from a key that really is the empty
         /// string.
         /// </para>
+        /// <para>
+        /// Named through <see cref="MapKeyErrors.KeyText"/> so that the path agrees with the message
+        /// beside it. <typeparamref name="TK"/> may itself be a <c>CborValue</c>, which renders a text
+        /// key quoted; describing it here directly reported one key two ways in one exception.
+        /// </para>
         /// </remarks>
         private static string? DescribeKey(TK? key)
         {
             try
             {
-                return key?.ToString();
+                return key is null ? null : MapKeyErrors.KeyText(key);
             }
             catch (Exception)
             {

--- a/src/Dahomey.Cbor/Serialization/Converters/MapKeyErrors.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MapKeyErrors.cs
@@ -4,7 +4,8 @@ using Dahomey.Cbor.Util;
 namespace Dahomey.Cbor.Serialization.Converters
 {
     /// <summary>
-    /// Messages for the ways adding a map entry can fail, so every read path words them the same.
+    /// Messages for the ways adding a map entry can fail, so every read path words them the same, and
+    /// the naming of a key those messages share with <see cref="CborException.Path"/>.
     /// </summary>
     /// <remarks>
     /// The backing dictionary reports all of these as <see cref="System.ArgumentException"/>, and

--- a/src/Dahomey.Cbor/Serialization/Converters/MapKeyErrors.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MapKeyErrors.cs
@@ -34,26 +34,36 @@ namespace Dahomey.Cbor.Serialization.Converters
             return $"Map key rejected: {Describe(key)} - {reason}";
         }
 
+        /// <summary>
+        /// The text a key is named by, before any budget is applied to it.
+        /// </summary>
         /// <remarks>
-        /// A text key is described by its text, whatever it arrived as. <see cref="CborString"/>
-        /// quotes itself in <c>ToString()</c>, so the object model handed this the six characters
+        /// A text key is named by its text, whatever it arrived as. <see cref="CborString"/>
+        /// quotes itself in <c>ToString()</c>, so the object model hands this the three characters
         /// <c>"a"</c> where every other decode target hands it the one character <c>a</c> - and
-        /// <see cref="TextTruncation.Ellipsize"/> then escaped those quotes as document text, since
-        /// it cannot know they were added by the description rather than present in the key. The same
-        /// document then read differently depending on what it was being read into, which is the
+        /// <see cref="TextTruncation.Ellipsize"/> then escapes those quotes as document text, since
+        /// it cannot know they were added by the rendering rather than present in the key. The same
+        /// document then reads differently depending on what it was being read into, which is the
         /// thing routing every target through one helper was meant to prevent.
         /// <para>
         /// Only the string case is unwrapped. A number, a boolean or a container key has no quoting
         /// of its own to undo, and <c>CborValue.ToString()</c> is the right rendering for it.
         /// </para>
+        /// <para>
+        /// Shared with the path a failure is reported at, rather than private to the message: a
+        /// <c>Dictionary&lt;CborValue, TV&gt;</c> names its key in both, and naming it two ways in one
+        /// exception is the same defect one step smaller. Null is passed through rather than
+        /// coalesced so that a caller can tell "named nothing" from "named the empty string".
+        /// </para>
         /// </remarks>
+        internal static string? KeyText(object key)
+        {
+            return key is CborString cborString ? cborString.Value<string>() : key.ToString();
+        }
+
         private static string Describe(object key)
         {
-            string text = key is CborString cborString
-                ? cborString.Value<string>()
-                : key.ToString() ?? string.Empty;
-
-            return TextTruncation.Ellipsize(text);
+            return TextTruncation.Ellipsize(KeyText(key) ?? string.Empty);
         }
     }
 }


### PR DESCRIPTION
Follow-up to #191, which closed #178 for the message and left the path segment beside it.

**This changes `exception.Path` for anyone reading into a `Dictionary<CborValue, TV>`.** That is the substance of the PR, not a side effect, so it is the first thing here — #191 set aside exactly this kind of change as worth deciding on its own, and this is the call being asked for.

## What it does

`AbstractDictionaryConverter` names its key twice in one exception: once for the message, once for the path segment. #191 unwrapped a `CborString` in the first but not the second, so a duplicate reported

```
Duplicate map key: a        at   $['\"a\"']
```

one key rendered two ways in a single message. Both now name it through `MapKeyErrors.KeyText`.

The duplicate is only where I noticed it. The path segment is built for **every** failure under such a dictionary, so most of the effect is elsewhere, and it compounds with depth:

| | master | here |
|---|---|---|
| value fails to read | `$['\"a\"']` | `$.a` |
| **nested, two levels** | `$['\"x\"']['\"a\"']` | `$.x.a` |
| empty text key | `$['\"\"']` | `$['']` |
| duplicate key | `$['\"a\"']` | `$.a` |

A `CborValue`-keyed dictionary and a `string`-keyed one now report the same path for the same document, which is the property #178 is about.

## What it costs

Unwrapping loses a distinction the quoting was carrying: a **text key `"[1]"` now paths identically to the array key `[1]`**, where before they read `$['\"[1]\"']` and `$['[1]']`. That is the same trade #191 accepted for the message — the text key `"1"` and the integer key `1` both render `1` — extended to the path so the two agree. Worth stating plainly: this buys agreement between message and path, not an independently unambiguous path. `ANonTextKeyIsPathedByItsOwnToString` pins it so it cannot widen.

Whether that is the right trade is yours to settle; if you would rather keep the path unambiguous and let it disagree with the message, the change is the one line in `DescribeKey` and I will drop it.

## The change

The unwrap moves out of the private `MapKeyErrors.Describe` into `MapKeyErrors.KeyText`, which `DescribeKey` now names its path segment through.

`KeyText` passes null through rather than coalescing to `string.Empty`, which `Describe` does at its own call site. `DescribeKey` returning null falls back to the entry's index, and its remarks are explicit that an empty name would be indistinguishable from a key that really is the empty string — coalescing in the shared helper would have quietly removed that fallback. The empty-key row above is that distinction still working.

The `try`/`catch` is unchanged and still needed: `KeyText` calls `TK.ToString()` for any non-`CborString` key, which is caller code running while an exception is in flight.

## Tests

`CborValueKeyedPathTests`, six tests, so `DuplicateMapKeyTests` is left to duplicates and returns to its state on master. Five fail on master; the sixth is the regression guard on the cost above.

**1667 tests green on net10.0 and net8.0**, 35 on the generator, all four TFMs build. (net9.0 has no runtime available in this container — CI only.)

## Noticed, not fixed

`MapKeyErrors.Describe` calls `key.ToString()` unguarded, and `DescribeAddFailure` reaches it from inside a `catch (ArgumentException)`. That is the same "caller code running while an exception is in flight" that `DescribeKey` wraps a `try` around, and a throwing `TK.ToString()` there would replace the duplicate-key failure with an unrelated one. It predates #191, and fixing it means deciding what a message should say when a key cannot name itself, so I have left it alone rather than widen this PR. Happy to take it separately.