### PR TITLE
End an indefinite-length tuple where its arity says, closes #199

### DIFF
--- a/src/Dahomey.Cbor.Tests/TupleTests.cs
+++ b/src/Dahomey.Cbor.Tests/TupleTests.cs
@@ -1,5 +1,6 @@
 using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.Tests.Extensions;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests
@@ -153,6 +154,63 @@ namespace Dahomey.Cbor.Tests
 
             Assert.Contains("Expected major type Array", exception.Message);
             Assert.Equal("$.a", exception.Path);
+        }
+
+        /// <summary>
+        /// An indefinite-length tuple ends where its arity says it does, at every arity and in both
+        /// length forms. The definite-length half already held, from <c>size != N</c>; the
+        /// indefinite-length half had no check after the last item at all, so the extra items were
+        /// silently dropped.
+        /// </summary>
+        [Fact]
+        public void ATupleWithTooManyItemsIsRefusedAtEveryArity()
+        {
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int)>("9F010203FF".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int)>("9F01020304FF".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int)>("9F0102030405FF".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int)>("9F010203040506FF".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int, int)>("9F01020304050607FF".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int, int, int)>("9F0102030405060708FF".HexToBytes()));
+
+            // The definite-length form of the same document, which the arity check already refused.
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int)>("83010203".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int)>("8401020304".HexToBytes()));
+        }
+
+        /// <summary>
+        /// The other side of that check: a well-formed indefinite-length tuple still reads, at every
+        /// arity. Refusing one would be the easy way to make the test above pass.
+        /// </summary>
+        [Fact]
+        public void AnIndefiniteLengthTupleIsStillReadAtEveryArity()
+        {
+            Assert.Equal((1, 2), Helper.Read<(int, int)>("9F0102FF"));
+            Assert.Equal((1, 2, 3), Helper.Read<(int, int, int)>("9F010203FF"));
+            Assert.Equal((1, 2, 3, 4), Helper.Read<(int, int, int, int)>("9F01020304FF"));
+            Assert.Equal((1, 2, 3, 4, 5), Helper.Read<(int, int, int, int, int)>("9F0102030405FF"));
+            Assert.Equal((1, 2, 3, 4, 5, 6), Helper.Read<(int, int, int, int, int, int)>("9F010203040506FF"));
+            Assert.Equal((1, 2, 3, 4, 5, 6, 7), Helper.Read<(int, int, int, int, int, int, int)>("9F01020304050607FF"));
+        }
+
+        /// <summary>
+        /// Where the unconsumed break did its damage: the closing <c>FF</c> was left in the buffer, so
+        /// whatever followed the tuple read it instead. An indefinite-length tuple was therefore only
+        /// usable as a whole document — as a map member the break was read as the next key, and as an
+        /// array element as the next element's head.
+        /// </summary>
+        [Fact]
+        public void AnIndefiniteLengthTupleLeavesNothingBehind()
+        {
+            // {"a": [_ 1, 2], "b": 7}
+            TupleMember member = Cbor.Deserialize<TupleMember>("A261619F0102FF616207".HexToBytes());
+
+            Assert.Equal((1, 2), member.A);
+            Assert.Equal(7, member.B);
+
+            // [[_ 1, 2], [_ 3, 4]]
+            List<(int, int)> list = Cbor.Deserialize<List<(int, int)>>("829F0102FF9F0304FF".HexToBytes());
+
+            Assert.Equal(new[] { (1, 2), (3, 4) }, list);
         }
 
         [Fact]

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -1115,7 +1115,7 @@ namespace Dahomey.Cbor.Serialization
         /// been consumed". <c>Data</c> matches what <see cref="SkipDataItem"/> does for a break.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void ConsumeBreak()
+        internal void ConsumeBreak()
         {
             GetHeader();
             _state = CborReaderState.Data;

--- a/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
@@ -69,6 +69,16 @@
             }
             T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
 
+            if (size == -1)
+            {
+                if (!reader.IsBreak())
+                {
+                    throw new CborException("Expected CBOR Array of size 2");
+                }
+
+                reader.ConsumeBreak();
+            }
+
             return (item1, item2);
         }
 
@@ -136,6 +146,16 @@
                 throw new CborException("Expected CBOR Array of size 3");
             }
             T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
+
+            if (size == -1)
+            {
+                if (!reader.IsBreak())
+                {
+                    throw new CborException("Expected CBOR Array of size 3");
+                }
+
+                reader.ConsumeBreak();
+            }
 
             return (item1, item2, item3);
         }
@@ -213,6 +233,16 @@
                 throw new CborException("Expected CBOR Array of size 4");
             }
             T4 item4 = TupleItemReader.Read(ref reader, _item4Converter, 3);
