### PR TITLE
Map each member once whichever order the mapping is configured in, closes #193

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,12 @@ type is recognized as the one the conventions already mapped — and the lambda 
 reach the same mapping. This is what ``MongoDB.Bson``'s ``BsonClassMap.MapMember``, which this API
 takes its shape from, does with the same input.
 
+``AutoMap`` reaches its own members the same way, so the order does not matter: called after a member
+was mapped by hand, it configures that mapping from the attributes rather than adding a second one,
+and the two settings live together — the caller's name, the attribute's requirement policy. Two
+``AutoMap`` calls likewise leave one mapping per member. Where the two do say something about the same
+setting, the attribute wins, since that is the call being made.
+
 > **Behaviour change.** ``MapMember`` used to append unconditionally, so the call above mapped ``A``
 > twice: under ``A`` from the conventions and under ``a`` from the call, writing the member under both
 > keys — a document that reads back without complaint, carrying a member it should not. Without the
@@ -684,5 +690,6 @@ takes its shape from, does with the same input.
 > Code that relied on the append to write one member under two keys has to declare a second member to
 > carry the second key.
 >
-> ``AutoMap`` itself still appends, so the calls in the other order — ``MapMember`` and then
-> ``AutoMap`` — leave the member mapped twice as before. Configure the mapping in the order above.
+> ``AutoMap`` now goes through ``MapMember`` for each member it maps, which is what makes the other
+> order behave too. A convention of your own that builds ``MemberMapping<T>`` itself and passes them to
+> ``AddMemberMappings`` still appends, unchanged: that call adds what it is given.

--- a/README.md
+++ b/README.md
@@ -645,27 +645,6 @@ Give the two members distinct names, or drop one. Where the collision comes from
 not own, ``[CborIgnore]`` on the member you do own removes it from the mapping, and
 ``ClearMemberMappings()`` followed by explicit ``MapMember`` calls decides the whole mapping by hand.
 
-Adjusting a single member needs none of that: ``MapMember`` over a member the mapping already covers
-returns that member's mapping rather than adding a second one, so ``AutoMap`` then ``MapMember`` reads
-as it looks — take the conventions, then change this one member.
-
-```csharp
-options.Registry.ObjectMappingRegistry.Register<Foo>(om =>
-{
-    om.AutoMap();
-    om.MapMember(o => o.A).SetMemberName("a").SetRequired(RequirementPolicy.Always);
-});
-```
-
-> **Behaviour change.** ``MapMember`` used to append unconditionally, so the call above mapped ``A``
-> twice: under ``A`` from the conventions and under ``a`` from the call, writing the member under both
-> keys. Without the rename the two mappings shared a name and the type is refused by the check above.
-> The member is now identified by its ``MemberInfo`` — the declaration, so a member inherited from a
-> base type is recognized as the one the conventions already mapped — and both the lambda and the
-> reflection overloads reach the same mapping. Code that relied on the append to write one member
-> under two keys has to declare a second member to carry the second key. This matches
-> ``MongoDB.Bson``'s ``BsonClassMap.MapMember``, which this API takes its shape from.
-
 > **Behaviour change.** Such a type used to serialize, so this is a new exception at first use for a
 > type that "worked". What it wrote was a document whose second member was unreadable — silently
 > discarded before #169, refused as a duplicate key after it — so the type never round-tripped; the
