### PR TITLE
Give decimal an interoperable encoding, closes #192

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,11 @@ Two things do not follow the setting. `CborWriter.WriteDecimal(value)` writes th
 always has, since a `CborWriter` holds no options; pass the format explicitly
 (`WriteDecimal(value, DecimalFormat.DecimalFraction)`) from a custom converter. And the object model
 has no decimal fraction of its own: a `CborDecimal` *writes* as tag 4 like any other decimal, but
-reading those bytes back gives a `CborArray` tagged 4 rather than a `CborDecimal`. The document is
-right either way; the DOM type is not what wrote it.
+reading those bytes back gives a `CborArray` tagged 4 rather than a `CborDecimal`. What is lost is the
+node's type and nothing else — such a value writes back byte-identically, tag included, so DOM code
+still carries a peer's decimals faithfully. It also carries the ones no `decimal` can hold, which is
+why narrowing tag 4 onto the type here would cost more than it gives; that trade-off belongs to
+[#170](https://github.com/dahomey-technologies/Dahomey.Cbor/issues/170).
 
 ### Custom converters
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ High-performance [CBOR](https://cbor.io/) serialization framework for .Net (C#)
 * Support for structs
 * Support for RFC 8746 typed arrays, opt-in per direction (CborOptions.TypedArrayMode)
 * Support for RFC 8949 §3.4.3 bignums (tags 2 and 3) as System.Numerics.BigInteger
+* Reads RFC 8949 §3.4.4 decimal fractions (tag 4) into decimal, and writes them on request
+  (CborOptions.DecimalFormat)
 * Duplicate map keys rejected on every decode target, with a last-wins opt-out (CborOptions.DuplicateKeyMode)
 * Reads RFC 8949 indefinite-length (chunked) byte and text strings; writes definite-length only
 * Ambiguous mappings — two members of a type under one CBOR name — refused when the mapping is built
@@ -266,8 +268,56 @@ through the stack and the innermost bignum tag decides. A text string, on the ot
 rather than parsed — there is no span overload of `BigInteger.Parse` on netstandard2.0, so accepting one
 would mean picking an encoding on a path nothing asks for.
 
-Tags 4 and 5 (decimal fraction and bigfloat) are not decoded semantically and still surface as a
-two-element array. Tracked as https://github.com/dahomey-technologies/Dahomey.Cbor/issues/170.
+Tag 5 (bigfloat) is not decoded semantically and still surfaces as a two-element array. Tracked as
+https://github.com/dahomey-technologies/Dahomey.Cbor/issues/170. Tag 4 (decimal fraction) reads into a
+`decimal`, which the next section is about; it has no object-model type of its own either.
+
+### Decimals (RFC 8949 §3.4.4)
+
+A `decimal` has two encodings, and which one is written is a setting:
+
+```csharp
+CborOptions options = new CborOptions { DecimalFormat = DecimalFormat.DecimalFraction };
+await Cbor.SerializeAsync(273.15m, stream, options);
+// writes C4 82 21 19 6AB3 -- tag 4, [-2, 27315]
+```
+
+| Value | What is written |
+|---|---|
+| `DecimalFloat` (default) | `FC` plus the sixteen raw bytes of the value: `FC 0000000000006AB3 0000000000020000`. |
+| `DecimalFraction` | Tag 4 over `[exponent, mantissa]`, the RFC 8949 §3.4.4 form. |
+
+**Prefer `DecimalFraction` for anything read outside this library.** RFC 8949 §3.3 lists additional
+information 28–30 in major type 7 as *reserved*, so the default form occupies a slot the format has not
+assigned: it round-trips here and no other decoder reads it — `System.Formats.Cbor` throws on it in
+both its lax and strict modes. It remains the default because changing it would move the bytes of every
+document with a `decimal` in it.
+
+The conversion is total and lossless in both directions, with no range or precision policy to pick: a
+`decimal` is a sign, a 96-bit mantissa and a scale of 0 to 28, which is exactly the decimal fraction
+`[-scale, mantissa]`. The scale is part of what is written, so `0.00m` and `0m` stay distinguishable —
+`C4 82 21 00` against `C4 82 00 00` — as they are in the default form. A mantissa past 2^64 goes out
+under the bignum tag (`decimal.MaxValue` writes as `C4 82 00 C2 4C FFFFFFFFFFFFFFFFFFFFFFFF`), which
+is the preferred serialization rather than a special case.
+
+#### Reading takes both, always
+
+There is nothing to opt into on the read side: a `decimal` member reads either form whatever
+`DecimalFormat` says, so turning the setting on does not stop a service reading the documents it wrote
+before, and leaving it off still lets it read a peer's tag 4. Accepting tag 4 takes nothing away — it
+was a `CborException` in earlier versions.
+
+Reading is deliberately the more generous of the two: an unnormalised mantissa is accepted rather than
+refused, so `[-30, 100]` reads as `1E-28`. What a `decimal` genuinely cannot hold — a mantissa wider
+than 96 bits, or a scale that cannot be reduced to 28 — is a `CborException` rather than a rounded
+value.
+
+Two things do not follow the setting. `CborWriter.WriteDecimal(value)` writes the default form as it
+always has, since a `CborWriter` holds no options; pass the format explicitly
+(`WriteDecimal(value, DecimalFormat.DecimalFraction)`) from a custom converter. And the object model
+has no decimal fraction of its own: a `CborDecimal` *writes* as tag 4 like any other decimal, but
+reading those bytes back gives a `CborArray` tagged 4 rather than a `CborDecimal`. The document is
+right either way; the DOM type is not what wrote it.
 
 ### Custom converters
 
@@ -469,11 +519,15 @@ A few things to know about what gets emitted:
   [CborSourceGenerationOptions(
       EnumFormat = ValueFormat.WriteToString,
       DateTimeFormat = DateTimeFormat.Unix,
-      TypedArrayMode = TypedArrayMode.ReadWriteLittleEndian)]
+      TypedArrayMode = TypedArrayMode.ReadWriteLittleEndian,
+      DecimalFormat = DecimalFormat.DecimalFraction)]
   ```
 
 * **A type with no CDDL representation is a build error (`CBOR1011`)**, not a silent omission — a
-  schema that quietly drops a member is worse than no schema at all.
+  schema that quietly drops a member is worse than no schema at all. A `decimal` member is the one case
+  a setting decides: `DecimalFormat.DecimalFraction` renders it as
+  `#6.4([int, (int / #6.2(bstr) / #6.3(bstr))])`, while the default encoding sits in a reserved major
+  type 7 slot that no CDDL can describe and so raises `CBOR1011`.
 
 The output uses core RFC 8610 grammar only — prelude types, arrays, maps, `*`, `/`, ranges and
 `#6.n(...)` — so it can be checked with any conformant CDDL tool; this repository's own tests validate

--- a/README.md
+++ b/README.md
@@ -293,12 +293,16 @@ assigned: it round-trips here and no other decoder reads it — `System.Formats.
 both its lax and strict modes. It remains the default because changing it would move the bytes of every
 document with a `decimal` in it.
 
-The conversion is total and lossless in both directions, with no range or precision policy to pick: a
+The conversion carries every value the type holds, with no range or precision policy to pick: a
 `decimal` is a sign, a 96-bit mantissa and a scale of 0 to 28, which is exactly the decimal fraction
 `[-scale, mantissa]`. The scale is part of what is written, so `0.00m` and `0m` stay distinguishable —
 `C4 82 21 00` against `C4 82 00 00` — as they are in the default form. A mantissa past 2^64 goes out
 under the bignum tag (`decimal.MaxValue` writes as `C4 82 00 C2 4C FFFFFFFFFFFFFFFFFFFFFFFF`), which
 is the preferred serialization rather than a special case.
+
+The one thing tag 4 does not carry is a signed zero, which it has no room for: `-0.00m` reads back as
+`0.00m`, equal by every comparison the language offers and distinguishable only by `decimal.GetBits` or
+by rendering it. The default form stores the sign bit as it stands and keeps it.
 
 #### Reading takes both, always
 

--- a/src/Dahomey.Cbor.Generator/CborSourceGenerator.cs
+++ b/src/Dahomey.Cbor.Generator/CborSourceGenerator.cs
@@ -326,6 +326,7 @@ namespace Dahomey.Cbor.Generator
         public string? EnumFormat { get; private set; }
         public string? DateTimeFormat { get; private set; }
         public string? TypedArrayMode { get; private set; }
+        public string? DecimalFormat { get; private set; }
 
         /// <summary>
         /// Whether this context writes RFC 8746 typed arrays, which is the only half of
@@ -334,6 +335,14 @@ namespace Dahomey.Cbor.Generator
         /// </summary>
         public bool WritesTypedArrays =>
             TypedArrayMode is "WriteLittleEndian" or "ReadWriteLittleEndian";
+
+        /// <summary>
+        /// Whether this context writes RFC 8949 §3.4.4 decimal fractions, which is the only form of
+        /// <c>decimal</c> a schema can describe - the default encoding is a reserved major type 7 slot
+        /// with no CDDL spelling. Like <see cref="WritesTypedArrays"/> this is a write-side question:
+        /// reading tag 4 is unconditional and says nothing about the documents this context produces.
+        /// </summary>
+        public bool WritesDecimalFractions => DecimalFormat is "DecimalFraction";
 
         public static GenerationOptions Read(INamedTypeSymbol contextSymbol, List<DiagnosticInfo> diagnostics)
         {
@@ -419,6 +428,14 @@ namespace Dahomey.Cbor.Generator
                             1 => "Read",
                             2 => "WriteLittleEndian",
                             3 => "ReadWriteLittleEndian",
+                            _ => null,
+                        };
+                        break;
+
+                    case "DecimalFormat":
+                        options.DecimalFormat = named.Value.Value switch
+                        {
+                            1 => "DecimalFraction",
                             _ => null,
                         };
                         break;

--- a/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
+++ b/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
@@ -266,6 +266,17 @@ namespace Dahomey.Cbor.Generator
                         "UnixMilliseconds" => "#6.1(float)",
                         _ => "#6.0(tstr)",
                     };
+
+                // Describable only in the RFC 8949 section 3.4.4 form. The default encoding is major
+                // type 7 with additional information 28, which section 3 reserves, so there is no CDDL
+                // for it and a context leaving DecimalFormat alone still falls through to CBOR1011
+                // below. The mantissa is the same three-way choice BigInteger renders as, and for the
+                // same reason: WriteBigInteger only reaches for a bignum tag past 64 bits, and a
+                // 96-bit mantissa does reach past it.
+                case SpecialType.System_Decimal:
+                    return options.WritesDecimalFractions
+                        ? "#6.4([int, (int / #6.2(bstr) / #6.3(bstr))])"
+                        : null;
             }
 
             // BigInteger has no SpecialType, so it is matched by name -- as TypeCollector.IsPrimitive
@@ -281,13 +292,12 @@ namespace Dahomey.Cbor.Generator
                 return "(int / #6.2(bstr) / #6.3(bstr))";
             }
 
-            // System.Decimal is deliberately absent: it is written as 0xFC plus 16 bytes, and
-            // additional information 28 is reserved and ill-formed under RFC 8949 section 3, so no
-            // conforming decoder can read it and no CDDL can describe it. Guid and DateTimeOffset
-            // have no scalar converter either. Nor does System.Half: the only place the library
-            // references it is the RFC 8746 typed-array element path, which writes `#6.84(bstr)` --
-            // a different representation entirely, not this method's concern. Each falls through to
-            // CBOR1011 rather than asserting a row no converter backs.
+            // Guid and DateTimeOffset have no scalar converter. Nor does System.Half: the only place
+            // the library references it is the RFC 8746 typed-array element path, which writes
+            // `#6.84(bstr)` -- a different representation entirely, not this method's concern.
+            // System.Decimal reaches here only in its default encoding, which is likewise
+            // indescribable. Each falls through to CBOR1011 rather than asserting a row no converter
+            // backs.
             return null;
         }
 

