### PR TITLE
Make every CDDL rule name a legal RFC 8610 id, and unique

### DIFF
--- a/src/Dahomey.Cbor.Generator/CddlEmitter.cs
+++ b/src/Dahomey.Cbor.Generator/CddlEmitter.cs
@@ -30,9 +30,12 @@ namespace Dahomey.Cbor.Generator
                 byKey[model.Symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)] = model;
             }
 
-            IReadOnlyDictionary<string, string> ruleNames = TypeNames.BuildRuleNames(ordered);
-            Dictionary<string, PolymorphicShape> shapes =
-                CddlPolymorphism.BuildShapes(ordered, byKey, ruleNames);
+            // Shapes first, because a polymorphic type is emitted under a second rule name derived from
+            // its first, and the uniqueness pass has to reserve both together. Only the order of a
+            // choice's arms depends on the names, so that one step waits.
+            Dictionary<string, PolymorphicShape> shapes = CddlPolymorphism.BuildShapes(ordered, byKey);
+            IReadOnlyDictionary<string, string> ruleNames = TypeNames.BuildRuleNames(ordered, shapes);
+            CddlPolymorphism.SortArms(shapes, ruleNames);
 
             // Use sites resolve through their own name table: a member declared as a base type names
             // that base's `-poly` rule, a member declared as a leaf names the leaf's bare rule. Keeping

--- a/src/Dahomey.Cbor.Generator/CddlPolymorphism.cs
+++ b/src/Dahomey.Cbor.Generator/CddlPolymorphism.cs
@@ -70,6 +70,27 @@ namespace Dahomey.Cbor.Generator
         {
             return EmitsPoly ? ruleName + "-poly" : ruleName;
         }
+
+        /// <summary>
+        /// The second rule name this type occupies, or null when it is emitted under one name only.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="ArmName"/> and <see cref="ReferenceName"/> mint this from a rule name that has
+        /// already been handed out, so it is never a candidate the uniqueness pass sees -- which is why
+        /// <see cref="TypeNames.BuildRuleNames"/> asks for it and reserves the two names together. A
+        /// type whose own declaration name reads <c>X-poly</c> would otherwise be free to take the
+        /// derived form of a polymorphic <c>X</c>, and two rules would be emitted under one name.
+        /// <para>
+        /// An over-approximation by one case: a type reported by CBOR1012 is skipped before either rule
+        /// is emitted, so its reservation holds a name nothing uses. That costs another type a suffix in
+        /// a compilation that already carries an error, which is cheaper than making the reservation
+        /// depend on diagnostics that have not run yet.
+        /// </para>
+        /// </remarks>
+        public string? DerivedRuleName(string ruleName)
+        {
+            return EmitsPoly ? ArmName(ruleName) : null;
+        }
     }
 
     /// <summary>
@@ -78,10 +99,15 @@ namespace Dahomey.Cbor.Generator
     /// </summary>
     internal static class CddlPolymorphism
     {
+        /// <remarks>
+        /// Takes no rule names, and that is what makes the ordering work: <see cref="TypeNames.BuildRuleNames"/>
+        /// needs to know which types emit a <c>-poly</c> rule *before* it hands names out, so the one
+        /// thing here that does depend on a name -- the order of a choice's arms -- is settled afterwards
+        /// by <see cref="SortArms"/>. Nothing else in a shape is derived from a rule name.
+        /// </remarks>
         public static Dictionary<string, PolymorphicShape> BuildShapes(
             IReadOnlyList<TypeModel> ordered,
-            IReadOnlyDictionary<string, TypeModel> byKey,
-            IReadOnlyDictionary<string, string> ruleNames)
+            IReadOnlyDictionary<string, TypeModel> byKey)
         {
             Dictionary<string, PolymorphicShape> shapes = new Dictionary<string, PolymorphicShape>();
 
@@ -119,11 +145,6 @@ namespace Dahomey.Cbor.Generator
 
             foreach (PolymorphicShape shape in shapes.Values)
             {
-                // Ordered by rule name rather than by collection order, so the emitted choice is a pure
-                // function of the source and the schema stays byte-stable across builds.
-                shape.Subtypes.Sort((left, right) => string.CompareOrdinal(
-                    ruleNames[Key(left.Symbol)], ruleNames[Key(right.Symbol)]));
-
                 shape.EmitsBare = shape.IsInstantiable
                     && !(shape.WritesDiscriminator && shape.Policy == "Always");
                 shape.EmitsPoly = shape.Subtypes.Count > 0
@@ -136,6 +157,21 @@ namespace Dahomey.Cbor.Generator
             }
 
             return shapes;
+        }
+
+        /// <summary>
+        /// Orders each type choice's arms by rule name rather than by collection order, so the emitted
+        /// choice is a pure function of the source and the schema stays byte-stable across builds.
+        /// </summary>
+        public static void SortArms(
+            IReadOnlyDictionary<string, PolymorphicShape> shapes,
+            IReadOnlyDictionary<string, string> ruleNames)
+        {
+            foreach (PolymorphicShape shape in shapes.Values)
+            {
+                shape.Subtypes.Sort((left, right) => string.CompareOrdinal(
+                    ruleNames[Key(left.Symbol)], ruleNames[Key(right.Symbol)]));
+            }
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Generator/TypeNames.cs
+++ b/src/Dahomey.Cbor.Generator/TypeNames.cs
@@ -1,5 +1,7 @@
 using Microsoft.CodeAnalysis;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -50,14 +52,24 @@ namespace Dahomey.Cbor.Generator
         }
 
         /// <summary>