@@ -678,3 +657,32 @@ options.Registry.ObjectMappingRegistry.Register<Foo>(om =>
 > rather than silently replacing the entry, as ``Dictionary<TKey, TValue>.Add`` does. The type has
 > neither an indexer nor a removal, so code of your own that relied on ``Add`` overwriting has to keep
 > the keys it has added and build a fresh dictionary instead.
+
+#### Adjusting a single member
+
+Taking the whole mapping over is not needed to change one member: ``MapMember`` over a member the
+mapping already covers returns that member's mapping rather than adding a second one, so ``AutoMap``
+then ``MapMember`` reads as it looks — take the conventions, then change this one member.
+
+```csharp
+options.Registry.ObjectMappingRegistry.Register<Foo>(om =>
+{
+    om.AutoMap();
+    om.MapMember(o => o.A).SetMemberName("a").SetRequired(RequirementPolicy.Always);
+});
+```
+
+The member is identified by its ``MemberInfo`` — the declaration, so a member inherited from a base
+type is recognized as the one the conventions already mapped — and the lambda and reflection overloads
+reach the same mapping. This is what ``MongoDB.Bson``'s ``BsonClassMap.MapMember``, which this API
+takes its shape from, does with the same input.
+
+> **Behaviour change.** ``MapMember`` used to append unconditionally, so the call above mapped ``A``
+> twice: under ``A`` from the conventions and under ``a`` from the call, writing the member under both
+> keys — a document that reads back without complaint, carrying a member it should not. Without the
+> rename the two mappings shared a name, and the type is refused by the duplicate-name check above.
+> Code that relied on the append to write one member under two keys has to declare a second member to
+> carry the second key.
+>
+> ``AutoMap`` itself still appends, so the calls in the other order — ``MapMember`` and then
+> ``AutoMap`` — leave the member mapped twice as before. Configure the mapping in the order above.

--- a/README.md
+++ b/README.md
@@ -629,8 +629,9 @@ the source looking wrong:
 
 * a **naming convention** that folds two member names into one — ``Id`` and ``ID`` under
   ``LowerCaseNamingConvention``;
-* a **mapping API call** over a member the conventions already covered — ``MapMember`` after
-  ``AutoMap`` without a ``ClearMemberMappings`` between them, or without a new name;
+* a **mapping API call** that renames a member onto a name another member already holds —
+  ``SetMemberName("X")`` where ``X`` is already mapped, whether by an attribute, by the conventions or
+  by an earlier call;
 * a member that **hides a base member** of the same name with ``new`` rather than ``override``, which
   reports both declarations and so maps both, under the one name. Where the hiding member is a
   **field** this always happens, whatever the two types are: field lookup folds nothing, so ``int``
@@ -643,6 +644,27 @@ the source looking wrong:
 Give the two members distinct names, or drop one. Where the collision comes from a base type you do
 not own, ``[CborIgnore]`` on the member you do own removes it from the mapping, and
 ``ClearMemberMappings()`` followed by explicit ``MapMember`` calls decides the whole mapping by hand.
+
+Adjusting a single member needs none of that: ``MapMember`` over a member the mapping already covers
+returns that member's mapping rather than adding a second one, so ``AutoMap`` then ``MapMember`` reads
+as it looks — take the conventions, then change this one member.
+
+```csharp
+options.Registry.ObjectMappingRegistry.Register<Foo>(om =>
+{
+    om.AutoMap();
+    om.MapMember(o => o.A).SetMemberName("a").SetRequired(RequirementPolicy.Always);
+});
+```
+
+> **Behaviour change.** ``MapMember`` used to append unconditionally, so the call above mapped ``A``
+> twice: under ``A`` from the conventions and under ``a`` from the call, writing the member under both
+> keys. Without the rename the two mappings shared a name and the type is refused by the check above.
+> The member is now identified by its ``MemberInfo`` — the declaration, so a member inherited from a
+> base type is recognized as the one the conventions already mapped — and both the lambda and the
+> reflection overloads reach the same mapping. Code that relied on the append to write one member
+> under two keys has to declare a second member to carry the second key. This matches
+> ``MongoDB.Bson``'s ``BsonClassMap.MapMember``, which this API takes its shape from.
 
 > **Behaviour change.** Such a type used to serialize, so this is a new exception at first use for a
 > type that "worked". What it wrote was a document whose second member was unreadable — silently

--- a/src/Dahomey.Cbor.Tests/ClassMemberModifierTests.cs
+++ b/src/Dahomey.Cbor.Tests/ClassMemberModifierTests.cs
@@ -234,9 +234,10 @@ namespace Dahomey.Cbor.Tests
         /// </summary>
         /// <remarks>
         /// <c>Name</c> is deliberately not mapped a second time. It used to be, and the expected
-        /// document carried the key twice as a result; a mapping that puts two members under one name
-        /// is now refused when it is built (issue #177), so mapping over what AutoMap already covered
-        /// throws rather than writing a document this type cannot read back.
+        /// document carried the key twice as a result. Neither half of that is reachable now: a
+        /// mapping that puts two members under one name is refused when it is built (issue #177), and
+        /// mapping over what <c>AutoMap</c> already covered returns the mapping it already has rather
+        /// than adding a second one (issue #193).
         /// </remarks>
         [Fact]
         public void TestWriteByApi()

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0177.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0177.cs
@@ -21,9 +21,9 @@ namespace Dahomey.Cbor.Tests.Issues
     /// Refusing at build time is a new failure at first use for a type that "worked" before, which is
     /// the point: the alternative is a document that silently drops a member. The check is on the
     /// mapped name, so it covers every route to the collision rather than the attribute alone: a
-    /// naming convention that folds two member names into one, a mapping API call that maps a member
-    /// twice, and a member that hides a base member of the same name all arrive at the same place with
-    /// nothing in the source looking wrong.
+    /// naming convention that folds two member names into one, a mapping API call that renames a
+    /// member onto a name already taken, and a member that hides a base member of the same name all
+    /// arrive at the same place with nothing in the source looking wrong.
     /// </para>
     /// </remarks>
     public class Issue0177
@@ -192,15 +192,24 @@ namespace Dahomey.Cbor.Tests.Issues
             Assert.Contains("'id'", ex.Message);
         }
 