--- a/src/Dahomey.Cbor.Generator/Emitter.cs
+++ b/src/Dahomey.Cbor.Generator/Emitter.cs
@@ -332,6 +332,12 @@ namespace Dahomey.Cbor.Generator
                 wrote = true;
             }
 
+            if (options.DecimalFormat is not null)
+            {
+                builder.AppendLine($"{indent}        options.DecimalFormat = DecimalFormat.{options.DecimalFormat};");
+                wrote = true;
+            }
+
             if (wrote)
             {
                 builder.AppendLine();

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlDecimalFractionTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlDecimalFractionTests.cs
@@ -1,0 +1,69 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Cddl
+{
+    public class CddlDecimals
+    {
+        public decimal Amount { get; set; }
+        public decimal Tiny { get; set; }
+        public decimal Huge { get; set; }
+    }
+
+    [CborSerializable(typeof(CddlDecimals))]
+    [CborSourceGenerationOptions(DecimalFormat = DecimalFormat.DecimalFraction)]
+    [CborCddlSchema]
+    public partial class CddlDecimalContext : CborSerializerContext
+    {
+    }
+
+    /// <summary>
+    /// The RFC 8949 §3.4.4 form is the only encoding of a <see cref="decimal"/> a schema can describe,
+    /// so <c>DecimalFormat</c> is schema-affecting in the way <c>TypedArrayMode</c> is: without it the
+    /// member has no CDDL at all and the generator says so through CBOR1011, which
+    /// <c>CddlDiagnosticTests</c> pins from both sides.
+    /// </summary>
+    public class CddlDecimalFractionTests
+    {
+        private static readonly CddlDecimalContext Context =
+            CborSerializerContext.Default<CddlDecimalContext>();
+
+        /// <summary>
+        /// The mantissa is a three-way choice for the reason <c>BigInteger</c>'s is: the writer emits a
+        /// basic integer while the value fits the integer header and only tags past it, and a 96-bit
+        /// mantissa does go past it. A schema naming only <c>int</c> would reject
+        /// <c>decimal.MaxValue</c>, and one naming only the bignum tags would reject every ordinary
+        /// amount.
+        /// </summary>
+        [Fact]
+        public void ADecimalIsTagFourOverAnExponentAndAMantissa()
+        {
+            Assert.Contains(
+                "\"Amount\": #6.4([int, (int / #6.2(bstr) / #6.3(bstr))]),",
+                CddlDecimalContext.CddlSchema.Replace("\r\n", "\n"));
+        }
+
+        /// <summary>
+        /// The sample spans what the schema claims: a value whose mantissa fits an integer header, one
+        /// scaled to the far end of the type, and one whose mantissa needs the bignum tag.
+        /// </summary>
+        [CddlFact]
+        public void SerializerOutputValidatesAgainstTheSchema()
+        {
+            CddlDecimals value = new CddlDecimals
+            {
+                Amount = 273.15m,
+                Tiny = 0.0000000000000000000000000001m,
+                Huge = decimal.MaxValue,
+            };
+
+            byte[] cbor = Helper.Write(value, Context.Options).HexToBytes();
+
+            CddlResult result = CddlTool.Validate(CddlDecimalContext.CddlSchema, "CddlDecimals", cbor);
+
+            Assert.True(result.Ok, result.Output);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlDiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlDiagnosticTests.cs
@@ -97,10 +97,10 @@ namespace Harness
         }
 
         /// <summary>
-        /// System.Decimal is written as 0xFC plus 16 bytes, where additional information 28 is reserved
-        /// and ill-formed under RFC 8949 section 3 -- no conforming decoder can read it, so no CDDL can
-        /// describe it. <see cref="CddlTypeReference"/>'s primitive switch has no case for it, which is
-        /// what CBOR1011 exists to catch rather than silently omitting the member.
+        /// In its default encoding System.Decimal is 0xFC plus 16 bytes, where additional information
+        /// 28 is reserved and ill-formed under RFC 8949 section 3 -- no conforming decoder can read it,
+        /// so no CDDL can describe it. <see cref="CddlTypeReference"/>'s primitive case returns nothing
+        /// for it, which is what CBOR1011 exists to catch rather than silently omitting the member.
         /// </summary>
         [Fact]
         public void DecimalHasNoCddlRepresentation()
@@ -116,6 +116,28 @@ namespace Harness
 
             Diagnostic reported = Assert.Single(diagnostics, d => d.Id == "CBOR1011");
             Assert.Equal(DiagnosticSeverity.Error, reported.Severity);
+        }
+
+        /// <summary>
+        /// Declare the interoperable encoding and the same member is describable: a decimal fraction is
+        /// tag 4 over an exponent and a mantissa, all of which CDDL has words for. This is the one
+        /// diagnostic in this file a setting can turn off, which is the point -- the schema follows what
+        /// the context writes.
+        /// </summary>
+        [Fact]
+        public void DecimalHasACddlRepresentationAsADecimalFraction()
+        {
+            ImmutableArray<Diagnostic> diagnostics = CddlGeneratorHarness.Run(Preamble + @"
+    public class Money { public decimal Amount { get; set; } }
+
+    [CborSerializable(typeof(Money))]
+    [CborSourceGenerationOptions(DecimalFormat = Dahomey.Cbor.DecimalFormat.DecimalFraction)]
+    [CborCddlSchema]
+    public partial class HarnessContext : CborSerializerContext { }
+}
+");
+
+            Assert.DoesNotContain(diagnostics, d => d.Id == "CBOR1011");
         }
 
         /// <summary>Guid has no scalar CBOR converter at all, so it falls through the same way.</summary>

--- a/src/Dahomey.Cbor.Tests/DecimalFractionTests.cs
+++ b/src/Dahomey.Cbor.Tests/DecimalFractionTests.cs
@@ -425,6 +425,26 @@ namespace Dahomey.Cbor.Tests
         }
 
         /// <summary>
+        /// What the object model gives up is the node's type, not the document: a decimal fraction read
+        /// into a <see cref="CborValue"/> writes back byte-identically, tag included. So a DOM read is
+        /// still a faithful carrier of someone else's decimals, which is what makes the asymmetry above
+        /// a limit of the model rather than a hole in it.
+        /// </summary>
+        [Theory]
+        [InlineData("C48221196AB3")]                          // [-2, 27315]
+        [InlineData("C48200C24CFFFFFFFFFFFFFFFFFFFFFFFF")]    // a mantissa needing the bignum tag
+        // Past what decimal holds, and this is the case that argues against decoding tag 4 into a
+        // CborDecimal here: the DOM carries a decimal fraction no .NET decimal can represent, and
+        // narrowing it to the type would make this document unreadable rather than merely untyped.
+        [InlineData("C48200C24D01000000000000000000000000")]  // [0, 2^96]
+        public void TheObjectModelCarriesADecimalFractionWithoutHoldingIt(string hexBuffer)
+        {
+            CborValue read = Helper.Read<CborValue>(hexBuffer);
+
+            Assert.Equal(hexBuffer, Helper.Write(read));
+        }
+
+        /// <summary>
         /// Negative zero is the one value the two forms disagree about. <c>decimal</c> has a sign bit
         /// independent of the mantissa; tag 4 does not, so <c>-0.00m</c> comes back as <c>0.00m</c> -
         /// equal by every comparison the language offers, and distinguishable only by

--- a/src/Dahomey.Cbor.Tests/DecimalFractionTests.cs
+++ b/src/Dahomey.Cbor.Tests/DecimalFractionTests.cs
@@ -379,6 +379,52 @@ namespace Dahomey.Cbor.Tests
         }
 
         /// <summary>