-        /// Maps each type to its CDDL rule name. A short name (<see cref="AccessorName"/>) that no
-        /// other type in <paramref name="ordered"/> shares is kept exactly as produced. A short name
-        /// shared by two or more types -- two different closed generics whose type arguments only
-        /// differ by namespace (<c>Envelope&lt;Left.Item&gt;</c> vs. <c>Envelope&lt;Right.Item&gt;</c>),
-        /// or two same-named nested types in different namespaces -- is re-derived for every member of
-        /// that collision from the full type key via <see cref="QualifiedAccessorName"/>, so the result
-        /// never depends on which was seen first and never collides again.
+        /// Maps each type to its CDDL rule name, in three steps that each guarantee something the next
+        /// one relies on. A short name (<see cref="AccessorName"/>) that no other type in
+        /// <paramref name="ordered"/> shares is kept exactly as produced; a short name shared by two or
+        /// more types -- two same-named nested types in different namespaces, say -- is re-derived for
+        /// every member of that collision from the full type key via
+        /// <see cref="QualifiedAccessorName"/>, so the result never depends on which was seen first.
+        /// Whatever those produce is then folded onto RFC 8610's identifier syntax
+        /// (<see cref="SanitizeRuleName"/>), and finally made unique
+        /// (<see cref="ResolveRemainingCollisions"/>).
         /// </summary>
+        /// <remarks>
+        /// The last step is what makes the guarantee unconditional, and it is load-bearing rather than
+        /// defensive: escaping folds a character outside ASCII onto a <c>_</c> sequence that a C# name
+        /// is free to contain literally, so <c>Café</c> and <c>Caf_00E9</c> reach it as one name. A
+        /// duplicate rule name is the one malformation an emitted schema can carry without any tool
+        /// complaining -- the gem reads a file whose second definition of a rule silently shadows the
+        /// first -- so it cannot be left to the shape of the names.
+        /// </remarks>
         public static IReadOnlyDictionary<string, string> BuildRuleNames(IReadOnlyList<TypeModel> ordered)
         {
             Dictionary<string, List<TypeModel>> byShortName = new Dictionary<string, List<TypeModel>>();
@@ -75,18 +87,166 @@ namespace Dahomey.Cbor.Generator
                 bucket.Add(model);
             }
 