-        /// <summary>And mapping a member twice through the mapping API, which names it only once.</summary>
+        /// <summary>
+        /// And a mapping API call that renames a member onto a name another member already holds,
+        /// which names it only once.
+        /// </summary>
+        /// <remarks>
+        /// Calling <c>MapMember</c> over a member the conventions already covered used to reach here
+        /// too, by mapping that member a second time under its own name. It no longer maps anything —
+        /// see #193 — so a second member renamed onto the first one's name is what this route looks
+        /// like now.
+        /// </remarks>
         [Fact]
-        public void MappingTheSameMemberTwiceByApiIsRefused()
+        public void AMemberRenamedOntoAnotherMembersNameIsRefused()
         {
             CborOptions options = new CborOptions();
             options.Registry.ObjectMappingRegistry.Register<DistinctNames>(objectMapping =>
             {
                 objectMapping.AutoMap();
-                objectMapping.MapMember(o => o.First);
+                objectMapping.MapMember(o => o.Second).SetMemberName("X");
             });
 
             CborException ex = AssertRefusedByValidation(
@@ -282,9 +291,9 @@ namespace Dahomey.Cbor.Tests.Issues
         }
 
         /// <summary>
-        /// A member added to the mapping after something has already initialized it arrives past the
-        /// check, at the read lookup, which refuses the key on its own terms. It reports as the same
-        /// kind of failure — the library's own exception type, not the raw
+        /// A collision reaching the mapping after something has already initialized it arrives past
+        /// the check, at the read lookup, which refuses the key on its own terms. It reports as the
+        /// same kind of failure — the library's own exception type, not the raw
         /// <see cref="System.ArgumentException"/> of the container that caught it — and says that it
         /// arrived late, which is what tells the two mechanisms apart.
         /// </summary>
@@ -299,7 +308,7 @@ namespace Dahomey.Cbor.Tests.Issues
                 // reading the mappings initializes them, so the validation has already run
                 _ = objectMapping.MemberMappings.Count;
 
-                objectMapping.MapMember(o => o.First);
+                objectMapping.MapMember(o => o.Second).SetMemberName("X");
             });
 
             CborException ex = AssertThrowsCborException(
@@ -321,7 +330,7 @@ namespace Dahomey.Cbor.Tests.Issues
             {
                 objectMapping.AutoMap();
                 _ = objectMapping.MemberMappings.Count;
-                objectMapping.MapMember(o => o.First);
+                objectMapping.MapMember(o => o.Second).SetMemberIndex(1);
             });
 
             CborException ex = AssertThrowsCborException(

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0193.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0193.cs
@@ -1,0 +1,202 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization.Converters.Mappings;
+using System.Reflection;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #193: <c>MapMember</c> always appended, so a call over a member the mapping already
+    /// covered left the type with that member mapped twice. It now returns the mapping already
+    /// covering the member.
+    /// </summary>
+    /// <remarks>
+    /// <c>AutoMap</c> followed by <c>MapMember</c> reads as "take the conventions, then adjust this
+    /// one member", and it is the natural way to reach <c>SetIngoreIfDefault</c>, <c>SetRequired</c>,
+    /// <c>SetLengthMode</c> or <c>SetConverter</c> for a single member. Appending adjusted nothing:
+    /// with a rename it wrote the member under two keys — a well-formed document carrying a member it
+    /// should not, which reads back without complaint — and without one it produced two mappings under
+    /// the one name, which #177 refuses when the mapping is built. Only the second was loud.
+    /// <para>
+    /// The identity is the <see cref="MemberInfo"/>, which both the lambda and the reflection
+    /// overloads have, and which is what <c>MongoDB.Bson</c>'s <c>BsonClassMap.MapMember</c> — the API
+    /// this one takes its shape from — keys on for the same purpose.
+    /// </para>
+    /// </remarks>
+    public class Issue0193
+    {
+        public class Adjusted
+        {
+            public int A { get; set; }
+            public int B { get; set; }
+        }
+
+        public class BaseWithAMember
+        {
+            public int Inherited { get; set; }
+        }
+
+        public class DerivedWithAMember : BaseWithAMember
+        {
+            public int Declared { get; set; }
+        }
+
+        public class PartiallyMapped
+        {
+            public int A { get; set; }
+
+            [CborIgnore]
+            public int B { get; set; }
+        }
+
+        [Fact]
+        public void MapMemberReturnsTheMappingAlreadyCoveringTheMember()
+        {
+            CborOptions options = new CborOptions();
+            MemberMapping<Adjusted> fromFirstCall = null;
+            MemberMapping<Adjusted> fromSecondCall = null;
+
+            options.Registry.ObjectMappingRegistry.Register<Adjusted>(objectMapping =>
+            {
+                objectMapping.AutoMap();
+                fromFirstCall = objectMapping.MapMember(o => o.A);
+                fromSecondCall = objectMapping.MapMember(o => o.A);
+            });
+
+            Assert.Same(fromFirstCall, fromSecondCall);
+
+            IObjectMapping objectMapping = options.Registry.ObjectMappingRegistry.Lookup<Adjusted>();
+            Assert.Equal(2, objectMapping.MemberMappings.Count);
+            Assert.Contains(fromFirstCall, objectMapping.MemberMappings);
+        }
+
+        /// <summary>
+        /// The reflection overloads reach the same mapping as the lambda one, since the identity is
+        /// the member rather than the way it was named.
+        /// </summary>
+        [Fact]
+        public void TheReflectionOverloadReachesTheSameMapping()
+        {
+            CborOptions options = new CborOptions();
+            MemberMapping<Adjusted> fromLambda = null;
+            MemberMapping<Adjusted> fromPropertyInfo = null;
+
+            options.Registry.ObjectMappingRegistry.Register<Adjusted>(objectMapping =>
+            {
+                objectMapping.AutoMap();
+                fromLambda = objectMapping.MapMember(o => o.A);
+                fromPropertyInfo = objectMapping.MapMember(typeof(Adjusted).GetProperty(nameof(Adjusted.A)));
+            });
+
+            Assert.Same(fromLambda, fromPropertyInfo);
+        }
+
+        /// <summary>
+        /// The shape the issue reports: a rename used to write the member under both names, the old
+        /// one alongside the new.
+        /// </summary>
+        [Fact]
+        public void RenamingAMappedMemberWritesItUnderTheNewNameOnly()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<Adjusted>(objectMapping =>
+                objectMapping
+                    .AutoMap()
+                    .MapMember(o => o.A)
+                        .SetMemberName("renamed")
+            );
+
+            Adjusted obj = new Adjusted { A = 7, B = 9 };
+
+            // a2 67 "renamed" 07 61 "B" 09 -- and no 'A', which is what used to be written too
+            const string hexBuffer = "A26772656E616D656407614209";
+            Helper.TestWrite(obj, hexBuffer, null, options);
+        }
+
+        [Fact]
+        public void ARenamedMemberReadsBackUnderItsNewName()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<Adjusted>(objectMapping =>
+                objectMapping
+                    .AutoMap()
+                    .MapMember(o => o.A)
+                        .SetMemberName("renamed")
+            );
+
+            Adjusted obj = Helper.Read<Adjusted>("A26772656E616D656407614209", options);
+
+            Assert.NotNull(obj);
+            Assert.Equal(7, obj.A);
+            Assert.Equal(9, obj.B);
+        }
+
+        /// <summary>
+        /// Adjusting a member without renaming it — the reason to make the call at all — used to leave
+        /// two mappings under the one name, which #177 refuses.
+        /// </summary>
+        [Fact]
+        public void AMappedMemberCanBeAdjustedWithoutRenamingIt()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<Adjusted>(objectMapping =>
+                objectMapping
+                    .AutoMap()
+                    .MapMember(o => o.A)
+                        .SetIngoreIfDefault(true)
+            );
+
+            Adjusted obj = new Adjusted { A = 0, B = 9 };
+
+            const string hexBuffer = "A1614209";
+            Helper.TestWrite(obj, hexBuffer, null, options);
+        }
+
+        /// <summary>
+        /// A member declared on a base type is the same member, though the two <see cref="MemberInfo"/>
+        /// are not equal.
+        /// </summary>
+        /// <remarks>
+        /// The conventions reflect over the derived type, so an inherited member arrives with its
+        /// <c>ReflectedType</c> set to that type, while <c>o =&gt; o.Inherited</c> compiles to the
+        /// accessor on the declaring type and so arrives with <c>ReflectedType</c> set to the base.
+        /// Reference equality separates them; the metadata definition does not.
+        /// </remarks>
+        [Fact]
+        public void AnInheritedMemberIsTheSameMember()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<DerivedWithAMember>(objectMapping =>
+                objectMapping
+                    .AutoMap()
+                    .MapMember(o => o.Inherited)
+                        .SetMemberName("renamed")
+            );
+
+            DerivedWithAMember obj = new DerivedWithAMember { Declared = 7, Inherited = 9 };
+
+            const string hexBuffer = "A2684465636C61726564076772656E616D656409";
+            Helper.TestWrite(obj, hexBuffer, null, options);
+        }
+
+        /// <summary>
+        /// A member the conventions left out is still added, which is the half of the old behaviour
+        /// that was the point of the method.
+        /// </summary>
+        [Fact]
+        public void AMemberTheConventionsLeftOutIsStillMapped()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<PartiallyMapped>(objectMapping =>
+                objectMapping
+                    .AutoMap()
+                    .MapMember(o => o.B)
+            );
+
+            PartiallyMapped obj = new PartiallyMapped { A = 7, B = 9 };
+
+            const string hexBuffer = "A2614107614209";
+            Helper.TestWrite(obj, hexBuffer, null, options);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0193.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0193.cs
@@ -41,6 +41,11 @@ namespace Dahomey.Cbor.Tests.Issues
             public int Declared { get; set; }
         }
 