+        /// Every shape of <see cref="decimal"/> round-trips bit for bit, scale included: all 96
+        /// mantissa bits, every scale, both signs. And what was read writes back byte-identically, so
+        /// the encoding is a function of the value rather than of the route taken to it.
+        /// </summary>
+        /// <remarks>
+        /// A fixed seed, so this is a large deterministic case list rather than a test that passes or
+        /// fails depending on the day. It exists because the arithmetic has more corners than a hand
+        /// written list covers: the reduction that brings a wide mantissa into range was originally
+        /// driven by the scale alone, which refused values as ordinary as <c>1E+28</c>, and no vector
+        /// anybody thought to write down caught it.
+        /// </remarks>
+        [Fact]
+        public void EveryDecimalShapeRoundTripsBitForBit()
+        {
+            Random random = new Random(20260812);
+            CborOptions options = InteroperableOptions();
+
+            for (int i = 0; i < 20_000; i++)
+            {
+                int low = random.Next(int.MinValue, int.MaxValue);
+                int middle = random.Next(3) == 0 ? random.Next(int.MinValue, int.MaxValue) : 0;
+                int high = random.Next(4) == 0 ? random.Next(int.MinValue, int.MaxValue) : 0;
+                bool isNegative = random.Next(2) == 0;
+                byte scale = (byte)random.Next(29);
+
+                decimal value = new decimal(low, middle, high, isNegative, scale);
+
+                string hexBuffer = Helper.Write(value, options);
+                decimal read = Helper.Read<decimal>(hexBuffer);
+
+                int[] expected = decimal.GetBits(value);
+                int[] actual = decimal.GetBits(read);
+
+                // Negative zero is the documented exception: tag 4 has no signed zero, so the sign bit
+                // is the one thing the round trip drops. See NegativeZeroLosesItsSign.
+                if (isNegative && low == 0 && middle == 0 && high == 0)
+                {
+                    expected[3] &= 0x7FFFFFFF;
+                }
+
+                Assert.Equal(expected, actual);
+                Assert.Equal(hexBuffer, Helper.Write(read, options));
+            }
+        }
+
+        /// <summary>
         /// Negative zero is the one value the two forms disagree about. <c>decimal</c> has a sign bit
         /// independent of the mantissa; tag 4 does not, so <c>-0.00m</c> comes back as <c>0.00m</c> -
         /// equal by every comparison the language offers, and distinguishable only by

--- a/src/Dahomey.Cbor.Tests/DecimalFractionTests.cs
+++ b/src/Dahomey.Cbor.Tests/DecimalFractionTests.cs
@@ -1,9 +1,11 @@
 using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.ObjectModel;
 using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Util;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Numerics;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests
@@ -139,11 +141,20 @@ namespace Dahomey.Cbor.Tests
         /// A mantissa with trailing zeros is in range even when its exponent is not: the factors of
         /// ten are divided out, so a producer that does not normalize is still readable.
         /// </summary>
+        /// <remarks>
+        /// Out of range on either end of the same operation, which is why the last three rows are here.
+        /// A scale past 28 has to give factors of ten back; so does a mantissa too wide for 96 bits,
+        /// and <c>[-1, 10^29]</c> is inside the scale limit while being too wide - it is the 1E+28 a
+        /// <c>decimal</c> holds at a scale of 0. Reducing only for the scale rejected it.
+        /// </remarks>
         [Theory]
         // C482 381D 1864 -> [-30, 100], which is 1E-28 and fits.
         [InlineData("C482381D1864", "0.0000000000000000000000000001")]
         // C482 381C 0A -> [-29, 10], the same value one factor of ten out.
         [InlineData("C482381C0A", "0.0000000000000000000000000001")]
