### PR TITLE
State the object model's one-tag limit, closes #180

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ The object model does not model typed arrays. A `CborValue` holding one is a `By
 `CborValue.SemanticTag`, so DOM code sees opaque bytes rather than numbers. The tag itself survives a
 read-then-write, so the document still describes a typed array afterwards.
 
+One tag, not a chain. `CborValue.SemanticTag` is a single `ulong?`, so a nested `C1 C2 01` keeps the outer
+tag and drops the inner. That is a limit of the object model rather than of the writer.
+
 ### Indefinite-length strings (RFC 8949 §3.2.3)
 
 A byte or text string may arrive as a series of chunks terminated by a break, which is what a producer


### PR DESCRIPTION
Closes #180. Three lines of README, no code.

## The half that was already fixed

The paragraph #180 quotes is no longer on `master`. #166 rewrote the surrounding *Typed arrays* section when it landed on 2026-08-11 and carried the correction with it, so the claim that `CborValueConverter` drops `SemanticTag` on write is already gone. Nothing to do there.

## The half that was not

#180 also asked for the limit that actually remains, and that is still missing. `CborValue.SemanticTag` is a single `ulong?`, so the object model structurally cannot hold a chain:

```
C1 C2 01   reads as tag(1) 1   writes back as C1 01
```

A reader who has just been told the round trip is lossless has no reason to expect this, and it is the one case where it is not. It belongs in the same paragraph as the reassurance, which is where #180 put it.

## The claim, verified rather than assumed

* `CborValueConverter.Write` calls `WriteSemanticTag` unconditionally — `CborValueConverter.cs:128` and `:333`. The tag is re-emitted.
* `CborValue.SemanticTag` is a single `ulong?` — `CborValue.cs:13`. The nesting limit is the model's, not the writer's, which is what the new sentence says.
* `Issue0162.ANestedTagKeepsOnlyTheOuterOne` pins exactly the example used: `C1C201` reads back as tag 1 and writes as `C101`.

`dotnet test -f net10.0 --filter Issue0162` — 18 passed, 0 failed.

## Wording

Taken from #180 unchanged, since it is the wording you asked for:

> One tag, not a chain. `CborValue.SemanticTag` is a single `ulong?`, so a nested `C1 C2 01` keeps the outer tag and drops the inner. That is a limit of the object model rather than of the writer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EW2P7FbSCJhANYMjo55Suy)_