+        public class RequiredBeforeAutoMap
+        {
+            [CborRequired] public int A { get; set; }
+        }
+
         public class PartiallyMapped
         {
             public int A { get; set; }
@@ -177,6 +182,52 @@ namespace Dahomey.Cbor.Tests.Issues
 
             const string hexBuffer = "A2684465636C61726564076772656E616D656409";
             Helper.TestWrite(obj, hexBuffer, null, options);
+        }
+
+        /// <summary>
+        /// The other order maps the member once too: <c>AutoMap</c> reaches its members through
+        /// <c>MapMember</c>, so one mapped by hand first is the one it configures.
+        /// </summary>
+        /// <remarks>
+        /// Both halves survive: the caller's rename, which the conventions have no opinion on, and
+        /// the requirement policy the attribute carries, which <c>AutoMap</c> applies to the mapping
+        /// it finds. Appending instead left the member under two keys with nothing saying so — the
+        /// same defect as the documented order, and silent for the same reason.
+        /// </remarks>
+        [Fact]
+        public void AutoMapConfiguresAMemberMappedBeforeIt()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<RequiredBeforeAutoMap>(objectMapping =>
+            {
+                objectMapping.MapMember(o => o.A).SetMemberName("renamed");
+                objectMapping.AutoMap();
+            });
+
+            IObjectMapping objectMapping = options.Registry.ObjectMappingRegistry.Lookup<RequiredBeforeAutoMap>();
+            Assert.Single(objectMapping.MemberMappings);
+
+            IMemberMapping memberMapping = Assert.Single(objectMapping.MemberMappings);
+            Assert.Equal("renamed", memberMapping.MemberName);
+            Assert.Equal(RequirementPolicy.Always, memberMapping.RequirementPolicy);
+
+            // a1 67 "renamed" 07
+            Helper.TestWrite(new RequiredBeforeAutoMap { A = 7 }, "A16772656E616D656407", null, options);
+        }
+
+        /// <summary>Two <c>AutoMap</c> calls leave one mapping per member, for the same reason.</summary>
+        [Fact]
+        public void AutoMapTwiceMapsEachMemberOnce()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<Adjusted>(objectMapping =>
+                objectMapping
+                    .AutoMap()
+                    .AutoMap()
+            );
+
+            Assert.Equal(2, options.Registry.ObjectMappingRegistry.Lookup<Adjusted>().MemberMappings.Count);
+            Helper.TestWrite(new Adjusted { A = 7, B = 9 }, "A2614107614209", null, options);
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
@@ -17,7 +17,6 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         public void Apply<T>(SerializationRegistry registry, ObjectMapping<T> objectMapping)
         {
             Type type = objectMapping.ObjectType;
-            List<MemberMapping<T>> memberMappings = new List<MemberMapping<T>>();
 
             CborDiscriminatorAttribute? discriminatorAttribute = type.GetCustomAttribute<CborDiscriminatorAttribute>();
             CborIntDiscriminatorAttribute? intDiscriminatorAttribute = type.GetCustomAttribute<CborIntDiscriminatorAttribute>();
@@ -95,12 +94,15 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                     continue;
                 }
 