+        [InlineData("C48220C24D01431E0FAE6D7217CAA0000000", "10000000000000000000000000000")]  // [-1, 10^29]
+        [InlineData("C48221C24D0C9F2C9CD04674EDEA40000000", "10000000000000000000000000000")]  // [-2, 10^30]
+        [InlineData("C4823827C2520125DFA371A19E6F7CB54395CA0000000000", "10")]                // [-40, 10^41]
         public void ReadsAnUnnormalizedMantissa(string hexBuffer, string expectedValue)
         {
             Helper.TestRead(hexBuffer, Parse(expectedValue));
@@ -191,6 +202,10 @@ namespace Dahomey.Cbor.Tests
         [InlineData("C482381D1865")                        ] // [-30, 101] - no trailing zero to give
         [InlineData("C482181D01")                          ] // [29, 1] - 1E29 is past decimal.MaxValue
         [InlineData("C48200C24D01000000000000000000000000")] // [0, 2^96] - one bit too wide
+        // Still too wide once every factor of ten the scale can give back has been given back: 1E+29
+        // is past decimal.MaxValue, and 2^96 is past the mantissa by one.
+        [InlineData("C48220C24D0C9F2C9CD04674EDEA40000000")] // [-1, 10^30]
+        [InlineData("C48220C24D0A000000000000000000000000")] // [-1, 2^96 * 10]
         [InlineData("C4821B00000002540BE40001")             ] // [10000000000, 1] - exponent past int
         // Malformed: the content of tag 4 is a two-element array of integers.
         [InlineData("C48321196AB300")]   // three items
@@ -200,6 +215,41 @@ namespace Dahomey.Cbor.Tests
         public void RejectsWhatIsNotAReadableDecimal(string hexBuffer)
         {
             Helper.TestRead<decimal>(hexBuffer, typeof(CborException));
+        }
+
+        /// <summary>
+        /// The rejection message names an oversized mantissa by its digit count rather than by its
+        /// digits. Rendering a <see cref="System.Numerics.BigInteger"/> is a base conversion, quadratic
+        /// in the digit count, so a message spelling one out costs far more than the decode it reports
+        /// on - about two seconds for a 33 KB document that is otherwise rejected in a millisecond.
+        /// </summary>
+        [Fact]
+        public void AnOversizedMantissaIsNotSpelledOutInTheMessage()
+        {
+            using ByteBufferWriter buffer = new ByteBufferWriter();
+            CborWriter writer = new CborWriter(buffer);
+
+            writer.WriteSemanticTag(4);
+            writer.WriteBeginArray(2);
+            writer.WriteInt32(-1);
+            writer.WriteBigInteger(BigInteger.Pow(10, 400) * 7);
+
+            byte[] document = buffer.WrittenSpan.ToArray();
+            string message = null;
+
+            try
+            {
+                CborReader reader = new CborReader(document);
+                reader.ReadDecimal();
+            }
+            catch (CborException exception)
+            {
+                message = exception.Message;
+            }
+
+            Assert.NotNull(message);
+            Assert.Contains("401-digit mantissa", message);
+            Assert.True(message.Length < 200, message);
         }
 
         [Fact]

--- a/src/Dahomey.Cbor.Tests/DecimalFractionTests.cs
+++ b/src/Dahomey.Cbor.Tests/DecimalFractionTests.cs
@@ -1,0 +1,348 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.ObjectModel;
+using Dahomey.Cbor.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    public class GeneratedDecimalHolder
+    {
+        public decimal Value { get; set; }
+        public decimal? Optional { get; set; }
+        public Dictionary<decimal, string> Keyed { get; set; }
+    }
+
+    /// <summary>
+    /// A generated context declaring the setting, which is the half a run-time test cannot reach: the
+    /// generated registrations resolve <c>decimal</c> through the same converter provider, so the
+    /// option has to survive the attribute-to-emitted-code round trip to have any effect there.
+    /// </summary>
+    [CborSerializable(typeof(GeneratedDecimalHolder))]
+    [CborSourceGenerationOptions(DecimalFormat = DecimalFormat.DecimalFraction)]
+    public partial class GeneratedDecimalFractionContext : CborSerializerContext
+    {
+    }
+
+    /// <summary>
+    /// RFC 8949 §3.4.4 decimal fractions: tag 4 over <c>[exponent, mantissa]</c>, which is what a
+    /// <see cref="decimal"/> looks like to every implementation but this one.
+    /// </summary>
+    /// <remarks>
+    /// The two halves are deliberately asymmetric, and these tests pin that. Writing tag 4 is opt-in
+    /// through <see cref="CborOptions.DecimalFormat"/>, because it moves the bytes of every document
+    /// with a decimal in it; reading it is unconditional, because it was a <see cref="CborException"/>
+    /// before and accepting it takes nothing away. So every read case here runs on default options.
+    /// <para>
+    /// The hex is the interoperable form rather than this library's own: <c>C48221196AB3</c> is what
+    /// <c>System.Formats.Cbor</c> writes for <c>273.15</c> and reads back as it, which is the whole
+    /// point of the exercise.
+    /// </para>
+    /// </remarks>
+    public class DecimalFractionTests
+    {
+        private static CborOptions InteroperableOptions()
+        {
+            return new CborOptions { DecimalFormat = DecimalFormat.DecimalFraction };
+        }
+
+        private static decimal Parse(string value)
+        {
+            return decimal.Parse(value, NumberStyles.Any, CultureInfo.InvariantCulture);
+        }
+
+        public class ObjectWithDecimal
+        {
+            [CborProperty("v")]
+            public decimal Value { get; set; }
+        }
+
+        public class ObjectWithNullableDecimal
+        {
+            [CborProperty("v")]
+            public decimal? Value { get; set; }
+        }
+
+        [Theory]
+        // C4 tag(4) 82 array(2) <exponent> <mantissa>
+        [InlineData("C48221196AB3", "273.15")]
+        [InlineData("C48221396AB2", "-273.15")]
+        [InlineData("C4820001", "1")]
+        [InlineData("C482221903E8", "1.000")]
+        [InlineData("C482271B00013D2B9C2D125A", "3487324.89798234")]
+        [InlineData("C4822F1B0DED017037E8D195", "100.3459873459458453")]
+        [InlineData("C482381B01", "0.0000000000000000000000000001")]
+        // A 96-bit mantissa does not fit an integer header, so it goes out under the bignum tags -
+        // C2 4C for the positive extreme and C3 4C for the negative one.
+        [InlineData("C48200C24CFFFFFFFFFFFFFFFFFFFFFFFF", "79228162514264337593543950335")]
+        [InlineData("C48200C34CFFFFFFFFFFFFFFFFFFFFFFFE", "-79228162514264337593543950335")]
+        public void WritesTheDecimalFraction(string hexBuffer, string value)
+        {
+            Helper.TestWrite(Parse(value), hexBuffer, null, InteroperableOptions());
+        }
+
+        /// <summary>
+        /// The scale is part of what tag 4 carries, so the distinction the DecimalFloat form keeps
+        /// between <c>0m</c> and <c>0.00m</c> survives the change of encoding.
+        /// </summary>
+        [Theory]
+        [InlineData("C4820000", "0")]
+        [InlineData("C4822100", "0.00")]
+        public void WritesTheScaleOfZero(string hexBuffer, string value)
+        {
+            Helper.TestWrite(Parse(value), hexBuffer, null, InteroperableOptions());
+        }
+
+        /// <summary>
+        /// Default options write what they have always written: 0xFC plus sixteen raw bytes. This is
+        /// the same vector as <c>CborWriterTests.WriteDecimal</c>, here to say out loud that adding
+        /// the setting moved no existing document.
+        /// </summary>
+        [Fact]
+        public void TheDefaultFormatIsUnchanged()
+        {
+            Helper.TestWrite(3487324.89798234m, "FC00013D2B9C2D125A0000000000080000");
+        }
+
+        [Fact]
+        public void WriteDecimalOnTheWriterIsUnchanged()
+        {
+            // The single-argument overload is not options-driven, so a caller writing straight to a
+            // CborWriter keeps the bytes it had.
+            Helper.TestWrite(nameof(Serialization.CborWriter.WriteDecimal), 3487324.89798234m,
+                "FC00013D2B9C2D125A0000000000080000", null);
+        }
+
+        [Theory]
+        [InlineData("C48221196AB3", "273.15")]
+        [InlineData("C48221396AB2", "-273.15")]
+        [InlineData("C4820000", "0")]
+        [InlineData("C4822100", "0.00")]
+        [InlineData("C4820001", "1")]
+        [InlineData("C482221903E8", "1.000")]
+        [InlineData("C482271B00013D2B9C2D125A", "3487324.89798234")]
+        [InlineData("C482381B01", "0.0000000000000000000000000001")]
+        [InlineData("C48200C24CFFFFFFFFFFFFFFFFFFFFFFFF", "79228162514264337593543950335")]
+        [InlineData("C48200C34CFFFFFFFFFFFFFFFFFFFFFFFE", "-79228162514264337593543950335")]
+        [InlineData("C482381BC24CFFFFFFFFFFFFFFFFFFFFFFFF", "7.9228162514264337593543950335")]
+        // Not the preferred encoding of the mantissa - 27315 fits an integer header - but a decoder
+        // has no business refusing it. C2 42 6AB3 is tag 2 over a two-byte magnitude.
+        [InlineData("C48221C2426AB3", "273.15")]
+        public void ReadsTheDecimalFraction(string hexBuffer, string expectedValue)
+        {
+            Helper.TestRead(hexBuffer, Parse(expectedValue));
+        }
+
+        /// <summary>
+        /// A mantissa with trailing zeros is in range even when its exponent is not: the factors of
+        /// ten are divided out, so a producer that does not normalize is still readable.
+        /// </summary>
+        [Theory]
+        // C482 381D 1864 -> [-30, 100], which is 1E-28 and fits.
+        [InlineData("C482381D1864", "0.0000000000000000000000000001")]
+        // C482 381C 0A -> [-29, 10], the same value one factor of ten out.
+        [InlineData("C482381C0A", "0.0000000000000000000000000001")]
+        public void ReadsAnUnnormalizedMantissa(string hexBuffer, string expectedValue)
+        {
+            Helper.TestRead(hexBuffer, Parse(expectedValue));
+        }
+
+        /// <summary>
+        /// Zero is zero at every exponent, so no exponent puts it out of range. The scale is kept
+        /// where the type has room for it and dropped where it does not, which costs nothing: the
+        /// value is the same either way.
+        /// </summary>
+        [Theory]
+        [InlineData("C482186400", "0")]      // [100, 0]
+        [InlineData("C4823A000186A000", "0")] // [-100001, 0]
+        public void ReadsZeroAtAnyExponent(string hexBuffer, string expectedValue)
+        {
+            Helper.TestRead(hexBuffer, Parse(expectedValue));
+        }
+
+        /// <summary>
+        /// §3.4.4 says the content is an array of two items; it does not say the length has to be
+        /// definite, and a streamed pair denotes the same value.
+        /// </summary>
+        [Fact]
+        public void ReadsAnIndefiniteLengthDecimalFraction()
+        {
+            // C4 tag(4) 9F array(*) 21 -2 196AB3 27315 FF break
+            Helper.TestRead("C49F21196AB3FF", 273.15m);
+        }
+
+        /// <summary>
+        /// A foreign tag around the decimal fraction is skipped as one is anywhere else, and a tag 4
+        /// anywhere in the stack still says decimal fraction - the same rule
+        /// <c>ReadBigInteger</c> applies to tags 2 and 3.
+        /// </summary>
+        [Theory]
+        [InlineData("C1C48221196AB3")] // tag 1 outside tag 4
+        [InlineData("C4C18221196AB3")] // tag 1 inside tag 4
+        public void ReadsThroughATagStack(string hexBuffer)
+        {
+            Helper.TestRead(hexBuffer, 273.15m);
+        }
+
+        [Theory]
+        // Out of range: decimal holds a 96-bit mantissa at a scale of 0 to 28.
+        [InlineData("C482381D1865")                        ] // [-30, 101] - no trailing zero to give
+        [InlineData("C482181D01")                          ] // [29, 1] - 1E29 is past decimal.MaxValue
+        [InlineData("C48200C24D01000000000000000000000000")] // [0, 2^96] - one bit too wide
+        [InlineData("C4821B00000002540BE40001")             ] // [10000000000, 1] - exponent past int
+        // Malformed: the content of tag 4 is a two-element array of integers.
+        [InlineData("C48321196AB300")]   // three items
+        [InlineData("C49F21196AB300FF")] // three items, indefinite length
+        [InlineData("C4196AB3")]         // not an array at all
+        [InlineData("C482216548656C6C6F")] // mantissa is a text string
+        public void RejectsWhatIsNotAReadableDecimal(string hexBuffer)
+        {
+            Helper.TestRead<decimal>(hexBuffer, typeof(CborException));
+        }
+
+        [Fact]
+        public void RoundTripsThroughAMember()
+        {
+            // A1 map(1) 6176 "v" C4 82 21 196AB3
+            const string hexBuffer = "A16176C48221196AB3";
+
+            Helper.TestWrite(new ObjectWithDecimal { Value = 273.15m }, hexBuffer, null, InteroperableOptions());
+            Assert.Equal(273.15m, Helper.Read<ObjectWithDecimal>(hexBuffer).Value);
+        }
+
+        [Fact]
+        public void RoundTripsThroughANullableMember()
+        {
+            const string hexBuffer = "A16176C48221196AB3";
+
+            Helper.TestWrite(new ObjectWithNullableDecimal { Value = 273.15m }, hexBuffer, null, InteroperableOptions());
+            Assert.Equal(273.15m, Helper.Read<ObjectWithNullableDecimal>(hexBuffer).Value);
+
+            Helper.TestWrite(new ObjectWithNullableDecimal { Value = null }, "A16176F6", null, InteroperableOptions());
+        }
+
+        /// <summary>
+        /// A decimal key goes out in the same form as a decimal value. It reaches the writer through
+        /// the dictionary converter's key converter rather than as a member, which is also the path
+        /// deterministic key ordering encodes keys on - so the bytes sorted are the bytes emitted.
+        /// </summary>
+        [Fact]
+        public void WritesADecimalDictionaryKey()
+        {
+            Dictionary<decimal, int> dictionary = new Dictionary<decimal, int> { [273.15m] = 1 };
+
+            // A1 map(1) C4 82 21 196AB3 01
+            Helper.TestWrite(dictionary, "A1C48221196AB301", null, InteroperableOptions());
+        }
+
+        /// <summary>
+        /// Deterministic key order is computed on the bytes that are written, not on a form chosen
+        /// separately: these two keys sort one way as decimal fractions and the other way as
+        /// DecimalFloat, and the emitted order follows the setting.
+        /// </summary>
+        /// <remarks>
+        /// A decimal fraction leads with its exponent, so <c>5m</c> (<c>[0, 5]</c>) sorts before
+        /// <c>0.3m</c> (<c>[-1, 3]</c>) - <c>00</c> before <c>20</c>. The DecimalFloat form leads with
+        /// the mantissa words and puts the scale last, so it orders the same pair the other way round,
+        /// mantissa 3 before mantissa 5.
+        /// </remarks>
+        [Fact]
+        public void WritesDecimalDictionaryKeysInTheOrderOfTheFormItWrites()
+        {
+            Dictionary<decimal, int> dictionary = new Dictionary<decimal, int>
+            {
+                [5m] = 1,
+                [0.3m] = 2,
+            };
+
+            CborOptions interoperable = InteroperableOptions();
+            interoperable.Deterministic = true;
+
+            // A2 map(2) C4820005 01 C4822003 02
+            Helper.TestWrite(dictionary, "A2C482000501C482200302", null, interoperable);
+
+            CborOptions legacy = new CborOptions { Deterministic = true };
+
+            Helper.TestWrite(
+                dictionary,
+                "A2"
+                + "FC00000000000000030000000000010000" + "02"
+                + "FC00000000000000050000000000000000" + "01",
+                null,
+                legacy);
+        }
+
+        /// <summary>
+        /// The object model has no decimal fraction of its own, so this is the one place the two
+        /// directions do not meet: a <see cref="CborDecimal"/> writes as tag 4 like any other decimal,
+        /// and reading those bytes back gives a tagged <see cref="CborArray"/> rather than a
+        /// <see cref="CborDecimal"/>. The document is right; the DOM type is not what wrote it.
+        /// </summary>
+        [Fact]
+        public void TheObjectModelWritesTagFourAndReadsAnArray()
+        {
+            CborValue value = 273.15m;
+
+            Helper.TestWrite(value, "C48221196AB3", null, InteroperableOptions());
+
+            CborValue read = Helper.Read<CborValue>("C48221196AB3");
+
+            CborArray array = Assert.IsType<CborArray>(read);
+            Assert.Equal(4ul, array.SemanticTag);
+            Assert.Equal(2, array.Count);
+            Assert.Equal(-2, array[0].Value<int>());
+            Assert.Equal(27315, array[1].Value<int>());
+        }
+
+        [Fact]
+        public void TheSettingReachesTheGeneratedOptions()
+        {
+            GeneratedDecimalFractionContext context =
+                CborSerializerContext.Default<GeneratedDecimalFractionContext>();
+
+            Assert.Equal(DecimalFormat.DecimalFraction, context.Options.DecimalFormat);
+        }
+
+        /// <summary>
+        /// And the generated path writes the same bytes the reflection path does, on a member, on a
+        /// nullable member and on a dictionary key alike.
+        /// </summary>
+        [Fact]
+        public void TheGeneratedPathWritesWhatTheReflectionPathWrites()
+        {
+            GeneratedDecimalFractionContext context =
+                CborSerializerContext.Default<GeneratedDecimalFractionContext>();
+
+            GeneratedDecimalHolder value = new GeneratedDecimalHolder
+            {
+                Value = 273.15m,
+                Optional = -0.5m,
+                Keyed = new Dictionary<decimal, string> { [1.5m] = "one and a half" },
+            };
+
+            string generated = Helper.Write(value, context.Options);
+
+            Assert.Equal(Helper.Write(value, InteroperableOptions()), generated);
+            Assert.Contains("C48221196AB3", generated);
+        }
+
+        /// <summary>
+        /// Negative zero is the one value the two forms disagree about. <c>decimal</c> has a sign bit
+        /// independent of the mantissa; tag 4 does not, so <c>-0.00m</c> comes back as <c>0.00m</c> -
+        /// equal by every comparison the language offers, and distinguishable only by
+        /// <see cref="decimal.GetBits(decimal)"/> or by rendering it.
+        /// </summary>
+        [Fact]
+        public void NegativeZeroLosesItsSign()
+        {
+            Helper.TestWrite(-0.00m, "C4822100", null, InteroperableOptions());
+
+            decimal read = Helper.Read<decimal>("C4822100");
+
+            Assert.Equal(-0.00m, read);
+            Assert.Equal("0.00", read.ToString(CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -148,6 +148,24 @@ namespace Dahomey.Cbor.Tests
                 };
             }
 
+            // Written as RFC 8949 section 3.4.4 decimal fractions, so the comparison catches a
+            // generated context that resolved a DecimalConverter built on default options: it would
+            // write the 0xFC form against the reflection path's tag 4. The values span the mantissa
+            // widths that form reaches for -- an integer header, and a bignum tag past 64 bits.
+            if (type == typeof(GeneratedDecimalHolder))
+            {
+                return new GeneratedDecimalHolder
+                {
+                    Value = 273.15m,
+                    Optional = decimal.MaxValue,
+                    Keyed = new Dictionary<decimal, string>
+                    {
+                        [1.5m] = "one and a half",
+                        [decimal.MinValue] = "the floor",
+                    },
+                };
+            }
+
             if (type == typeof(float[]))
             {
                 return new[] { 1.5f, -2.25f };
@@ -224,6 +242,16 @@ namespace Dahomey.Cbor.Tests
             if (type == typeof(Cddl.CddlRow))
             {
                 return new Cddl.CddlRow { Id = 2, Name = "row" };
+            }
+
+            if (type == typeof(Cddl.CddlDecimals))
+            {
+                return new Cddl.CddlDecimals
+                {
+                    Amount = 273.15m,
+                    Tiny = 0.0000000000000000000000000001m,
+                    Huge = decimal.MaxValue,
+                };
             }
 
             if (type == typeof(Cddl.CddlEscaped))
@@ -461,11 +489,12 @@ namespace Dahomey.Cbor.Tests
             // is byte-identical to an ArrayConverter, so a context that forgot to register one would
             // compare equal and pass. With the mode on, the reflection side writes tag 85 and a
             // generated side that fell back to ArrayConverter writes a plain array.
-            // EnumFormat and DateTimeFormat are copied for exactly the same reason, and are the two a
-            // context can now declare that change the bytes without changing which converter is
-            // registered: leaving either at its default here compares a generated context writing
-            // names or Unix seconds against a reflection path writing ordinals or ISO 8601, which
-            // fails for a reason that is this list's omission rather than the generator's doing.
+            // EnumFormat, DateTimeFormat and DecimalFormat are copied for exactly the same reason, and
+            // are the three a context can now declare that change the bytes without changing which
+            // converter is registered: leaving any of them at its default here compares a generated
+            // context writing names, Unix seconds or tag 4 against a reflection path writing ordinals,
+            // ISO 8601 or the 0xFC form, which fails for a reason that is this list's omission rather
+            // than the generator's doing.
             CborOptions reflection = new CborOptions
             {
                 DefaultNamingConvention = generated.DefaultNamingConvention,
@@ -474,6 +503,7 @@ namespace Dahomey.Cbor.Tests
                 Deterministic = generated.Deterministic,
                 EnumFormat = generated.EnumFormat,
                 DateTimeFormat = generated.DateTimeFormat,
+                DecimalFormat = generated.DecimalFormat,
             };
 
             string reflectionBytes = WriteAs(type, Sample(type), reflection);

--- a/src/Dahomey.Cbor/Attributes/CborSourceGenerationOptionsAttribute.cs
+++ b/src/Dahomey.Cbor/Attributes/CborSourceGenerationOptionsAttribute.cs
@@ -46,5 +46,17 @@ namespace Dahomey.Cbor.Attributes
         /// <see cref="CborOptions.TypedArrayMode"/>.
         /// </summary>
         public TypedArrayMode TypedArrayMode { get; set; } = TypedArrayMode.Never;
+
+        /// <summary>
+        /// Which encoding a <see cref="decimal"/> is written as. Mirrors
+        /// <see cref="CborOptions.DecimalFormat"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="DecimalFormat.DecimalFraction"/> is also the one setting that gives a
+        /// <see cref="decimal"/> member a CDDL representation: the default form occupies a reserved
+        /// major type 7 slot that no CDDL can describe, so a schema-generating context leaving this
+        /// alone still reports CBOR1011 for such a member.
+        /// </remarks>
+        public DecimalFormat DecimalFormat { get; set; } = DecimalFormat.DecimalFloat;
     }
 }

--- a/src/Dahomey.Cbor/CborOptions.cs
+++ b/src/Dahomey.Cbor/CborOptions.cs
@@ -135,10 +135,17 @@ namespace Dahomey.Cbor
         /// decimal.
         /// </summary>
         /// <remarks>
-        /// Lossless in both directions and no wider than the type. A <see cref="decimal"/> of scale
-        /// <c>s</c> and mantissa <c>m</c> is exactly the decimal fraction <c>[-s, m]</c>, so the
-        /// scale survives the round trip - <c>0.00m</c> writes as <c>[-2, 0]</c> and <c>0m</c> as
-        /// <c>[0, 0]</c>, the same distinction <see cref="DecimalFloat"/> keeps.
+        /// Carries every value the type holds, and its scale with it: a <see cref="decimal"/> of scale
+        /// <c>s</c> and mantissa <c>m</c> is exactly the decimal fraction <c>[-s, m]</c>, so
+        /// <c>0.00m</c> writes as <c>[-2, 0]</c> and <c>0m</c> as <c>[0, 0]</c> - the same distinction
+        /// <see cref="DecimalFloat"/> keeps.
+        /// <para>
+        /// One exception, and it is in the encoding rather than in this library: a decimal fraction has
+        /// no signed zero, so <c>-0.00m</c> reads back as <c>0.00m</c>. Equal by every comparison the
+        /// language offers, and distinguishable only by <see cref="decimal.GetBits(decimal)"/> or by
+        /// rendering it - where <see cref="DecimalFloat"/>, which stores the sign bit as it stands,
+        /// keeps it.
+        /// </para>
         /// </remarks>
         DecimalFraction = 1,
     }

--- a/src/Dahomey.Cbor/CborOptions.cs
+++ b/src/Dahomey.Cbor/CborOptions.cs
@@ -101,6 +101,48 @@ namespace Dahomey.Cbor
         ReadWriteLittleEndian = Read | WriteLittleEndian,
     }
 