-            Dictionary<string, string> names = new Dictionary<string, string>();
+            Dictionary<string, string> candidates = new Dictionary<string, string>(StringComparer.Ordinal);
 
             foreach (KeyValuePair<string, List<TypeModel>> entry in byShortName)
             {
                 foreach (TypeModel model in entry.Value)
                 {
                     string key = model.Symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-                    names[key] = entry.Value.Count == 1 ? entry.Key : QualifiedAccessorName(model.Symbol);
+                    candidates[key] = SanitizeRuleName(
+                        entry.Value.Count == 1 ? entry.Key : QualifiedAccessorName(model.Symbol));
+                }
+            }
+
+            return ResolveRemainingCollisions(candidates);
+        }
+
+        /// <summary>
+        /// Gives every type a rule name no other type in the same schema holds, keeping each candidate
+        /// where it is already unique and appending <c>-2</c>, <c>-3</c> and so on to the rest.
+        /// </summary>
+        /// <remarks>
+        /// Which member of a collision keeps the bare name is decided by ordinal order of the full type
+        /// key, and the groups are walked in ordinal order of the candidate, so the whole mapping is a
+        /// function of the set of types alone. That is the property a rule name needs and an accessor
+        /// name does not: a schema is a published artifact, compared against other copies of itself, so
+        /// a name that depended on the order <c>ordered</c> happened to arrive in would make two builds
+        /// of one context disagree. A suffixed name is checked against the names already handed out
+        /// rather than assumed free, since a candidate elsewhere in the schema may already read
+        /// <c>X-2</c>.
+        /// </remarks>
+        private static IReadOnlyDictionary<string, string> ResolveRemainingCollisions(
+            IReadOnlyDictionary<string, string> candidates)
+        {
+            Dictionary<string, List<string>> keysByCandidate =
+                new Dictionary<string, List<string>>(StringComparer.Ordinal);
+
+            foreach (KeyValuePair<string, string> candidate in candidates)
+            {
+                if (!keysByCandidate.TryGetValue(candidate.Value, out List<string>? keys))
+                {
+                    keys = new List<string>();
+                    keysByCandidate[candidate.Value] = keys;
+                }
+
+                keys.Add(candidate.Key);
+            }
+
+            Dictionary<string, string> names = new Dictionary<string, string>(StringComparer.Ordinal);
+            HashSet<string> used = new HashSet<string>(StringComparer.Ordinal);
+
+            // Uncontested candidates first, and all of them, so a suffix minted below cannot take a
+            // name that some other type was always going to hold.
+            foreach (KeyValuePair<string, List<string>> entry in keysByCandidate)
+            {
+                if (entry.Value.Count == 1)
+                {
+                    names[entry.Value[0]] = entry.Key;
+                    used.Add(entry.Key);
+                }
+            }
+
+            IEnumerable<string> contested = keysByCandidate
+                .Where(entry => entry.Value.Count > 1)
+                .Select(entry => entry.Key)
+                .OrderBy(candidate => candidate, StringComparer.Ordinal);
+
+            foreach (string candidate in contested)
+            {
+                List<string> keys = keysByCandidate[candidate];
+                keys.Sort(StringComparer.Ordinal);
+
+                foreach (string key in keys)
+                {
+                    string name = candidate;
+
+                    for (int suffix = 2; !used.Add(name); suffix++)
+                    {
+                        name = candidate + "-" + suffix.ToString(CultureInfo.InvariantCulture);
+                    }
+
+                    names[key] = name;
                 }
             }
 
             return names;
+        }
+
+        /// <summary>
+        /// Folds an identifier onto RFC 8610's <c>id</c> production, which is ASCII-only:
+        /// <c>id = EALPHA *(*("-" / ".") (EALPHA / DIGIT))</c>, where <c>EALPHA</c> is an ASCII letter,
+        /// <c>@</c>, <c>_</c> or <c>$</c>. A C# type name may contain any Unicode letter or digit, and
+        /// a rule named with one is not a schema a tool merely dislikes: <c>cddl</c> stops on it with a
+        /// parse error and exits 65, and a schema that does not parse cannot fail an instance check, so
+        /// nothing downstream reports it either.
+        /// </summary>
+        /// <remarks>
+        /// Each character outside the production becomes <c>_</c> followed by its code point in
+        /// uppercase hex, which keeps two names differing only outside ASCII apart -- dropping the
+        /// character instead would collapse <c>Café</c> and <c>Cafe</c> onto one rule. A character
+        /// outside the BMP is one code point arriving as a surrogate pair, so the pair is escaped
+        /// together rather than as two lone surrogates.
+        /// </remarks>
+        private static string SanitizeRuleName(string name)
+        {
+            StringBuilder builder = new StringBuilder(name.Length);
+
+            for (int index = 0; index < name.Length; index++)
+            {
+                char character = name[index];
+
+                if (IsIdCharacter(character))
+                {
+                    builder.Append(character);
+                    continue;
+                }
+
+                int codePoint = character;
+
+                if (char.IsHighSurrogate(character)
+                    && index + 1 < name.Length
+                    && char.IsLowSurrogate(name[index + 1]))
+                {
+                    codePoint = char.ConvertToUtf32(character, name[index + 1]);
+                    index++;
+                }
+
+                builder.Append('_').Append(codePoint.ToString("X4", CultureInfo.InvariantCulture));
+            }
+
+            // `id` has to open with EALPHA. Nothing a C# type name can produce arrives here -- an
+            // identifier cannot begin with a digit, and an escape begins with '_' -- so this keeps the
+            // method total rather than covering a case that has a name.
+            if (builder.Length == 0 || !IsIdStartCharacter(builder[0]))
+            {
+                builder.Insert(0, '_');
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary><c>EALPHA</c>: an ASCII letter, or one of <c>@</c>, <c>_</c>, <c>$</c>.</summary>
+        private static bool IsIdStartCharacter(char character)
+        {
+            return (character >= 'A' && character <= 'Z')
+                || (character >= 'a' && character <= 'z')
+                || character == '@'
+                || character == '_'
+                || character == '$';
+        }
+
+        /// <summary>
+        /// <c>EALPHA / DIGIT</c>, plus the <c>-</c> and <c>.</c> the production allows between them.
+        /// Neither separator can arrive from a C# name; <c>-</c> is what the qualified forms above join
+        /// segments with, and it is accepted here so sanitizing one of those is a no-op.
+        /// </summary>
+        private static bool IsIdCharacter(char character)
+        {
+            return IsIdStartCharacter(character)
+                || (character >= '0' && character <= '9')
+                || character == '-'
+                || character == '.';
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Generator/TypeNames.cs
+++ b/src/Dahomey.Cbor.Generator/TypeNames.cs
@@ -65,12 +65,20 @@ namespace Dahomey.Cbor.Generator
         /// <remarks>
         /// The last step is what makes the guarantee unconditional, and it is load-bearing rather than
         /// defensive: escaping folds a character outside ASCII onto a <c>_</c> sequence that a C# name
-        /// is free to contain literally, so <c>Café</c> and <c>Caf_00E9</c> reach it as one name. A
-        /// duplicate rule name is the one malformation an emitted schema can carry without any tool
-        /// complaining -- the gem reads a file whose second definition of a rule silently shadows the
-        /// first -- so it cannot be left to the shape of the names.
+        /// is free to contain literally, so <c>Café</c> and <c>Caf_00E9</c> reach it as one name. What a
+        /// duplicate rule name then costs depends on the two bodies, and the quiet case is the reason to
+        /// settle it here: the gem takes an *identical* redefinition as a warning on stderr and exits 0,
+        /// so a schema whose rules collide can pass every check downstream while describing something
+        /// other than the types it came from. Differing bodies are a <c>RuntimeError</c> and exit 1.
+        /// <para>
+        /// <paramref name="shapes"/> is what a type is emitted under rather than what it asks for: a
+        /// polymorphic type occupies a second name (<see cref="PolymorphicShape.DerivedRuleName"/>) that
+        /// is minted from the first, so the two are reserved together.
+        /// </para>
         /// </remarks>
-        public static IReadOnlyDictionary<string, string> BuildRuleNames(IReadOnlyList<TypeModel> ordered)
+        public static IReadOnlyDictionary<string, string> BuildRuleNames(
+            IReadOnlyList<TypeModel> ordered,
+            IReadOnlyDictionary<string, PolymorphicShape> shapes)
         {
             Dictionary<string, List<TypeModel>> byShortName = new Dictionary<string, List<TypeModel>>();
 
@@ -99,7 +107,7 @@ namespace Dahomey.Cbor.Generator
                 }
             }
 
-            return ResolveRemainingCollisions(candidates);
+            return ResolveRemainingCollisions(candidates, shapes);
         }
 
         /// <summary>
@@ -115,9 +123,18 @@ namespace Dahomey.Cbor.Generator
         /// of one context disagree. A suffixed name is checked against the names already handed out
         /// rather than assumed free, since a candidate elsewhere in the schema may already read
         /// <c>X-2</c>.
+        /// <para>
+        /// The names a type occupies are taken together or not at all, because a polymorphic type is
+        /// emitted under two: rejecting <c>X</c> for a type that would then have had to give up
+        /// <c>X-poly</c> is what keeps the two rules of one type from being split across a suffix. That
+        /// is also why the uncontested pass can suffix: two candidates that differ can still contend,
+        /// one of them reading <c>X-poly</c> where the other is <c>X</c>, so it walks in ordinal order
+        /// like the contested one rather than in dictionary order.
+        /// </para>
         /// </remarks>
         private static IReadOnlyDictionary<string, string> ResolveRemainingCollisions(
-            IReadOnlyDictionary<string, string> candidates)
+            IReadOnlyDictionary<string, string> candidates,
+            IReadOnlyDictionary<string, PolymorphicShape> shapes)
         {
             Dictionary<string, List<string>> keysByCandidate =
                 new Dictionary<string, List<string>>(StringComparer.Ordinal);
@@ -138,13 +155,14 @@ namespace Dahomey.Cbor.Generator
 
             // Uncontested candidates first, and all of them, so a suffix minted below cannot take a
             // name that some other type was always going to hold.
-            foreach (KeyValuePair<string, List<string>> entry in keysByCandidate)
+            IEnumerable<string> uncontested = keysByCandidate
+                .Where(entry => entry.Value.Count == 1)
+                .Select(entry => entry.Key)
+                .OrderBy(candidate => candidate, StringComparer.Ordinal);
+
+            foreach (string candidate in uncontested)
             {
-                if (entry.Value.Count == 1)
-                {
-                    names[entry.Value[0]] = entry.Key;
-                    used.Add(entry.Key);
-                }
+                Take(keysByCandidate[candidate][0], candidate, names, used, shapes);
             }
 
             IEnumerable<string> contested = keysByCandidate
@@ -159,18 +177,47 @@ namespace Dahomey.Cbor.Generator
 
                 foreach (string key in keys)
                 {
-                    string name = candidate;
-
-                    for (int suffix = 2; !used.Add(name); suffix++)
-                    {
-                        name = candidate + "-" + suffix.ToString(CultureInfo.InvariantCulture);
-                    }
-
-                    names[key] = name;
+                    Take(key, candidate, names, used, shapes);
                 }
             }
 
             return names;