-                MemberMapping<T> memberMapping = new MemberMapping<T>(registry.ConverterRegistry, objectMapping, propertyInfo, propertyInfo.PropertyType);
+                // Through MapMember rather than by construction, so that a member already mapped by
+                // hand is the one the conventions configure rather than a second mapping of it. The
+                // two orders then agree: AutoMap either way leaves one mapping per member, carrying
+                // both what the attributes say and what the caller set.
+                MemberMapping<T> memberMapping = objectMapping.MapMember(propertyInfo, propertyInfo.PropertyType);
                 ProcessDefaultValue(propertyInfo, memberMapping);
                 ProcessShouldSerializeMethod(memberMapping);
                 ProcessLengthMode(propertyInfo, memberMapping);
                 ProcessRequired(propertyInfo, memberMapping);
-                memberMappings.Add(memberMapping);
             }
 
             foreach (FieldInfo fieldInfo in fields)
@@ -115,18 +117,12 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                     continue;
                 }
 
-                Type fieldType = fieldInfo.FieldType;
-
-                MemberMapping<T> memberMapping = new MemberMapping<T>(registry.ConverterRegistry, objectMapping, fieldInfo, fieldInfo.FieldType);
+                MemberMapping<T> memberMapping = objectMapping.MapMember(fieldInfo, fieldInfo.FieldType);
                 ProcessDefaultValue(fieldInfo, memberMapping);
                 ProcessShouldSerializeMethod(memberMapping);
                 ProcessLengthMode(fieldInfo, memberMapping);
                 ProcessRequired(fieldInfo, memberMapping);