+    /// <summary>
+    /// Which of the two encodings a <see cref="decimal"/> is written as.
+    /// </summary>
+    /// <remarks>
+    /// Reading is not affected and needs no setting: a <see cref="decimal"/> is read from either form
+    /// whatever this says, so widening a service's input costs nothing and turning this on does not
+    /// stop it reading the documents it wrote before.
+    /// <para>
+    /// Only writing has to choose, because the choice moves bytes: every <see cref="decimal"/> this
+    /// library has ever written uses <see cref="DecimalFloat"/>, so that stays the default and no
+    /// existing document changes shape underneath a caller who has not asked for it.
+    /// </para>
+    /// </remarks>
+    public enum DecimalFormat
+    {
+        /// <summary>
+        /// Major type 7 with additional information 28, followed by the sixteen raw bytes of the
+        /// value. The historical form, and the default.
+        /// </summary>
+        /// <remarks>
+        /// RFC 8949 §3.3 lists additional information 28-30 in major type 7 as reserved, so this
+        /// occupies a slot the format has not assigned: it round-trips through this library and no
+        /// other decoder reads it. Keep it for a contract whose only participants are Dahomey.Cbor,
+        /// or while documents written by an earlier version are still in circulation; choose
+        /// <see cref="DecimalFraction"/> for anything read outside this library.
+        /// </remarks>
+        DecimalFloat = 0,
+
+        /// <summary>
+        /// The RFC 8949 §3.4.4 decimal fraction: tag 4 over the two-element array
+        /// <c>[exponent, mantissa]</c>, which is what every other CBOR implementation means by a
+        /// decimal.
+        /// </summary>
+        /// <remarks>
+        /// Lossless in both directions and no wider than the type. A <see cref="decimal"/> of scale
+        /// <c>s</c> and mantissa <c>m</c> is exactly the decimal fraction <c>[-s, m]</c>, so the
+        /// scale survives the round trip - <c>0.00m</c> writes as <c>[-2, 0]</c> and <c>0m</c> as
+        /// <c>[0, 0]</c>, the same distinction <see cref="DecimalFloat"/> keeps.
+        /// </remarks>
+        DecimalFraction = 1,
+    }
+
     public class CborOptions
     {
         public static CborOptions Default { get; } = new CborOptions()
@@ -207,6 +249,23 @@ namespace Dahomey.Cbor
         /// </para>
         /// </remarks>
         public TypedArrayMode TypedArrayMode { get; set; } = TypedArrayMode.Never;
+
+        /// <summary>
+        /// Which encoding a <see cref="decimal"/> is written as. Default
+        /// <see cref="DecimalFormat.DecimalFloat"/>, the non-standard form this library has always
+        /// written, so no existing document moves.
+        /// </summary>
+        /// <remarks>
+        /// A write-side setting only. Both forms are read whatever this says, and reading tag 4 is new
+        /// capability rather than changed behaviour: it was a <see cref="CborException"/> before.
+        /// <para>
+        /// Independent of <see cref="Deterministic"/>. Either setting gives one <see cref="decimal"/>
+        /// exactly one encoding - a decimal fraction's exponent and mantissa each use the shortest-form
+        /// argument, and the mantissa reaches for a bignum tag only past 64 bits - so the bytes are
+        /// determined either way, and §4.2.1 has nothing to say about which of the two to pick.
+        /// </para>
+        /// </remarks>
+        public DecimalFormat DecimalFormat { get; set; }
 
         /// <summary>
         /// Semantic Tag to check if the discriminator is present when ObjectFormat is Array

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -81,6 +81,12 @@ namespace Dahomey.Cbor.Serialization
         private const ulong UNSIGNED_BIGNUM_TAG = 2;
         private const ulong NEGATIVE_BIGNUM_TAG = 3;
 
+        // RFC 8949 §3.4.4.
+        private const ulong DECIMAL_FRACTION_TAG = 4;
+
+        /// <summary>Widest scale a <see cref="decimal"/> holds.</summary>
+        private const int MAX_DECIMAL_SCALE = 28;
+
         private ReadOnlySpan<byte> _buffer;
         private ReadOnlySequence<byte>? _sequence;
         private int _currentPos;
@@ -630,10 +636,43 @@ namespace Dahomey.Cbor.Serialization
             }
         }
 