+        }
+
+        /// <summary>
+        /// Gives one type the first form of <paramref name="candidate"/> whose every name is free, and
+        /// records all of them as taken.
+        /// </summary>
+        private static void Take(
+            string key,
+            string candidate,
+            Dictionary<string, string> names,
+            HashSet<string> used,
+            IReadOnlyDictionary<string, PolymorphicShape> shapes)
+        {
+            shapes.TryGetValue(key, out PolymorphicShape? shape);
+
+            string name = candidate;
+
+            for (int suffix = 2; ; suffix++)
+            {
+                string? derived = shape?.DerivedRuleName(name);
+
+                if (!used.Contains(name) && (derived is null || !used.Contains(derived)))
+                {
+                    used.Add(name);
+
+                    if (derived is not null)
+                    {
+                        used.Add(derived);
+                    }
+
+                    names[key] = name;
+                    return;
+                }
+
+                name = candidate + "-" + suffix.ToString(CultureInfo.InvariantCulture);
+            }
         }
 
         /// <summary>
@@ -187,6 +234,12 @@ namespace Dahomey.Cbor.Generator
         /// character instead would collapse <c>Café</c> and <c>Cafe</c> onto one rule. A character
         /// outside the BMP is one code point arriving as a surrogate pair, so the pair is escaped
         /// together rather than as two lone surrogates.