-
-                memberMappings.Add(memberMapping);
             }
-
-            objectMapping.AddMemberMappings(memberMappings);
 
             if (!type.IsAbstract)
             {

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
@@ -131,6 +131,12 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             // well-formed document carrying a member it should not — and collided under #177's
             // duplicate-name check when it did not. Returning the mapping already covering the member
             // matches MongoDB.Bson's BsonClassMap.MapMember, whose shape this API takes.
+            //
+            // Only a MemberMapping<T> can be returned, so only those are looked at. Every mapping
+            // this library builds from a member is one; an implementation of IMemberMapping from
+            // outside it that names a member of its own is left to the duplicate-name check, which
+            // reports the collision rather than this silently returning something that is not the
+            // mapping the caller was handed.
             foreach (IMemberMapping memberMapping in _memberMappings)
             {
                 if (memberMapping is MemberMapping<T> existingMapping

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
@@ -97,8 +97,14 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         }
 
         /// <summary>
-        /// Creates a member map and adds it to the object mapping.
+        /// Returns the member map for a member, creating and adding one if the mapping does not
+        /// already cover that member.
         /// </summary>
+        /// <remarks>
+        /// A member the mapping already covers — which <see cref="AutoMap"/> is the usual way of
+        /// arranging — is adjusted rather than mapped a second time, so
+        /// <c>AutoMap().MapMember(o =&gt; o.A).SetRequired(...)</c> means what it reads as.
+        /// </remarks>
         /// <typeparam name="TM">The member type.</typeparam>
         /// <param name="memberLambda">A lambda expression specifying the member.</param>
         /// <returns>The member map.</returns>
@@ -108,11 +114,35 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             return MapMember(memberInfo, memberType);
         }
 
+        /// <summary>
+        /// Returns the member map for a member, creating and adding one if the mapping does not
+        /// already cover that member.
+        /// </summary>
+        /// <param name="memberInfo">The field or property to map.</param>
+        /// <param name="memberType">The type of that field or property.</param>
+        /// <returns>The member map.</returns>
         public MemberMapping<T> MapMember(MemberInfo memberInfo, Type memberType)
         {
-            MemberMapping<T> memberMapping = new MemberMapping<T>(_registry.ConverterRegistry, this, memberInfo, memberType);
-            _memberMappings.Add(memberMapping);
-            return memberMapping;
+            // Adjusting one member is what this call is for: "take the conventions, then set
+            // SetRequired/SetConverter/… on this one" is how AutoMap followed by MapMember reads, and
+            // the only alternative is ClearMemberMappings() plus mapping every member by hand, which
+            // drifts the moment a member is added to the type. Appending a second mapping for the
+            // same member instead wrote it under two keys when the second call renamed it — a
+            // well-formed document carrying a member it should not — and collided under #177's
+            // duplicate-name check when it did not. Returning the mapping already covering the member
+            // matches MongoDB.Bson's BsonClassMap.MapMember, whose shape this API takes.
+            foreach (IMemberMapping memberMapping in _memberMappings)
+            {
+                if (memberMapping is MemberMapping<T> existingMapping
+                    && IsSameMember(existingMapping.MemberInfo, memberInfo))
+                {
+                    return existingMapping;
+                }
+            }
+
+            MemberMapping<T> newMapping = new MemberMapping<T>(_registry.ConverterRegistry, this, memberInfo, memberType);
+            _memberMappings.Add(newMapping);
+            return newMapping;
         }
 
         public MemberMapping<T> MapMember(FieldInfo fieldInfo)
@@ -407,6 +437,31 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                     }
                     break;
             }