+        /// <summary>
+        /// Reads a <see cref="decimal"/> from either of its two encodings: the RFC 8949 §3.4.4 decimal
+        /// fraction - tag 4 over <c>[exponent, mantissa]</c>, which is what other implementations write
+        /// - or the <see cref="CborPrimitive.DecimalFloat"/> form this library writes by default. Also
+        /// accepts any basic integer and a text string, as its neighbours do.
+        /// </summary>
+        /// <remarks>
+        /// Accepting tag 4 is unconditional and is not governed by
+        /// <see cref="CborOptions.DecimalFormat"/>: that setting decides what is written, and there is
+        /// nothing to lose by reading a form that used to be a <see cref="CborException"/>.
+        /// <para>
+        /// Which is why this does not open with <c>SkipSemanticTag</c> like the rest of them. The tag
+        /// carries the meaning here, so it has to be noticed rather than stepped over. The stack walk
+        /// mirrors <see cref="ReadBigInteger"/>: foreign tags are skipped as they are everywhere else,
+        /// and a tag 4 anywhere in the stack says decimal fraction.
+        /// </para>
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public decimal ReadDecimal()
         {
-            SkipSemanticTag();
+            bool isDecimalFraction = false;
+
+            while (IsSemanticTag())
+            {
+                TryReadSemanticTag(out ulong tag);
+
+                if (tag == DECIMAL_FRACTION_TAG)
+                {
+                    isDecimalFraction = true;
+                }
+            }
+
+            if (isDecimalFraction)
+            {
+                return ReadDecimalFraction();
+            }
+
             CborReaderHeader header = GetHeader();
 
             switch (header.MajorType)
@@ -678,6 +717,153 @@ namespace Dahomey.Cbor.Serialization
                     ThrowCbor($"Invalid major type {header.MajorType}");
                     return default; // Unreachable
             }