+        /// <para>
+        /// The escape is not injective, and does not need to be: a hex run is not self-delimiting, so
+        /// <c>U+1F60</c> followed by a literal <c>0</c> and <c>U+1F600</c> both fold to <c>_1F600</c>.
+        /// That is the same collision <c>Café</c> and <c>Caf_00E9</c> reach by another route, and
+        /// <see cref="ResolveRemainingCollisions"/> is what settles both.
+        /// </para>
         /// </remarks>
         private static string SanitizeRuleName(string name)
         {

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlIdentifierSyntaxTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlIdentifierSyntaxTests.cs
@@ -1,5 +1,7 @@
 using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.Serialization;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests.Cddl
@@ -14,10 +16,15 @@ namespace Dahomey.Cbor.Tests.Cddl
         public int Value { get; set; }
     }
 
-    /// <summary>The same, with one escape, and the pair below asks for one rule name.</summary>
+    /// <summary>
+    /// The same, with one escape, and the pair below asks for one rule name. Its member differs from
+    /// <see cref="Caf_00E9"/>'s deliberately: two rules with identical bodies are indistinguishable in
+    /// the emitted schema, so which of the pair keeps the bare name would be unassertable, and the gem
+    /// would take a duplicate between them as a warning rather than an error.
+    /// </summary>
     public class Café
     {
-        public int Value { get; set; }
+        public string Name { get; set; }
     }
 
     /// <summary>
@@ -41,23 +48,31 @@ namespace Dahomey.Cbor.Tests.Cddl
     /// <summary>
     /// A rule name has to be an RFC 8610 <c>id</c>, and no two rules in one schema may share one.
     /// Neither is a preference: the gem stops on a non-ASCII rule name with a parse error and exit 65,
-    /// and it reads a file whose second definition of a rule shadows the first without saying anything
-    /// at all.
+    /// and what it does with a duplicate depends on the two bodies — an identical redefinition is a
+    /// warning on stderr and exit 0, differing bodies a <c>RuntimeError</c> and exit 1.
     /// </summary>
     /// <remarks>