+        }
+
+        /// <summary>
+        /// Whether two <see cref="MemberInfo"/> denote the same declared field or property.
+        /// </summary>
+        /// <remarks>
+        /// Reference equality is not enough for a member declared on a base type: the conventions
+        /// reflect over <typeparamref name="T"/>, so an inherited member arrives with
+        /// <c>ReflectedType</c> set to <typeparamref name="T"/>, while <c>o =&gt; o.A</c> compiles to
+        /// the accessor on the declaring type and so arrives with <c>ReflectedType</c> set to that
+        /// base. The two are unequal, and the same declaration. Comparing the metadata definition —
+        /// what <c>MemberInfo.HasSameMetadataDefinitionAs</c> does, which netstandard2.0 does not
+        /// have — sees through the difference.
+        /// </remarks>
+        private static bool IsSameMember(MemberInfo? left, MemberInfo? right)
+        {
+            if (left is null || right is null)
+            {
+                // A null one is a mapping defined by delegates rather than by reflection - the
+                // discriminator, or what a source generator emits - which no member identifies.
+                return false;
+            }
+
+            return left == right
+                || (left.MetadataToken == right.MetadataToken && left.Module.Equals(right.Module));
         }
 
         private static (MemberInfo, Type) GetMemberInfoFromLambda<TM>(Expression<Func<T, TM>> memberLambda)

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberMappingErrors.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberMappingErrors.cs
@@ -21,7 +21,8 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// </summary>
         /// <remarks>
         /// Worth saying because the two have different fixes: one is two members declared under one
