### PR TITLE
Name stringref when refusing it, closes #142

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,26 @@ and maps, not to strings, so what this library emits is unchanged.
 A chunk whose major type differs from the enclosing string, and a nested indefinite-length string, are
 both malformed and raise a `CborException`.
 
+### String references (tag 25)
+
+String references — tag 25 over an index into a table of the strings already seen, the table scoped by a
+tag 256 around the document — come from the [cbor.schmorp.de](http://cbor.schmorp.de/stringref)
+specification rather than from RFC 8949, and are **not supported**. Python `cbor2` emits them on
+`dumps(..., string_referencing=True)`, which is not its default; `System.Formats.Cbor` does not read them
+either.
+
+Both tags raise a `CborException` naming them, instead of being skipped the way an unrecognised tag is. A
+skipped tag 256 leaves the first reference to surface as a type error at whichever member happened to
+repeat a key, which describes neither the cause nor the place. Reading them is not a matter of decoding
+one more tag: the table is built from every string in document order, including the ones a decode never
+materialises, so stepping over an unmapped member would have to decode it anyway or every later index
+would refer to the wrong string.
+
+If the aim is compactness rather than interoperability with a producer you do not control,
+`CborObjectFormat.IntKeyMap` writes each key as a small integer and `CborObjectFormat.Array` drops the
+keys altogether. Both compress a document of repeated keys harder than string references do, in plain
+RFC 8949.
+
 ### Bignums (RFC 8949 §3.4.3)
 
 A member typed `System.Numerics.BigInteger` reads and writes integers of any width. Values that fit in 64

--- a/README.md
+++ b/README.md
@@ -257,9 +257,15 @@ it did not surface at all: the tag was skipped like any other and the member too
 value. Tag 256 is skipped, since a namespace with no reference under it is ordinary CBOR, and so is a
 reference inside a member the type does not map, since nothing needs resolving to discard it.
 
-The refusal is in the reader, so it covers deserialization into your own types. The object model is
-unchanged: `CborValue` carries a tag it does not model as data — as it does for typed arrays — so a
-document read into one keeps tag 25 in `CborValue.SemanticTag` over the index, rather than throwing.
+The refusal is in the reader, so it covers deserialization into your own types, including the members
+whose readers walk the tag stack themselves — `decimal`, `BigInteger`, `CborDecimalFraction`,
+`CborBigFloat`.
+
+The object model is unchanged, and reads a reference where it can. `CborValue` carries a tag it does not
+model as data — as it does for typed arrays — so a document read into one keeps tag 25 in
+`CborValue.SemanticTag` over the index rather than throwing. `CborValue.SemanticTag` holds one tag, so
+that applies to an outermost reference only: a tag 25 nested under another tag is read as the value
+underneath, which refuses it.
 
 If the aim is compactness rather than interoperability with a producer you do not control,
 `CborObjectFormat.IntKeyMap` writes each key as a small integer and `CborObjectFormat.Array` drops the

--- a/README.md
+++ b/README.md
@@ -246,12 +246,20 @@ specification rather than from RFC 8949, and are **not supported**. Python `cbor
 `dumps(..., string_referencing=True)`, which is not its default; `System.Formats.Cbor` does not read them
 either.
 
-Both tags raise a `CborException` naming them, instead of being skipped the way an unrecognised tag is. A
-skipped tag 256 leaves the first reference to surface as a type error at whichever member happened to
-repeat a key, which describes neither the cause nor the place. Reading them is not a matter of decoding
-one more tag: the table is built from every string in document order, including the ones a decode never
-materialises, so stepping over an unmapped member would have to decode it anyway or every later index
-would refer to the wrong string.
+Supporting them is not a matter of decoding one more tag: the table is built from every string in
+document order, including the ones a decode never materialises, so stepping over an unmapped member would
+have to decode it anyway or every later index would refer to the wrong string.
+
+What a reference no longer does is pass silently. Tag 25 raises a `CborException` naming stringref
+wherever the item it stands for is about to be used — as a string it used to surface as `Expected major
+type TextString`, which names neither the tag nor the document that carries it, and over a numeric member
+it did not surface at all: the tag was skipped like any other and the member took the table index as its
+value. Tag 256 is skipped, since a namespace with no reference under it is ordinary CBOR, and so is a
+reference inside a member the type does not map, since nothing needs resolving to discard it.
+
+The refusal is in the reader, so it covers deserialization into your own types. The object model is
+unchanged: `CborValue` carries a tag it does not model as data — as it does for typed arrays — so a
+document read into one keeps tag 25 in `CborValue.SemanticTag` over the index, rather than throwing.
 
 If the aim is compactness rather than interoperability with a producer you do not control,
 `CborObjectFormat.IntKeyMap` writes each key as a small integer and `CborObjectFormat.Array` drops the

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0142.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0142.cs
@@ -1,4 +1,5 @@
 using Dahomey.Cbor.Attributes;
+using System.Numerics;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests.Issues
@@ -22,6 +23,18 @@ namespace Dahomey.Cbor.Tests.Issues
         {
             [CborProperty("temperature")]
             public int Temperature { get; set; }
+        }
+
+        public class DecimalHolder
+        {
+            [CborProperty("value")]
+            public decimal Value { get; set; }
+        }
+
+        public class BigIntegerHolder
+        {
+            [CborProperty("value")]
+            public BigInteger Value { get; set; }
         }
 
         /// <summary>
@@ -67,6 +80,41 @@ namespace Dahomey.Cbor.Tests.Issues
             // a1 6b "temperature" d8 19 00 -- {"temperature": stringref(0)}
             CborException ex = Assert.Throws<CborException>(
                 () => Helper.Read<Measurement>("A16B74656D7065726174757265D81900"));
+
+            Assert.Contains("semantic tag 25", ex.Message);
+        }
+
+        /// <summary>a1 65 "value" d8 19 00 — <c>{"value": stringref(0)}</c>.</summary>
+        private const string ReferenceOverAValue = "A16576616C7565D81900";
+
+        /// <summary>
+        /// The readers that walk the tag stack themselves — <c>decimal</c>, <c>BigInteger</c> and the
+        /// §3.4.4 pair — take their tags through <c>TryReadSemanticTag</c>, which does not refuse, so
+        /// each has to refuse the reference itself. Silent otherwise, like the numeric case above:
+        /// these are the members that were left taking the table index for their value.
+        /// </summary>
+        [Fact]
+        public void AStringReferenceOverADecimalIsRefusedByName()
+        {
+            CborException ex = Assert.Throws<CborException>(() => Helper.Read<DecimalHolder>(ReferenceOverAValue));
+
+            Assert.Contains("semantic tag 25", ex.Message);
+        }
+
+        [Fact]
+        public void AStringReferenceOverABigIntegerIsRefusedByName()
+        {
+            CborException ex = Assert.Throws<CborException>(() => Helper.Read<BigIntegerHolder>(ReferenceOverAValue));
+
+            Assert.Contains("semantic tag 25", ex.Message);
+        }
+
+        /// <summary>The same, for the type that reads a §3.4.4 tag stack of its own.</summary>
+        [Fact]
+        public void AStringReferenceInPlaceOfADecimalFractionIsRefusedByName()
+        {
+            // d8 19 00 -- stringref(0) where tag 4 belongs
+            CborException ex = Assert.Throws<CborException>(() => Helper.Read<CborDecimalFraction>("D81900"));
 
             Assert.Contains("semantic tag 25", ex.Message);
         }

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0142.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0142.cs
@@ -5,18 +5,16 @@ namespace Dahomey.Cbor.Tests.Issues
 {
     /// <summary>
     /// Issue #142: a document encoded with string references — <c>cbor2.dumps(..., string_referencing=True)</c>,
-    /// http://cbor.schmorp.de/stringref — failed with a message about the wrong thing.
+    /// http://cbor.schmorp.de/stringref — failed with a message about the wrong thing, or read a
+    /// table index as if it were the value.
     /// </summary>
     /// <remarks>
-    /// Stringref is not supported and these tests do not ask for it to be. What they pin is the
-    /// diagnosis: the tags are refused by name, at the tag, instead of being skipped and surfacing
-    /// later as "Expected major type TextString" at whichever member first repeated a key — an error
-    /// that names neither stringref nor the tag that caused it, and points at a part of the document
-    /// that is perfectly well formed.
-    /// <para>
-    /// Refusing is not a narrowing: every one of these documents already threw, since dropping tag 256
-    /// and then meeting tag 25 over an index is a type error whatever the reader does with it.
-    /// </para>
+    /// Stringref is not supported and these tests do not ask for it to be. What they pin is that a
+    /// reference is named where it matters and stepped over where it does not: tag 25 is refused, by
+    /// name, when the item it stands for is about to be used, while tag 256 and any reference inside a
+    /// member nobody reads are skipped like any unrecognised tag. A namespace on its own is ordinary
+    /// CBOR, and a discarded member is discarded whether or not its strings could have been resolved,
+    /// so refusing either would reject documents that used to read correctly.
     /// </remarks>
     public class Issue0142
     {
@@ -39,19 +37,15 @@ namespace Dahomey.Cbor.Tests.Issues
         private const string StringRefDocument = "D9010082A16B74656D706572617475726501A1D8190002";
 
         [Fact]
-        public void TheNamespaceTagIsRefusedByName()
+        public void AStringReferenceIsRefusedByName()
         {
             CborException ex = Assert.Throws<CborException>(() => Helper.Read<Measurement[]>(StringRefDocument));
 
-            Assert.Contains("semantic tag 256", ex.Message);
+            Assert.Contains("semantic tag 25", ex.Message);
             Assert.Contains("cbor.schmorp.de/stringref", ex.Message);
         }
 
-        /// <summary>
-        /// The reference itself, reached without its namespace: a map key is read by a path that does
-        /// not skip tags, so this one arrives as a major type mismatch rather than at the tag. It is
-        /// named too, which is the case that produced the misleading message in the report.
-        /// </summary>
+        /// <summary>The reference on its own, reached without the namespace around it.</summary>
         [Fact]
         public void AStringReferenceUsedAsAKeyIsRefusedByName()
         {
@@ -63,8 +57,51 @@ namespace Dahomey.Cbor.Tests.Issues
         }
 
         /// <summary>
-        /// Only these two tags are refused. Unrecognised tags are still skipped, which is what lets a
-        /// document carrying the self-described CBOR tag read as the value underneath it.
+        /// A reference standing where a number belongs is refused too. This is the case that used to
+        /// pass silently: the tag was skipped like any other, so the member took the table index as
+        /// its value — <c>Temperature = 0</c>, from a document that states no temperature at all.
+        /// </summary>
+        [Fact]
+        public void AStringReferenceUsedAsAValueIsRefusedByName()
+        {
+            // a1 6b "temperature" d8 19 00 -- {"temperature": stringref(0)}
+            CborException ex = Assert.Throws<CborException>(
+                () => Helper.Read<Measurement>("A16B74656D7065726174757265D81900"));
+
+            Assert.Contains("semantic tag 25", ex.Message);
+        }
+
+        /// <summary>
+        /// The namespace tag alone is not refused: <c>string_referencing=True</c> writes it around
+        /// every document, including one that repeats nothing, and such a document is ordinary CBOR.
+        /// </summary>
+        [Fact]
+        public void ANamespaceWithoutAReferenceStillReads()
+        {
+            // d9 0100 a1 6b "temperature" 01
+            Measurement value = Helper.Read<Measurement>("D90100A16B74656D706572617475726501");
+
+            Assert.NotNull(value);
+            Assert.Equal(1, value.Temperature);
+        }
+
+        /// <summary>
+        /// A reference inside a member the type does not map is skipped, not refused. Nothing needs
+        /// resolving to discard it, and it read correctly before this was diagnosed at all.
+        /// </summary>
+        [Fact]
+        public void AStringReferenceInsideAnUnmappedMemberIsStillSkipped()
+        {
+            // a2 6b "temperature" 01 61 78 d8 19 00 -- {"temperature": 1, "x": stringref(0)}
+            Measurement value = Helper.Read<Measurement>("A26B74656D7065726174757265016178D81900");
+
+            Assert.NotNull(value);
+            Assert.Equal(1, value.Temperature);
+        }
+
+        /// <summary>
+        /// Only tag 25 is refused. Unrecognised tags are still skipped, which is what lets a document
+        /// carrying the self-described CBOR tag read as the value underneath it.
         /// </summary>
         [Fact]
         public void AnUnrelatedTagIsStillSkipped()

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0142.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0142.cs
@@ -1,0 +1,79 @@
+using Dahomey.Cbor.Attributes;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #142: a document encoded with string references — <c>cbor2.dumps(..., string_referencing=True)</c>,
+    /// http://cbor.schmorp.de/stringref — failed with a message about the wrong thing.
+    /// </summary>
+    /// <remarks>
+    /// Stringref is not supported and these tests do not ask for it to be. What they pin is the
+    /// diagnosis: the tags are refused by name, at the tag, instead of being skipped and surfacing
+    /// later as "Expected major type TextString" at whichever member first repeated a key — an error
+    /// that names neither stringref nor the tag that caused it, and points at a part of the document
+    /// that is perfectly well formed.
+    /// <para>
+    /// Refusing is not a narrowing: every one of these documents already threw, since dropping tag 256
+    /// and then meeting tag 25 over an index is a type error whatever the reader does with it.
+    /// </para>
+    /// </remarks>
+    public class Issue0142
+    {
+        public class Measurement
+        {
+            [CborProperty("temperature")]
+            public int Temperature { get; set; }
+        }
+
+        /// <summary>
+        /// The shape a stringref encoder actually produces: tag 256 around the document, the key
+        /// spelled out the first time, and tag 25 over its table index every time after.
+        /// </summary>
+        /// <remarks>
+        /// d9 0100                          tag 256, the namespace
+        ///   82                             array(2)
+        ///     a1 6b "temperature" 01       the key, which enters the table as index 0
+        ///     a1 d8 19 00        02        tag 25 over index 0 — the same key, by reference
+        /// </remarks>
+        private const string StringRefDocument = "D9010082A16B74656D706572617475726501A1D8190002";
+
+        [Fact]
+        public void TheNamespaceTagIsRefusedByName()
+        {
+            CborException ex = Assert.Throws<CborException>(() => Helper.Read<Measurement[]>(StringRefDocument));
+
+            Assert.Contains("semantic tag 256", ex.Message);
+            Assert.Contains("cbor.schmorp.de/stringref", ex.Message);
+        }
+
+        /// <summary>
+        /// The reference itself, reached without its namespace: a map key is read by a path that does
+        /// not skip tags, so this one arrives as a major type mismatch rather than at the tag. It is
+        /// named too, which is the case that produced the misleading message in the report.
+        /// </summary>
+        [Fact]
+        public void AStringReferenceUsedAsAKeyIsRefusedByName()
+        {
+            // a1 d8 19 00 02 -- {stringref(0): 2}
+            CborException ex = Assert.Throws<CborException>(() => Helper.Read<Measurement>("A1D8190002"));
+
+            Assert.Contains("semantic tag 25", ex.Message);
+            Assert.Contains("cbor.schmorp.de/stringref", ex.Message);
+        }
+
+        /// <summary>
+        /// Only these two tags are refused. Unrecognised tags are still skipped, which is what lets a
+        /// document carrying the self-described CBOR tag read as the value underneath it.
+        /// </summary>
+        [Fact]
+        public void AnUnrelatedTagIsStillSkipped()
+        {
+            // d9 d9f7 a1 6b "temperature" 01 -- tag 55799 (self-described CBOR) over the map
+            Measurement value = Helper.Read<Measurement>("D9D9F7A16B74656D706572617475726501");
+
+            Assert.NotNull(value);
+            Assert.Equal(1, value.Temperature);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0142.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0142.cs
@@ -1,4 +1,5 @@
 using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.ObjectModel;
 using System.Numerics;
 using Xunit;
 
@@ -145,6 +146,38 @@ namespace Dahomey.Cbor.Tests.Issues
 
             Assert.NotNull(value);
             Assert.Equal(1, value.Temperature);
+        }
+
+        /// <summary>
+        /// The object model reads a reference where it can, and this pins where that stops.
+        /// <c>CborValueConverter</c> takes a tag through <c>TryReadSemanticTag</c>, which does not
+        /// refuse, so an outermost tag 25 lands in <see cref="CborValue.SemanticTag"/> over the index
+        /// — the treatment every tag it does not model gets, typed arrays included.
+        /// </summary>
+        [Fact]
+        public void AnOutermostReferenceReadsIntoTheObjectModelAsATaggedIndex()
+        {
+            // d8 19 00 -- stringref(0)
+            CborValue value = Helper.Read<CborValue>("D81900");
+
+            Assert.Equal(CborValueType.Positive, value.Type);
+            Assert.Equal(25ul, value.SemanticTag);
+            Assert.Equal(0, value.Value<int>());
+        }
+
+        /// <summary>
+        /// One tag, though: <see cref="CborValue.SemanticTag"/> holds a single <c>ulong?</c>, so a
+        /// reference nested under another tag is read as the value underneath that tag, and that read
+        /// refuses it. The object model is spared the refusal only where it has somewhere to put the
+        /// tag.
+        /// </summary>
+        [Fact]
+        public void AReferenceNestedUnderAnotherTagIsRefusedInTheObjectModel()
+        {
+            // d8 20 d8 19 00 -- tag 32 (URI) over stringref(0), a repeated URI as cbor2 writes it
+            CborException ex = Assert.Throws<CborException>(() => Helper.Read<CborValue>("D820D81900"));
+
+            Assert.Contains("semantic tag 25", ex.Message);
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -671,6 +671,7 @@ namespace Dahomey.Cbor.Serialization
             while (IsSemanticTag())
             {
                 TryReadSemanticTag(out ulong tag);
+                RejectStringRef(tag);
 
                 if (tag == DECIMAL_FRACTION_TAG)
                 {
@@ -967,6 +968,7 @@ namespace Dahomey.Cbor.Serialization
             while (IsSemanticTag())
             {
                 TryReadSemanticTag(out ulong tag);
+                RejectStringRef(tag);
 
                 if (tag == UNSIGNED_BIGNUM_TAG || tag == NEGATIVE_BIGNUM_TAG)
                 {
@@ -1053,6 +1055,7 @@ namespace Dahomey.Cbor.Serialization
             while (IsSemanticTag())
             {
                 TryReadSemanticTag(out ulong tag);
+                RejectStringRef(tag);
 
                 if (tag == DECIMAL_FRACTION_TAG || tag == BIGFLOAT_TAG)
                 {
@@ -1645,6 +1648,13 @@ namespace Dahomey.Cbor.Serialization
         /// <c>string_referencing=True</c> writes for a document that repeats nothing - is ordinary
         /// CBOR; and <see cref="SkipDataItem"/> steps over a reference without complaint, since an
         /// unmapped member is discarded whether or not its strings could have been resolved.
+        /// </para>
+        /// <para>
+        /// The readers that walk the tag stack themselves - <see cref="ReadDecimal"/>,
+        /// <see cref="ReadBigInteger"/> and <see cref="ReadFractionParts"/>, which take their tags
+        /// through <see cref="TryReadSemanticTag"/> rather than through the skip - call this on every
+        /// tag they take, or a reference over one of those members would keep taking the table index
+        /// for its value.
         /// </para>
         /// </remarks>
         private void RejectStringRef(ulong semanticTag)

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -87,7 +87,6 @@ namespace Dahomey.Cbor.Serialization
 
         // http://cbor.schmorp.de/stringref - not supported, see RejectStringRef.
         private const ulong STRINGREF_TAG = 25;
-        private const ulong STRINGREF_NAMESPACE_TAG = 256;
 
         /// <summary>Widest scale a <see cref="decimal"/> holds.</summary>
         private const int MAX_DECIMAL_SCALE = 28;
@@ -452,7 +451,7 @@ namespace Dahomey.Cbor.Serialization
                 return null;
             }
 
-            ExpectTextString();
+            Expect(CborMajorType.TextString);
             return Encoding.UTF8.GetString(ReadSizeAndBytes(allowScratchBuffer: true));
         }
 
@@ -486,7 +485,7 @@ namespace Dahomey.Cbor.Serialization
                 return null;
             }
 
-            ExpectTextString();
+            Expect(CborMajorType.TextString);
             return ReadSizeAndBytes(allowScratchBuffer: false);
         }
 
@@ -1604,6 +1603,11 @@ namespace Dahomey.Cbor.Serialization
         /// value, and <see cref="ObjectModel.CborValue.SemanticTag"/> holds one tag. A lost tag is the
         /// intended shortfall; a value decoded from the wrong bytes was not.
         /// </para>
+        /// <para>
+        /// One tag is not lost but refused, since losing it is what decodes the wrong bytes: see
+        /// <see cref="RejectStringRef"/>. <see cref="SkipDataItem"/> uses
+        /// <see cref="SkipSemanticTagUnchecked"/> instead, having no bytes to decode wrongly.
+        /// </para>
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SkipSemanticTag()
@@ -1617,27 +1621,35 @@ namespace Dahomey.Cbor.Serialization
         }
 
         /// <summary>
-        /// Throws on the two string reference tags, which are not supported.
+        /// Throws on a string reference, which cannot be resolved, when the item it stands for is
+        /// about to be used.
         /// </summary>
         /// <remarks>
         /// Stringref (http://cbor.schmorp.de/stringref, issue #142) replaces a repeated string with
         /// tag 25 over its index into a table of the strings already seen, the table being scoped by a
-        /// tag 256 around the document. Reading it is not a matter of decoding one more tag: the table
-        /// is built from every string in document order, including the ones a decode never
-        /// materialises, so <see cref="SkipDataItem"/> - which <c>ObjectConverter</c> runs over every
-        /// unmapped member - would have to decode what it currently steps over, or every later index
-        /// would refer to the wrong string.
+        /// tag 256 around the document. It is not supported, and supporting it is not a matter of
+        /// decoding one more tag: the table is built from every string in document order, including
+        /// the ones a decode never materialises, so <see cref="SkipDataItem"/> - which
+        /// <c>ObjectConverter</c> runs over every unmapped member - would have to decode what it
+        /// currently steps over, or every later index would refer to the wrong string.
         /// <para>
-        /// So the tag is refused rather than half-honoured, and refused by name. Skipping it silently
-        /// is what produced the report: the tag 256 disappeared, then the first tag 25 surfaced as
-        /// "Expected major type TextString" at whatever member happened to hold a repeated key, which
-        /// says nothing about stringref and points at the wrong part of the document. A caller who
-        /// controls the encoder wants to hear that the encoder is the thing to change.
+        /// What the tag cannot do is pass silently, which is what produced the report: it was skipped
+        /// like any unrecognised tag, leaving its index behind as the value. Over a string that
+        /// surfaced as "Expected major type TextString", which names neither stringref nor the tag;
+        /// over an <c>int</c> member it did not surface at all, and the member took the index as its
+        /// value. Both now say what the tag is and which encoder setting produces it.
+        /// </para>
+        /// <para>
+        /// Only tag 25 is refused, and only where the item is wanted. Tag 256 is skipped like any
+        /// other tag, since a namespace with no reference under it - which is what
+        /// <c>string_referencing=True</c> writes for a document that repeats nothing - is ordinary
+        /// CBOR; and <see cref="SkipDataItem"/> steps over a reference without complaint, since an
+        /// unmapped member is discarded whether or not its strings could have been resolved.
         /// </para>
         /// </remarks>
         private void RejectStringRef(ulong semanticTag)
         {
-            if (semanticTag == STRINGREF_TAG || semanticTag == STRINGREF_NAMESPACE_TAG)
+            if (semanticTag == STRINGREF_TAG)
             {
                 ThrowCbor(
                     $"Unsupported semantic tag {semanticTag}: CBOR string references "
@@ -1647,10 +1659,24 @@ namespace Dahomey.Cbor.Serialization
             }
         }
 
+        /// <summary>
+        /// <see cref="SkipSemanticTag"/> for an item whose content is discarded, which passes over a
+        /// string reference rather than refusing it - see <see cref="RejectStringRef"/>.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void SkipSemanticTagUnchecked()
+        {
+            while (Accept(CborMajorType.SemanticTag))
+            {
+                ReadInteger();
+                _state = CborReaderState.Data;
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SkipDataItem()
         {
-            SkipSemanticTag();
+            SkipSemanticTagUnchecked();
 
             CborReaderHeader header = GetHeader();
 
@@ -1675,7 +1701,7 @@ namespace Dahomey.Cbor.Serialization
                     break;
 
                 case CborMajorType.SemanticTag:
-                    // Impossible - SkipSemanticTag above takes the whole stack. It used to take one,
+                    // Impossible - the skip above takes the whole stack. It used to take one,
                     // which made this arm reachable for a nested tag and this method return with the
                     // tagged item unread, leaving the buffer one item out of step.
                     break;
@@ -1812,33 +1838,6 @@ namespace Dahomey.Cbor.Serialization
             {
                 ThrowCbor($"Expected major type {majorType} ({(byte)majorType})");
             }
-        }
-
-        /// <summary>
-        /// <see cref="Expect(CborMajorType)"/> for a text string, naming stringref when that is what
-        /// stands in the way.
-        /// </summary>
-        /// <remarks>
-        /// The two text string reads are the ones that do not begin with <see cref="SkipSemanticTag"/>,
-        /// so a tag 25 in front of a string - a repeated map key, which is exactly where stringref puts
-        /// them - arrives here as a major type mismatch instead of passing through
-        /// <see cref="RejectStringRef"/>. The tag is read only once the read has already failed, so the
-        /// path that finds its string pays nothing for the better message.
-        /// </remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void ExpectTextString()
-        {
-            if (Accept(CborMajorType.TextString))
-            {
-                return;
-            }
-
-            if (_header.MajorType == CborMajorType.SemanticTag)
-            {
-                RejectStringRef(ReadInteger());
-            }
-
-            ThrowCbor($"Expected major type {CborMajorType.TextString} ({(byte)CborMajorType.TextString})");
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -85,6 +85,10 @@ namespace Dahomey.Cbor.Serialization
         private const ulong DECIMAL_FRACTION_TAG = 4;
         private const ulong BIGFLOAT_TAG = 5;
 
+        // http://cbor.schmorp.de/stringref - not supported, see RejectStringRef.
+        private const ulong STRINGREF_TAG = 25;
+        private const ulong STRINGREF_NAMESPACE_TAG = 256;
+
         /// <summary>Widest scale a <see cref="decimal"/> holds.</summary>
         private const int MAX_DECIMAL_SCALE = 28;
 
@@ -448,7 +452,7 @@ namespace Dahomey.Cbor.Serialization
                 return null;
             }
 
-            Expect(CborMajorType.TextString);
+            ExpectTextString();
             return Encoding.UTF8.GetString(ReadSizeAndBytes(allowScratchBuffer: true));
         }
 
@@ -482,7 +486,7 @@ namespace Dahomey.Cbor.Serialization
                 return null;
             }
 
-            Expect(CborMajorType.TextString);
+            ExpectTextString();
             return ReadSizeAndBytes(allowScratchBuffer: false);
         }
 
@@ -1606,8 +1610,40 @@ namespace Dahomey.Cbor.Serialization
         {
             while (Accept(CborMajorType.SemanticTag))
             {
-                ReadInteger();
+                ulong tag = ReadInteger();
                 _state = CborReaderState.Data;
+                RejectStringRef(tag);
+            }
+        }
+
+        /// <summary>
+        /// Throws on the two string reference tags, which are not supported.
+        /// </summary>
+        /// <remarks>
+        /// Stringref (http://cbor.schmorp.de/stringref, issue #142) replaces a repeated string with
+        /// tag 25 over its index into a table of the strings already seen, the table being scoped by a
+        /// tag 256 around the document. Reading it is not a matter of decoding one more tag: the table
+        /// is built from every string in document order, including the ones a decode never
+        /// materialises, so <see cref="SkipDataItem"/> - which <c>ObjectConverter</c> runs over every
+        /// unmapped member - would have to decode what it currently steps over, or every later index
+        /// would refer to the wrong string.
+        /// <para>
+        /// So the tag is refused rather than half-honoured, and refused by name. Skipping it silently
+        /// is what produced the report: the tag 256 disappeared, then the first tag 25 surfaced as
+        /// "Expected major type TextString" at whatever member happened to hold a repeated key, which
+        /// says nothing about stringref and points at the wrong part of the document. A caller who
+        /// controls the encoder wants to hear that the encoder is the thing to change.
+        /// </para>
+        /// </remarks>
+        private void RejectStringRef(ulong semanticTag)
+        {
+            if (semanticTag == STRINGREF_TAG || semanticTag == STRINGREF_NAMESPACE_TAG)
+            {
+                ThrowCbor(
+                    $"Unsupported semantic tag {semanticTag}: CBOR string references "
+                    + "(http://cbor.schmorp.de/stringref) are not implemented. Re-encode the document "
+                    + "without them - with Python cbor2, that is dumps(..., string_referencing=False), "
+                    + "which is the default.");
             }
         }
 
@@ -1776,6 +1812,33 @@ namespace Dahomey.Cbor.Serialization
             {
                 ThrowCbor($"Expected major type {majorType} ({(byte)majorType})");
             }
+        }
+
+        /// <summary>
+        /// <see cref="Expect(CborMajorType)"/> for a text string, naming stringref when that is what
+        /// stands in the way.
+        /// </summary>
+        /// <remarks>
+        /// The two text string reads are the ones that do not begin with <see cref="SkipSemanticTag"/>,
+        /// so a tag 25 in front of a string - a repeated map key, which is exactly where stringref puts
+        /// them - arrives here as a major type mismatch instead of passing through
+        /// <see cref="RejectStringRef"/>. The tag is read only once the read has already failed, so the
+        /// path that finds its string pays nothing for the better message.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ExpectTextString()
+        {
+            if (Accept(CborMajorType.TextString))
+            {
+                return;
+            }
+
+            if (_header.MajorType == CborMajorType.SemanticTag)
+            {
+                RejectStringRef(ReadInteger());
+            }
+
+            ThrowCbor($"Expected major type {CborMajorType.TextString} ({(byte)CborMajorType.TextString})");
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Closes #142.

#142 asks for tag 25, "string reference" — tag 25 over an index into a table of the strings already seen, the table scoped by a tag 256 around the document, per [cbor.schmorp.de/stringref](http://cbor.schmorp.de/stringref).

**This does not implement it, and closes the request.** Three reasons:

- The request as written is a compactness one — "lots of mappings with the same key names repeated multiple times" — and that already has a better answer here. `CborObjectFormat.IntKeyMap` writes each key as a small integer, `CborObjectFormat.Array` drops the keys altogether, and both compress that shape of document harder than string references do, in plain RFC 8949 rather than through a tag most implementations don't recognise. The question of whether the requester instead needed interop with a producer they don't control went unanswered.
- Supporting it is not one more tag to decode. The table is built from every string in document order, including the ones a decode never materialises, so `SkipDataItem` — which `ObjectConverter` runs over every unmapped member — would have to decode what it currently steps over, or every later index would refer to the wrong string. Map keys are also read as spans over the buffer, and a reference resolves to a string that isn't in it. That is a change to the hot path throughout the reader, plus the same again in the source generator.
- stringref is a cbor.schmorp.de specification, not an IETF one. It is IANA-registered and implemented by `cbor2` and `CBOR::XS`, but `System.Formats.Cbor` does not read it and neither do most others.

## What this changes

A reference no longer passes silently. `SkipSemanticTag` refuses tag 25 with a `CborException` naming stringref, the tag, and the encoder setting that produces it — so the refusal lands wherever the item the reference stands for is about to be used. That covers the report, where a repeated key surfaced as `Expected major type TextString` at whichever member happened to carry it, naming neither the cause nor the place. It also covers the case that made no noise at all: a reference over a numeric member, where the skipped tag left the member holding the table index as its value.

Refused where the item is wanted, and nowhere else — everything a document could previously decode correctly, it still decodes:

- **Tag 256 is skipped**, like any unrecognised tag. `cbor2` writes the namespace around every document under `string_referencing=True`, including one that repeats nothing, and a namespace with no reference under it is ordinary CBOR.
- **`SkipDataItem` skips references**, through `SkipSemanticTagUnchecked`. It steps over an unmapped member whole and needs no string table to do it, so a reference nobody reads costs nothing.
- **`TryReadSemanticTag` is untouched**, so a converter that asks for a tag by hand still gets it. `CborValue` therefore carries tag 25 as data over the index rather than throwing — the same treatment it gives typed arrays and any other tag it does not model. The README says so rather than changing it; the refusal is for deserialization into your own types.

## Tests

`Issues/Issue0142.cs` — a reference refused by name as a key and as a value, on a document in the shape `cbor2` emits and on the reference alone; a namespace with no reference still reading; a reference inside an unmapped member still skipped; and tag 55799 (self-described CBOR) still skipped, so the refusal stays limited to tag 25.

README gains a "String references (tag 25)" section stating the non-support, what is refused and what is skipped, the object-model behaviour, and the `CborObjectFormat` alternative.

⚠️ Not built or run locally: this environment has no .NET SDK and the network policy blocks `builds.dotnet.microsoft.com`, so the three target frameworks are verified by CI on this branch rather than by me.