+
+            if (size == -1)
+            {
+                if (!reader.IsBreak())
+                {
+                    throw new CborException("Expected CBOR Array of size 4");
+                }
+
+                reader.ConsumeBreak();
+            }
 
             return (item1, item2, item3, item4);
         }
@@ -299,6 +329,16 @@
                 throw new CborException("Expected CBOR Array of size 5");
             }
             T5 item5 = TupleItemReader.Read(ref reader, _item5Converter, 4);
+
+            if (size == -1)
+            {
+                if (!reader.IsBreak())
+                {
+                    throw new CborException("Expected CBOR Array of size 5");
+                }
+
+                reader.ConsumeBreak();
+            }
 
             return (item1, item2, item3, item4, item5);
         }
@@ -394,6 +434,16 @@
                 throw new CborException("Expected CBOR Array of size 6");
             }
             T6 item6 = TupleItemReader.Read(ref reader, _item6Converter, 5);
+
+            if (size == -1)
+            {
+                if (!reader.IsBreak())
+                {
+                    throw new CborException("Expected CBOR Array of size 6");
+                }
+
+                reader.ConsumeBreak();
+            }
 
             return (item1, item2, item3, item4, item5, item6);
         }
@@ -498,6 +548,16 @@
                 throw new CborException("Expected CBOR Array of size 7");
             }
             T7 item7 = TupleItemReader.Read(ref reader, _item7Converter, 6);
+
+            if (size == -1)
+            {
+                if (!reader.IsBreak())
+                {
+                    throw new CborException("Expected CBOR Array of size 7");
+                }
+
+                reader.ConsumeBreak();
+            }
 
             return (item1, item2, item3, item4, item5, item6, item7);
         }
@@ -611,6 +671,16 @@
                 throw new CborException("Expected CBOR Array of size 8");
             }
             T8 item8 = TupleItemReader.Read(ref reader, _item8Converter, 7);
+
+            if (size == -1)
+            {
+                if (!reader.IsBreak())
+                {
+                    throw new CborException("Expected CBOR Array of size 8");
+                }
+
+                reader.ConsumeBreak();
+            }
 
             return (item1, item2, item3, item4, item5, item6, item7, item8);
         }


### PR DESCRIPTION
Closes #199, as you specified it. **1717 tests**, +3 here, green on net10.0; all four TFMs build.

The trailing check is now the mirror of the leading ones at each of the seven arities, so an indefinite-length tuple ends where its arity says it does and the break is consumed.

## Two notes on the implementation

**`reader.ReadEndArray()` does not exist.** The suggested fix names it, and `CborReader` has no such method — `ConsumeBreak` is what `ReadChunksArray` and the skip paths use, and it was `private`. It is now `internal`, which is what `IsBreak` already is and what this converter already depends on. If you would rather have a public `ReadEndArray()` for the symmetry with `CborWriter.WriteEndArray(size)` — it is the method a hand-written array-shaped converter needs, and its absence is arguably why this defect was writable in the first place — say so and I will add it here instead.

**`Tuple8Converter` gets the check too, and nothing can reach it.** #198 keeps every arity past seven from building a converter at all. Same call as #189, which put the major-type check there for the same reason: the code is right for when the arity becomes reachable, rather than needing to be revisited then. It does mean that one of the seven is unasserted, which is what #198's own note about #189's coverage records.

## Tests

The three cases you named:

* **Too many items refused at every arity**, both length forms — the definite-length half already held from `size != N`, and is asserted alongside so the two stay together.
* **A well-formed indefinite-length tuple still reads at every arity.** This is the guard against the easy way to make the first test pass.
* **Nothing left behind**, in the two places the stray break did its damage: `{"a": [_ 1, 2], "b": 7}` now reads as `(1, 2)` and `7`, and `[[_ 1, 2], [_ 3, 4]]` as two tuples. Both were `CborException`s before, at `$` and `$[1]`.

Checked by reverting the converter and re-running: the first and third fail, the second passes either way, as its remark says it should.

## Scope

**This does not close #198.** It is the other half of what you found reviewing #189, and the arity defect needs a decision this PR does not take — the wire format for arity 8 and up. `Tuple8Converter` would have to write its `Rest` field's items *inline* rather than as a nested array, since a nine-element tuple should be `[1, …, 9]` and not `[1, …, 7, [8, 9]]`, and that means every arity growing an "write my items into the array you already opened" entry point plus support for the one-element `Rest` the provider currently refuses outright. Nothing works there today, so there is no wire compatibility to preserve and the flat form is free to be chosen — but it is a redesign of that file rather than a fix, and refusing arity above seven with a plain `CborException` is a defensible alternative that costs five lines. I would rather you picked. Happy to build either.

---
_Generated by [Claude Code](https://claude.ai/code)_