-        /// name, the other is a <c>MapMember</c> call over a member the conventions already covered.
+        /// name, the other is a mapping API call - a <c>SetMemberName</c> or <c>SetMemberIndex</c>
+        /// onto a key already taken - made after the mapping had been used.
         /// </remarks>
         public const string AddedAfterValidation =
             ". The collision was added to the mapping after it was validated.";

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -219,10 +219,11 @@ namespace Dahomey.Cbor.Serialization.Converters
                 if (memberMapping.CanBeDeserialized || isCreatorMember)
                 {
                     // Both lookups refuse a key they already hold, and the mapping was validated for
-                    // exactly that before this loop began. A collision reaching here is therefore a
-                    // member added to the mapping after its validation ran - mapping over a member
-                    // AutoMap already covered, once something has read MemberMappings - which is the
-                    // same mistake arriving late, and is reported as the same kind of failure rather
+                    // exactly that before this loop began. A collision reaching here is therefore one
+                    // that reached the mapping after its validation ran - a SetMemberName or
+                    // SetMemberIndex onto a key already taken, once something has read
+                    // MemberMappings - which is the same mistake arriving late, and is reported as
+                    // the same kind of failure rather
                     // than as the raw ArgumentException of the container that caught it. The clause
                     // naming the lateness is what tells the two apart: the validator sees the whole
                     // mapping and refuses any collision in it, while this sees only the members that


### PR DESCRIPTION
`MapMember` always appended. Called over a member the mapping already covered — which `AutoMap` is the usual way of arranging — it added a second `MemberMapping` for the same `MemberInfo`, and both were honoured:

* **with a rename**, the member was written under two keys — `{"A": 7, "B": 9, "renamed": 7}` — a well-formed document carrying a member it should not, which reads back without complaint;
* **without one**, the two mappings shared a name, which #177 refuses when the mapping is built.

Neither is what the call was for. `AutoMap` followed by `MapMember` reads as "take the conventions, then adjust this one member", and it is the natural way to reach `SetIngoreIfDefault`, `SetRequired`, `SetLengthMode` or `SetConverter` for a single member. The only alternative was `ClearMemberMappings()` followed by mapping every member by hand, which is a great deal of code to change one flag and drifts silently the moment a member is added to the type.

## What changed

**`MapMember` returns the mapping already covering the member**, and only creates one when none does. Both the lambda and the reflection overloads reach the same mapping, since they go through the same two-argument overload.

The issue asked for `MongoDB.Bson` to be checked rather than recalled. `BsonClassMap.MapMember` does exactly this — `_declaredMemberMaps.Find(m => m.MemberInfo == memberInfo)`, create only if not found — so this is an alignment rather than an invention.

**Identity is compared by metadata definition, not by reference.** The conventions reflect over `T`, so an inherited member arrives with `ReflectedType` set to `T`, while `o => o.A` compiles to the accessor on the declaring type and so arrives with `ReflectedType` set to that base. The two `MemberInfo` are unequal and the same declaration — verified, not assumed — so a reference comparison would have left a member declared on a base type duplicating exactly as before. `MemberInfo.HasSameMetadataDefinitionAs` is what this reproduces; netstandard2.0 does not have it.

A mapping whose `MemberInfo` is null — the discriminator, or what the source generator emits — is never matched, so nothing identified by delegates is folded into a reflection-mapped member.

**`AutoMap` reaches its own members through `MapMember`.** Fixing only `MapMember` left the two disagreeing, and the defect reachable by writing the calls the other way round: `MapMember(o => o.A).SetMemberName("renamed")` then `AutoMap()` still wrote `A` under both keys, silent for the same reason — the names differ, so #177's check has nothing to refuse. `DefaultObjectMappingConvention` no longer constructs `MemberMapping<T>` and hands the batch to `AddMemberMappings`; a member already mapped by hand is the one it configures, so the caller's name survives and the attributes' default value, `ShouldSerialize`, length mode and requirement policy are applied to that same mapping. Where both speak to one setting the attribute wins, which is what asking for the conventions means. Two `AutoMap` calls likewise leave one mapping per member.

The order in which members are appended is unchanged, so a mapping configured the documented way — `AutoMap` first — is byte-for-byte what it was. `AddMemberMappings` still appends what it is given: it is the call a convention of one's own, or the source generator, uses for mappings that no `MemberInfo` identifies.

## Behaviour change

A caller who relied on the append to write one member under two keys loses that; #177 already removed the same-name half of it. The README's duplicate-key section gains a subsection for the mapping API, and its list of routes into the duplicate-name refusal drops the `MapMember`-after-`AutoMap` entry, which no longer reaches it, in favour of the one that does: a `SetMemberName` onto a name already taken.

## Tests

`Issues/Issue0193.cs`, nine tests: the existing mapping is returned (lambda and reflection overloads alike), a rename writes and reads under the new name only, a member is adjusted without renaming — the shape #177 used to refuse — an inherited member is recognized as the same member, `AutoMap` after a hand-mapped member configures it rather than duplicating it, `AutoMap` twice maps each member once, and a member the conventions left out is still mapped. Six of the nine fail on `master`.

Three #177 tests reached the duplicate-name check through the old append and now take the route that remains, a second member renamed onto a name already taken, so the check itself stays covered in both its validation and late-arrival forms.

Full suite green on net8.0 and net10.0 (1681 passed, 42 skipped), generator tests included; net9.0 not run locally for want of the runtime, and the change is framework-agnostic.