+        }
+
+        /// <summary>
+        /// Reads the content of an RFC 8949 §3.4.4 decimal fraction, whose tag has already been
+        /// consumed: a two-element array of an integer exponent and an integer or bignum mantissa.
+        /// </summary>
+        /// <remarks>
+        /// The mantissa goes through <see cref="ReadBigInteger"/>, which accepts a basic integer or a
+        /// bignum - a 96-bit mantissa needs tag 2 or 3 past 2^64, so a decimal written by this library
+        /// can carry either - and rejects everything else, so nothing composite reaches the arithmetic
+        /// below.
+        /// <para>
+        /// An indefinite-length array is accepted too. §3.4.4 describes the content as an array of two
+        /// items and does not require a definite length, and this library reads other
+        /// indefinite-length shapes wherever they are well-formed; a producer that streams the pair
+        /// is readable rather than rejected on a detail that does not change the value.
+        /// </para>
+        /// <para>
+        /// No <see cref="EnterNestedItem"/>: the array's two items are read by the two calls below,
+        /// neither of which reads a container, so this cannot recurse and has no stack to bound.
+        /// </para>
+        /// </remarks>
+        private decimal ReadDecimalFraction()
+        {
+            Expect(CborMajorType.Array);
+
+            int size = ReadSize();
+
+            if (size != 2 && size != -1)
+            {
+                ThrowCbor($"A decimal fraction is an array of 2 items, not {size}");
+            }
+
+            int exponent = ReadInt32();
+            BigInteger mantissa = ReadBigInteger();
+
+            if (size == -1)
+            {
+                if (!IsBreak())
+                {
+                    ThrowCbor("A decimal fraction is an array of 2 items, and this one holds more");
+                }
+
+                ConsumeBreak();
+            }
+
+            return DecimalFromDecimalFraction(exponent, mantissa);
+        }
+
+        /// <summary>
+        /// Rebuilds the <see cref="decimal"/> denoted by <c>mantissa x 10^exponent</c>, or throws if
+        /// the type cannot hold it exactly.
+        /// </summary>
+        /// <remarks>
+        /// Every <see cref="decimal"/> is a decimal fraction but not every decimal fraction is a
+        /// <see cref="decimal"/>: the type holds a 96-bit mantissa at a scale of 0 to 28, and tag 4
+        /// bounds neither. What does not fit is a <see cref="CborException"/> rather than a rounded
+        /// value - a decoder that quietly loses digits of a monetary amount is worse than one that
+        /// says it cannot read the document.
+        /// <para>
+        /// A mantissa carrying trailing zeros is not out of range just because its exponent is: the
+        /// factors of ten are divided out first, so <c>[-30, 100]</c> reads as <c>1E-28</c> rather than
+        /// being refused for a scale of 30. Producers outside .NET have no reason to normalize.
+        /// </para>
+        /// </remarks>
+        private decimal DecimalFromDecimalFraction(int exponent, BigInteger mantissa)
+        {
+            bool isNegative = mantissa.Sign < 0;
+            BigInteger magnitude = BigInteger.Abs(mantissa);
+
+            // Zero at any exponent is zero, so this is in range whatever the exponent says. The scale
+            // is kept where decimal has room for it, which is what makes [-2, 0] read back as the
+            // 0.00m that wrote it.
+            if (magnitude.IsZero)
+            {
+                int zeroScale = exponent >= 0 ? 0 : (int)Math.Min(-(long)exponent, MAX_DECIMAL_SCALE);
+
+                return new decimal(0, 0, 0, false, (byte)zeroScale);
+            }
+
+            // long, because -(int.MinValue) does not fit an int - and the value is checked before it is
+            // narrowed to the byte the decimal constructor takes.
+            long scale;
+
+            if (exponent > 0)
+            {
+                // 10^29 is already past decimal.MaxValue, so a positive exponent beyond the scale limit
+                // is out of range whatever the mantissa is. Checked before the multiply rather than
+                // after: BigInteger.Pow would otherwise be handed an exponent out of a hostile document
+                // and asked for a number with billions of digits.
+                if (exponent > MAX_DECIMAL_SCALE)
+                {
+                    ThrowDecimalFractionOutOfRange(exponent, mantissa);
+                }
+
+                magnitude *= BigInteger.Pow(10, exponent);
+                scale = 0;
+            }
+            else
+            {
+                scale = -(long)exponent;
+
+                if (scale > MAX_DECIMAL_SCALE)
+                {
+                    long excess = scale - MAX_DECIMAL_SCALE;
+
+                    // A value cannot lose more factors of ten than it has digits, and Log10 bounds the
+                    // digit count without materialising anything: this keeps Pow's argument tied to the
+                    // size of the mantissa actually in the document rather than to the exponent it
+                    // claims.
+                    if (excess > (long)BigInteger.Log10(magnitude) + 1)
+                    {
+                        ThrowDecimalFractionOutOfRange(exponent, mantissa);
+                    }
+
+                    magnitude = BigInteger.DivRem(
+                        magnitude, BigInteger.Pow(10, (int)excess), out BigInteger remainder);
+
+                    if (!remainder.IsZero)
+                    {
+                        ThrowDecimalFractionOutOfRange(exponent, mantissa);
+                    }
+
+                    scale = MAX_DECIMAL_SCALE;
+                }
+            }
+
+            // 96 bits, checked after the scale reduction above rather than before it, since dividing
+            // out the trailing zeros is what brings a value such as [-30, 10^29] into range.
+            if (!(magnitude >> 96).IsZero)
+            {
+                ThrowDecimalFractionOutOfRange(exponent, mantissa);
+            }
+
+            return new decimal(
+                (int)(uint)(magnitude & uint.MaxValue),
+                (int)(uint)((magnitude >> 32) & uint.MaxValue),
+                (int)(uint)(magnitude >> 64),
+                isNegative,
+                (byte)scale);
+        }
+
+        private void ThrowDecimalFractionOutOfRange(int exponent, BigInteger mantissa)
+        {
+            ThrowCbor(
+                $"The decimal fraction [{exponent}, {mantissa}] is not exactly representable as a decimal, "
+                + $"which holds a 96-bit mantissa at a scale of 0 to {MAX_DECIMAL_SCALE}");
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -87,6 +87,12 @@ namespace Dahomey.Cbor.Serialization
         /// <summary>Widest scale a <see cref="decimal"/> holds.</summary>
         private const int MAX_DECIMAL_SCALE = 28;
 
+        /// <summary>
+        /// Decimal digits a 96-bit mantissa can span. 10^29 is already past <c>2^96 - 1</c>, so a
+        /// magnitude of 30 digits or more is out of range whatever its digits are.
+        /// </summary>
+        private const int MAX_DECIMAL_DIGITS = 29;
+
         private ReadOnlySpan<byte> _buffer;
         private ReadOnlySequence<byte>? _sequence;
         private int _currentPos;
@@ -822,30 +828,41 @@ namespace Dahomey.Cbor.Serialization
                 if (scale > MAX_DECIMAL_SCALE)
                 {
                     long excess = scale - MAX_DECIMAL_SCALE;
+                    long digits = (long)BigInteger.Log10(magnitude) + 1;
 
-                    // A value cannot lose more factors of ten than it has digits, and Log10 bounds the
-                    // digit count without materialising anything: this keeps Pow's argument tied to the
-                    // size of the mantissa actually in the document rather than to the exponent it
-                    // claims.
-                    if (excess > (long)BigInteger.Log10(magnitude) + 1)
+                    // Two bounds on what Pow is asked for, so its argument follows the mantissa actually
+                    // in the document rather than an exponent the document only claims. A value cannot
+                    // lose more factors of ten than it has digits; and what is left has to be within
+                    // reach of the width reduction below, which gives back at most MAX_DECIMAL_SCALE
+                    // more. Log10 bounds the digit count without materialising anything.
+                    if (excess > digits
+                        || digits - excess > MAX_DECIMAL_DIGITS + MAX_DECIMAL_SCALE)
                     {
                         ThrowDecimalFractionOutOfRange(exponent, mantissa);
                     }
 
-                    magnitude = BigInteger.DivRem(
-                        magnitude, BigInteger.Pow(10, (int)excess), out BigInteger remainder);
-
-                    if (!remainder.IsZero)
-                    {
-                        ThrowDecimalFractionOutOfRange(exponent, mantissa);
-                    }
+                    magnitude = DivideOutFactorsOfTen(
+                        magnitude, BigInteger.Pow(10, (int)excess), exponent, mantissa);
 
                     scale = MAX_DECIMAL_SCALE;
                 }
             }
 
-            // 96 bits, checked after the scale reduction above rather than before it, since dividing
-            // out the trailing zeros is what brings a value such as [-30, 10^29] into range.
+            // A mantissa too wide for 96 bits is reduced the same way and for the same reason a scale
+            // past 28 is - the two are one operation seen from either end, since dividing the mantissa
+            // by ten and decrementing the scale leaves the value alone. [-1, 10^29] arrives here inside
+            // the scale limit and still too wide, and is the 1E+28 that decimal holds perfectly well at
+            // a scale of 0.
+            //
+            // Bounded by the scale, which is at most MAX_DECIMAL_SCALE by now, so this is a handful of
+            // divisions rather than a search. A magnitude with a non-zero digit to give up is out of
+            // range and leaves on the first one.
+            while (!(magnitude >> 96).IsZero && scale > 0)
+            {
+                magnitude = DivideOutFactorsOfTen(magnitude, 10, exponent, mantissa);
+                scale--;
+            }
+
             if (!(magnitude >> 96).IsZero)
             {
                 ThrowDecimalFractionOutOfRange(exponent, mantissa);
@@ -859,11 +876,63 @@ namespace Dahomey.Cbor.Serialization
                 (byte)scale);
         }
 
+        /// <summary>
+        /// Divides <paramref name="magnitude"/> by <paramref name="divisor"/>, which must be a power of
+        /// ten, and throws if that would drop a digit that is not zero.
+        /// </summary>
+        /// <remarks>
+        /// Removing a factor of ten from the mantissa while giving one back to the scale leaves the
+        /// value unchanged - which is what makes the reduction legitimate. A non-zero remainder is the
+        /// case where it would not: the digit dropped is part of the value, so the document names
+        /// something a <see cref="decimal"/> cannot hold rather than something to be rounded.
+        /// </remarks>
+        private BigInteger DivideOutFactorsOfTen(
+            BigInteger magnitude, BigInteger divisor, int exponent, BigInteger mantissa)
+        {
+            BigInteger reduced = BigInteger.DivRem(magnitude, divisor, out BigInteger remainder);
+
+            if (!remainder.IsZero)
+            {
+                ThrowDecimalFractionOutOfRange(exponent, mantissa);
+            }
+
+            return reduced;
+        }
+
         private void ThrowDecimalFractionOutOfRange(int exponent, BigInteger mantissa)
         {
             ThrowCbor(
-                $"The decimal fraction [{exponent}, {mantissa}] is not exactly representable as a decimal, "
-                + $"which holds a 96-bit mantissa at a scale of 0 to {MAX_DECIMAL_SCALE}");
+                $"The decimal fraction [{exponent}, {DescribeMantissa(mantissa)}] is not exactly "
+                + $"representable as a decimal, which holds a 96-bit mantissa at a scale of 0 to "
+                + $"{MAX_DECIMAL_SCALE}");
+        }
+
+        /// <summary>
+        /// Renders a mantissa for the message above: its value where a <see cref="decimal"/> could have
+        /// held it, and its digit count where it could not.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="BigInteger.ToString()"/> is a base conversion, quadratic in the digit count, so a
+        /// mantissa straight out of an untrusted document must not reach it. A 33 KB document carries
+        /// 80,000 digits and takes about two seconds to render - which would make the diagnostic far
+        /// more expensive than the decode it is diagnosing, and reachable on a document the reader
+        /// otherwise rejects in a millisecond. The digit count comes from <see cref="BigInteger.Log10"/>,
+        /// which reads the leading bits rather than every digit.
+        /// <para>
+        /// The cutoff is the width of the type, so the exact value is still named for every mantissa
+        /// that was close to fitting, which is the case where it helps.
+        /// </para>
+        /// </remarks>
+        private static string DescribeMantissa(BigInteger mantissa)
+        {
+            BigInteger magnitude = BigInteger.Abs(mantissa);
+
+            if ((magnitude >> 96).IsZero)
+            {
+                return mantissa.ToString();
+            }
+
+            return $"a {(long)BigInteger.Log10(magnitude) + 1}-digit mantissa";
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor/Serialization/CborWriter.cs
+++ b/src/Dahomey.Cbor/Serialization/CborWriter.cs
@@ -30,6 +30,9 @@ namespace Dahomey.Cbor.Serialization
         private const ulong UNSIGNED_BIGNUM_TAG = 2;
         private const ulong NEGATIVE_BIGNUM_TAG = 3;
 
+        // RFC 8949 §3.4.4.
+        private const ulong DECIMAL_FRACTION_TAG = 4;
+
         /// <summary>
         /// Default nesting limit, matching <see cref="CborOptions.MaxDepth"/> and
         /// <c>System.Text.Json</c>.
@@ -225,9 +228,38 @@ namespace Dahomey.Cbor.Serialization
             InternalWriteDouble(value);
         }
 