-    /// The second is the failure worth having a test for, because it is the one that stays quiet. A
-    /// schema whose rules collide describes something other than the types it was generated from, and
-    /// every instance check run against it passes or fails on the surviving rule.
+    /// The identical case is the failure worth having a test for, because it is the one that stays
+    /// quiet: a schema whose rules collide describes something other than the types it was generated
+    /// from, and every instance check run against it passes or fails on the surviving rule.
     /// </remarks>
     public class CddlIdentifierSyntaxTests
     {
+        /// <summary>
+        /// Asserted over the rule names rather than the whole schema: CDDL text literals accept
+        /// <c>NONASCII</c>, so a member named <c>Grüße</c> reaches the output as itself and is no
+        /// evidence either way.
+        /// </summary>
         [Fact]
         public void EveryCharacterOutsideAsciiIsEscapedInARuleName()
         {
             string schema = CddlIdentifierSyntaxContext.CddlSchema.Replace("\r\n", "\n");
 
-            Assert.DoesNotContain("ö", schema);
-            Assert.DoesNotContain("ß", schema);
+            foreach (string ruleName in RuleNames(schema))
+            {
+                Assert.All(ruleName, character => Assert.InRange(character, (char)0x20, (char)0x7E));
+            }
+
             Assert.Contains("Gr_00F6_00DFe = {\n", schema);
         }
 
@@ -67,13 +82,31 @@ namespace Dahomey.Cbor.Tests.Cddl
         /// them in — two builds of one context have to agree, since a schema is compared against other
         /// copies of itself. <c>_</c> sorts below <c>é</c>, so the type spelling the escape out keeps it.
         /// </summary>
+        /// <remarks>
+        /// The bodies say which is which. Asserting only that both names are present would pass with the
+        /// tie-break reversed, which is the one regression the ordinal ordering exists to prevent.
+        /// </remarks>
         [Fact]
         public void TwoTypesAskingForOneRuleNameEachGetTheirOwn()
         {
             string schema = CddlIdentifierSyntaxContext.CddlSchema.Replace("\r\n", "\n");
 
-            Assert.Contains("Caf_00E9 = {\n", schema);
-            Assert.Contains("Caf_00E9-2 = {\n", schema);
+            Assert.Contains("Caf_00E9 = {\n  \"Value\"", schema);
+            Assert.Contains("Caf_00E9-2 = {\n  \"Name\"", schema);
+        }
+
+        /// <summary>The left-hand side of every rule in the schema.</summary>
+        private static IEnumerable<string> RuleNames(string schema)
+        {
+            foreach (string line in schema.Split('\n'))
+            {
+                int assignment = line.IndexOf(" = ", StringComparison.Ordinal);
+
+                if (assignment > 0 && !line.StartsWith(" ", StringComparison.Ordinal))
+                {
+                    yield return line.Substring(0, assignment);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlIdentifierSyntaxTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlIdentifierSyntaxTests.cs
@@ -1,0 +1,93 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Cddl
+{
+    /// <summary>
+    /// A type whose name is a perfectly ordinary C# identifier and not an RFC 8610 one. Any Unicode
+    /// letter is legal in an identifier; <c>id</c> is ASCII-only, so the name reaches the schema as an
+    /// escape — two of them here, one per character outside ASCII.
+    /// </summary>
+    public class Größe
+    {
+        public int Value { get; set; }
+    }
+
+    /// <summary>The same, with one escape, and the pair below asks for one rule name.</summary>
+    public class Café
+    {
+        public int Value { get; set; }
+    }
+
+    /// <summary>
+    /// The name <see cref="Café"/> escapes to, declared literally. Contrived on purpose: it is the one
+    /// shape that makes two distinct types ask for one rule name, because escaping folds a character
+    /// outside ASCII onto a <c>_</c> sequence that an identifier is free to spell out.
+    /// </summary>
+    public class Caf_00E9
+    {
+        public int Value { get; set; }
+    }
+
+    [CborSerializable(typeof(Größe))]
+    [CborSerializable(typeof(Café))]
+    [CborSerializable(typeof(Caf_00E9))]
+    [CborCddlSchema]
+    public partial class CddlIdentifierSyntaxContext : CborSerializerContext
+    {
+    }
+
+    /// <summary>
+    /// A rule name has to be an RFC 8610 <c>id</c>, and no two rules in one schema may share one.
+    /// Neither is a preference: the gem stops on a non-ASCII rule name with a parse error and exit 65,
+    /// and it reads a file whose second definition of a rule shadows the first without saying anything
+    /// at all.
+    /// </summary>
+    /// <remarks>
+    /// The second is the failure worth having a test for, because it is the one that stays quiet. A
+    /// schema whose rules collide describes something other than the types it was generated from, and
+    /// every instance check run against it passes or fails on the surviving rule.
+    /// </remarks>
+    public class CddlIdentifierSyntaxTests
+    {
+        [Fact]
+        public void EveryCharacterOutsideAsciiIsEscapedInARuleName()
+        {
+            string schema = CddlIdentifierSyntaxContext.CddlSchema.Replace("\r\n", "\n");
+
+            Assert.DoesNotContain("ö", schema);
+            Assert.DoesNotContain("ß", schema);
+            Assert.Contains("Gr_00F6_00DFe = {\n", schema);
+        }
+
+        /// <summary>
+        /// Which of the two keeps the bare name is settled by ordinal order of the fully qualified type
+        /// name, so it is a function of the types alone rather than of the order the generator collected
+        /// them in — two builds of one context have to agree, since a schema is compared against other
+        /// copies of itself. <c>_</c> sorts below <c>é</c>, so the type spelling the escape out keeps it.
+        /// </summary>
+        [Fact]
+        public void TwoTypesAskingForOneRuleNameEachGetTheirOwn()
+        {
+            string schema = CddlIdentifierSyntaxContext.CddlSchema.Replace("\r\n", "\n");
+
+            Assert.Contains("Caf_00E9 = {\n", schema);
+            Assert.Contains("Caf_00E9-2 = {\n", schema);
+        }
+
+        /// <summary>
+        /// The escape and the suffix are only worth anything if the result parses.
+        /// <c>CddlSchemaParsesTests</c> covers this context too, by assembly scan; this says so where
+        /// the reason lives, since every name asserted above is constructed rather than copied from a
+        /// type.
+        /// </summary>
+        [CddlFact]
+        public void TheEscapedAndSuffixedSchemaParses()
+        {
+            CddlResult result = CddlTool.Parse(CddlIdentifierSyntaxContext.CddlSchema);
+
+            Assert.True(result.Ok, result.Output);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlPolymorphicRuleNamingTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlPolymorphicRuleNamingTests.cs
@@ -1,0 +1,100 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Xunit;
+
+// A polymorphic type contributes a second rule, named by appending `-poly` to its rule name, and that
+// name is minted after rule names have been handed out. So a type whose own rule name is already the
+// `-poly` form of another type's collides with it, and the collision is invisible to a uniqueness pass
+// that only sees the declaration names.
+//
+// Reaching it needs a type named `poly` sitting where the qualified form of some polymorphic type is
+// its prefix. A namespace and a type of the same name conflict in C#, so the pair cannot be built that
+// way -- but a *nested* type sidesteps the conflict entirely: `Left.X.poly` qualifies through its
+// containing type, giving exactly the base's qualified name plus `-poly`. Five ordinary types in one
+// compilation, no cross-assembly trick.
+//
+// CS8981 is disabled for the two types named `poly`: the collision is against the literal suffix, so
+// the name cannot be spelled any other way, and the warning is about names C# may one day reserve.
+#pragma warning disable CS8981
+
+namespace Dahomey.Cbor.Tests.Cddl.Left
+{
+    /// <summary>
+    /// Contested with <see cref="Right.X"/>, so it takes the qualified form -- which is what makes its
+    /// derived `-poly` name predictable enough to be collided with.
+    /// </summary>
+    public class X
+    {
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Lower case deliberately: the collision is against the literal suffix, so the name has to be
+        /// spelled the way <c>PolymorphicShape</c> spells it.
+        /// </summary>
+        public class poly
+        {
+            public int Value { get; set; }
+        }
+    }
+
+    /// <summary>Gives <see cref="X"/> a subtype, which is what makes it emit a type choice at all.</summary>
+    [CborDiscriminator("sub")]
+    public class XSub : X
+    {
+        public int Extra { get; set; }
+    }
+}
+
+namespace Dahomey.Cbor.Tests.Cddl.Right
+{
+    /// <summary>Contests the short name <c>X</c>, and nothing else.</summary>
+    public class X
+    {
+        public int Id { get; set; }
+    }
+
+    /// <summary>Contests the short name <c>poly</c> with <see cref="Left.X.poly"/>.</summary>
+    public class poly
+    {
+        public int Value { get; set; }
+    }
+}
+
+namespace Dahomey.Cbor.Tests.Cddl
+{
+    [CborSerializable(typeof(Left.X))]
+    [CborSerializable(typeof(Left.X.poly))]
+    [CborSerializable(typeof(Left.XSub))]
+    [CborSerializable(typeof(Right.X))]
+    [CborSerializable(typeof(Right.poly))]
+    [CborCddlSchema]
+    public partial class CddlPolymorphicRuleNamingContext : CborSerializerContext
+    {
+    }
+
+    /// <summary>
+    /// The uniqueness guarantee covers the names a type is *emitted* under, not only the ones it asks
+    /// for. A polymorphic type occupies two: its declaration name and the <c>-poly</c> form its type
+    /// choice is emitted as, so both have to be reserved together or the second one is free for a
+    /// declaration name to take.
+    /// </summary>
+    public class CddlPolymorphicRuleNamingTests
+    {
+        [Fact]
+        public void ATypeNamedForThePolySuffixDoesNotTakeAPolymorphicTypesSecondRule()
+        {
+            string schema = CddlPolymorphicRuleNamingContext.CddlSchema.Replace("\r\n", "\n");
+
+            Assert.Contains("Dahomey-Cbor-Tests-Cddl-Left-X-poly = ", schema);
+            Assert.Contains("Dahomey-Cbor-Tests-Cddl-Left-X-poly-2 = {\n", schema);
+        }
+
+        [CddlFact]
+        public void TheSchemaCarryingBothParses()
+        {
+            CddlResult result = CddlTool.Parse(CddlPolymorphicRuleNamingContext.CddlSchema);
+
+            Assert.True(result.Ok, result.Output);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlRuleNamingTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlRuleNamingTests.cs
@@ -33,13 +33,10 @@ namespace N
 namespace Dahomey.Cbor.Tests.Cddl
 {
     // N.Other.Inner is reached transitively through this member rather than declared as its own
-    // [CborSerializable] root. Emitter.cs's accessor generation (a separate, unrelated code path
-    // that also calls TypeNames.AccessorName, with no disambiguation of its own) only emits one
-    // accessor per *root*, keyed on the same colliding short name -- declaring both N.Outer.Inner
-    // and N.Other.Inner as roots reproduces that pre-existing accessor-name collision too and the
-    // generated context fails to compile (CS0102) before the schema is ever reached. Routing one of
-    // the pair in as a plain member sidesteps that unrelated bug while still putting both types in
-    // the same context's TypeModel list, which is all TypeNames.BuildRuleNames needs to collide on.
+    // [CborSerializable] root, which keeps the fixture to the one collision it is about: routing one
+    // of the pair in as a plain member still puts both types in the same context's TypeModel list,
+    // which is all TypeNames.BuildRuleNames needs to collide on, without also exercising the separate
+    // accessor-name collision that Emitter.UniqueAccessorName resolves for two same-short-named roots.
     public class CddlRuleNamingOtherHolder
     {
         public N.Other.Inner Value { get; set; }
@@ -59,8 +56,9 @@ namespace Dahomey.Cbor.Tests.Cddl
     /// same-named nested types in different namespaces collide in that short name --
     /// <c>N.Outer.Inner</c> and <c>N.Other.Inner</c> are both just <c>Inner</c> -- so
     /// <c>BuildRuleNames</c> must fall back to a namespace- and containing-type-qualified name for
-    /// every member of the collision. Without that fallback the gem would silently accept two rules
-    /// with the same name in one schema file, one of them shadowing the other.
+    /// every member of the collision. Without that fallback the schema carries two rules under one
+    /// name, which the gem accepts silently when their bodies are identical, the second shadowing the
+    /// first.
     /// </summary>
     public class CddlRuleNamingTests
     {

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -89,6 +89,21 @@ namespace Dahomey.Cbor.Tests
                 };
             }
 
+            if (type == typeof(Cddl.Größe))
+            {
+                return new Cddl.Größe { Value = 3 };
+            }
+
+            if (type == typeof(Cddl.Café))
+            {
+                return new Cddl.Café { Value = 4 };
+            }
+
+            if (type == typeof(Cddl.Caf_00E9))
+            {
+                return new Cddl.Caf_00E9 { Value = 5 };
+            }
+
             if (type == typeof(GeneratedPerson))
             {
                 return new GeneratedPerson

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -96,7 +96,7 @@ namespace Dahomey.Cbor.Tests
 
             if (type == typeof(Cddl.Café))
             {
-                return new Cddl.Café { Value = 4 };
+                return new Cddl.Café { Name = "four" };
             }
 
             if (type == typeof(Cddl.Caf_00E9))
@@ -408,6 +408,31 @@ namespace Dahomey.Cbor.Tests
             if (type == typeof(Cddl.CddlRuleNamingOtherHolder))
             {
                 return new Cddl.CddlRuleNamingOtherHolder { Value = new N.Other.Inner { Value = 2 } };
+            }
+
+            if (type == typeof(Cddl.Left.X))
+            {
+                return new Cddl.Left.X { Id = 6 };
+            }
+
+            if (type == typeof(Cddl.Left.X.poly))
+            {
+                return new Cddl.Left.X.poly { Value = 7 };
+            }
+
+            if (type == typeof(Cddl.Left.XSub))
+            {
+                return new Cddl.Left.XSub { Id = 8, Extra = 9 };
+            }
+
+            if (type == typeof(Cddl.Right.X))
+            {
+                return new Cddl.Right.X { Id = 10 };
+            }
+
+            if (type == typeof(Cddl.Right.poly))
+            {
+                return new Cddl.Right.poly { Value = 11 };
             }
 
             if (type == typeof(Cddl.CddlScalars))


### PR DESCRIPTION
The two points your #159 review left open, both of which you said needed a design call. **1723 library tests plus 35 generator tests**, +9 here, green on net10.0; three TFMs build.

## Point 6 — a non-ASCII type name

Verified rather than inferred: it is a hard failure, not a schema a tool merely dislikes.

```
Größe = { "v" : int }
```

```
*** Look for syntax problems around the %%% markers:
start = Gr%%%öße
*** Parse error at 10 upto 10 of 36 (1382).
exit=65
```

And a schema that does not parse cannot fail an instance check, so nothing downstream reports it either — the failure is silent everywhere except at the gem's own exit code.

Rule names are now folded onto `id = EALPHA *(*("-" / ".") (EALPHA / DIGIT))`: each character outside it becomes `_` followed by its code point in uppercase hex, a surrogate pair escaped as the one code point it is. `Größe` → `Gr_00F6_00DFe`.

Escaping rather than dropping, because dropping collapses `Café` and `Cafe` onto one rule — which is the whole subject of the other half.

## Point 5 — the collision-breaking name colliding

**The collision you describe is not constructible within one compilation**, and that is worth stating before the fix. It needs a namespace chain and a containing-type chain that flatten to the same string, and C# refuses the pair outright:

```csharp
namespace A.B { public class C { } }
namespace A { public class B { public class C { } } }
```

```
error CS0101: The namespace 'A' already contains a definition for 'B'
```

Two assemblies can each supply one half, so it is reachable across an assembly boundary — but there both types render as `global::A.B.C` under `FullyQualifiedFormat`, which is the key `CddlEmitter.byKey`, `ruleNames` and `TypeCollector` all identify a type by, so the rule name is not the first thing that breaks. I have not built that case; I am noting it rather than claiming it, and it is not what this PR fixes.

So the fix is not a better rendering — no rendering scheme can be shown to be injective over an input C# cannot produce. It is a guarantee: after escaping, names that still collide are separated by ordinal order of the full type key, the first keeping the bare name and the rest taking `-2`, `-3`. Ordinal order of the key rather than arrival order, because a schema is compared against other copies of itself, so the mapping has to be a function of the set of types alone. That is the property a rule name needs and `Emitter.UniqueAccessorName` deliberately does not.

## What makes the second half load-bearing rather than defensive

Escaping folds a character outside ASCII onto a `_` sequence an identifier is free to spell out, so `Café` and `Caf_00E9` arrive asking for one rule name — and that pair *is* constructible, which is why it is the fixture.

And a duplicate rule name is the one malformation an emitted schema can carry with nothing complaining. Measured, not assumed: with the uniqueness pass disabled and escaping left in, a schema carrying two `Caf_00E9` rules still passes `EveryEmittedSchemaParses` — the gem reads the second definition as a silent shadow of the first. A schema whose rules collide describes something other than the types it was generated from, and every instance check run against it then passes or fails on the surviving rule.

## Tests, and that they bind

`CddlIdentifierSyntaxTests` declares `Größe`, `Café` and `Caf_00E9`. All three are enrolled in `GeneratedCorpusTests` (six cases) as well, so their generated converters stay pinned to the reflection path's bytes, and `CddlSchemaParsesTests` picks the context up by assembly scan.

Each half was checked by disabling it and re-running, which is also where the two measurements above come from:

| disabled | result |
|---|---|
| escaping | `TheEscapedAndSuffixedSchemaParses` and `EveryEmittedSchemaParses` both fail — `*** Parse error at 0 upto 679 of 826` |
| the uniqueness pass | `TwoTypesAskingForOneRuleNameEachGetTheirOwn` fails on the missing `-2`, and every gem check stays green |

## One thing I left out deliberately

`PolymorphicShape` mints `{ruleName}-poly` from a rule name, and `TypeNames` does not reserve that derived form — so a type whose own rule name is another type's plus `-poly` would collide with it. Reaching it needs a namespace `X` holding a type named `poly`, alongside a polymorphic type whose rule name is `X`, with the first in a collision bucket so it takes the qualified form at all. I have not built it and am not claiming it is reachable. Reserving the derived names would mean `TypeNames` knowing the suffix `CddlPolymorphism` appends, which is a coupling I would rather you agree to than assume — say the word and it is a two-line change.

---
_Generated by [Claude Code](https://claude.ai/code)_