+        /// <summary>
+        /// Writes a <see cref="decimal"/> in the historical <see cref="DecimalFormat.DecimalFloat"/>
+        /// form: major type 7, additional information 28, sixteen raw bytes.
+        /// </summary>
+        /// <remarks>
+        /// Unchanged, and deliberately not routed through <see cref="CborOptions.DecimalFormat"/> -
+        /// nothing here holds the options, and a caller writing to a <see cref="CborWriter"/> directly
+        /// gets the bytes this overload has always produced. Pass the format explicitly to choose the
+        /// interoperable encoding; a converter reached through <see cref="CborOptions"/> already does.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteDecimal(decimal value)
         {
+            InternalWriteDecimal(value);
+        }
+
+        /// <inheritdoc cref="WriteDecimal(decimal)"/>
+        /// <param name="value">The value to write.</param>
+        /// <param name="format">
+        /// Which encoding to use. <see cref="DecimalFormat.DecimalFraction"/> writes the RFC 8949
+        /// §3.4.4 form that other implementations read; <see cref="DecimalFormat.DecimalFloat"/> is the
+        /// same as the single-argument overload.
+        /// </param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteDecimal(decimal value, DecimalFormat format)
+        {
+            if (format == DecimalFormat.DecimalFraction)
+            {
+                InternalWriteDecimalFraction(value);
+                return;
+            }
+
             InternalWriteDecimal(value);
         }
 
@@ -647,6 +679,48 @@ namespace Dahomey.Cbor.Serialization
             }
 
             _bufferWriter.Advance(16);
+        }
+
+        /// <summary>
+        /// Writes an RFC 8949 §3.4.4 decimal fraction: tag 4 over <c>[exponent, mantissa]</c>.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="decimal"/> is a sign, a 96-bit mantissa and a scale of 0 to 28, which is
+        /// exactly the decimal fraction <c>mantissa x 10^-scale</c> - so this conversion is total and
+        /// lossless, and unlike the float encodings it has no range or precision policy to choose.
+        /// <para>
+        /// The mantissa goes through <see cref="WriteBigInteger"/> rather than being written as an
+        /// integer, because it does not always fit one: a mantissa past 2^64 needs the bignum tag, and
+        /// <see cref="WriteBigInteger"/> reaches for it only then, leaving every ordinary value a
+        /// basic integer.
+        /// </para>
+        /// <para>
+        /// The array is definite-length regardless of <see cref="CborOptions.ArrayLengthMode"/>. It is
+        /// two items by definition of the tag rather than a collection the caller handed over, so its
+        /// length is never unknown in advance, and RFC 8949 §4.2.1 wants the definite form.
+        /// </para>
+        /// </remarks>
+        private void InternalWriteDecimalFraction(decimal value)
+        {
+            int[] bits = decimal.GetBits(value);
+
+            // bits[3] is the flags word: bit 31 is the sign and bits 16-23 the scale. The three
+            // magnitude words are unsigned - reading them as int would make any value with the top bit
+            // of the high word set come out negative.
+            int scale = (bits[3] >> 16) & 0xFF;
+            bool isNegative = bits[3] < 0;
+
+            BigInteger mantissa = ((BigInteger)(uint)bits[2] << 64)
+                + ((BigInteger)(uint)bits[1] << 32)
+                + (uint)bits[0];
+
+            WriteSemanticTag(DECIMAL_FRACTION_TAG);
+            WriteBeginArray(2);
+
+            // Negated: the tag's exponent is the power of ten the mantissa is multiplied by, where
+            // decimal's scale is the power it is divided by.
+            WriteSigned(-scale);
+            WriteBigInteger(isNegative ? -mantissa : mantissa);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/CborValueConverter.cs
@@ -154,8 +154,12 @@ namespace Dahomey.Cbor.Serialization.Converters
                     writer.WriteDouble(value.Value<double>());
                     break;
 
+                // Honours CborOptions.DecimalFormat like the typed path does, so a document does not
+                // depend on whether the decimal in it was written from a member or from the object
+                // model. Note the read side is not symmetrical: a decimal fraction has no CborValueType
+                // of its own, so it comes back as a tagged CborArray rather than as a CborDecimal.
                 case CborValueType.Decimal:
-                    writer.WriteDecimal(value.Value<decimal>());
+                    writer.WriteDecimal(value.Value<decimal>(), _options.DecimalFormat);
                     break;
 
                 case CborValueType.String:

--- a/src/Dahomey.Cbor/Serialization/Converters/DecimalConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/DecimalConverter.cs
@@ -2,14 +2,25 @@
 {
     public class DecimalConverter : CborConverterBase<decimal>
     {
+        private readonly CborOptions _options;
+
+        public DecimalConverter(CborOptions options)
+        {
+            _options = options;
+        }
+
         public override decimal Read(ref CborReader reader)
         {
             return reader.ReadDecimal();
         }
 
+        /// <summary>
+        /// Writes the form <see cref="CborOptions.DecimalFormat"/> asks for. Reading takes both forms
+        /// whatever it says, so only this half consults it.
+        /// </summary>
         public override void Write(ref CborWriter writer, decimal value)
         {
-            writer.WriteDecimal(value);
+            writer.WriteDecimal(value, _options.DecimalFormat);
         }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
@@ -24,7 +24,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
                 case TypeCode.DateTime:
                     return new DateTimeConverter(options);
                 case TypeCode.Decimal:
-                    return new DecimalConverter();
+                    return new DecimalConverter(options);
                 case TypeCode.Double:
                     return new DoubleConverter();
                 case TypeCode.Int16:


### PR DESCRIPTION
Closes #192, taking option 2 from the issue: opt-in on write, reader widened immediately and independently.

## Write: `CborOptions.DecimalFormat`

`DecimalFloat` stays the default, so no existing document moves. `DecimalFraction` writes the RFC 8949 §3.4.4 form — tag 4 over `[-scale, mantissa]`, which is what a `decimal` already is, so the conversion is total and needs no range policy.

```
273.15m            -> C4 82 21 19 6AB3                            (was FC 0000000000006AB3 0000000000020000)
decimal.MaxValue   -> C4 82 00 C2 4C FFFFFFFFFFFFFFFFFFFFFFFF     (mantissa past 2^64 takes the bignum tag)
0.00m / 0m         -> C4 82 21 00 / C4 82 00 00                   (the scale survives, as it does today)
```

The choice is made in `DecimalConverter` rather than in `CborWriter`, and that placement is load-bearing: `DeterministicKeyOrder` encodes keys through the key converter, so the bytes it sorts are the bytes that go out. A flag on the writer would have sorted one form and emitted the other. `CborWriter.WriteDecimal(value)` is unchanged — it holds no options — and a second overload takes the format for custom converters.

## Read: unconditional

`ReadDecimal` walks the tag stack the way `ReadBigInteger` does instead of calling `SkipSemanticTag`, because here the tag carries the meaning. Tag 4 was a `CborException` before, so accepting it takes nothing away, and a service can turn the setting on without losing the documents it wrote before.

Reading is the more generous half: an indefinite-length pair and an unnormalised mantissa are both accepted, so `[-30, 100]` reads as `1E-28`. What a `decimal` genuinely cannot hold — a mantissa wider than 96 bits, or a scale that will not reduce to 28 — is a `CborException` rather than a rounded value. The exponent is bounded before `BigInteger.Pow` sees it, and the reduction divides once against a divisor bounded by `Log10` of the mantissa, so neither is driven by a number a hostile document merely claims.

## Source generation and CDDL

`DecimalFormat` is declarable on `[CborSourceGenerationOptions]`, and it is the only encoding of a `decimal` a schema can describe: with it, such a member renders as `#6.4([int, (int / #6.2(bstr) / #6.3(bstr))])` instead of raising CBOR1011. The mantissa is the same three-way choice `BigInteger` renders as, for the same reason.

## Two things worth a second opinion

- **Minor source break.** `DecimalConverter` now takes `CborOptions`, matching `DateTimeConverter`. Anyone calling `new DecimalConverter()` has to pass options.
- **The object model is asymmetric.** A `CborDecimal` writes as tag 4 like any other decimal, but reading those bytes back gives a `CborArray` tagged 4 — the DOM has no type for a decimal fraction, and giving it one is #170's business. The document is right either way; only the DOM type differs from what wrote it. Documented in the README next to the equivalent typed-array caveat, and pinned by a test that asserts exactly this.

## Tests

`DecimalFractionTests` covers both directions, the tag stack, indefinite length, the out-of-range and malformed rejections, dictionary keys under `Deterministic` (the pair sorts one way as decimal fractions and the other way as `DecimalFloat`), the DOM asymmetry, and negative zero losing its sign. `Cddl/CddlDecimalFractionTests` pins the rendering and validates real output against the schema. Both new fixture types are enrolled in `GeneratedCorpusTests`, which was missing `DecimalFormat` from the settings it copies onto the reflection side — without that the corpus would have compared tag 4 against the `FC` form.

1726 tests green on net10.0 and net8.0, 35 on the generator, netstandard2.0 compiles. net9.0 has no runtime available in the container, and the CDDL cases skip locally without the `cddl` gem — both are on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnnTU1dzbhPdmUQBs8rmw9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnnTU1dzbhPdmUQBs8rmw9)_