### PR TITLE
Read and write a tuple of any arity as one flat array, closes #198

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ High-performance [CBOR](https://cbor.io/) serialization framework for .Net (C#)
 * Support for structs
 * Support for RFC 8746 typed arrays, opt-in per direction (CborOptions.TypedArrayMode)
 * Support for RFC 8949 §3.4.3 bignums (tags 2 and 3) as System.Numerics.BigInteger
+* Support for tuples of any arity, as one flat array, on the reflection and source-generated paths
 * Reads RFC 8949 §3.4.4 decimal fractions (tag 4) into decimal, and writes them on request
   (CborOptions.DecimalFormat)
 * Support for RFC 8949 §3.4.4 decimal fractions (tag 4) and bigfloats (tag 5) as their own types,
@@ -390,6 +391,47 @@ Equality is structural over the pair as encoded, so `10e0` and `1e1` are the sam
 equal, and neither is normalised on the way out — a document round-trips byte for byte. Two encodings of
 one number are therefore two distinct dictionary keys, and under `CborOptions.Deterministic` they sort as
 the different byte strings they are.
+
+### Tuples
+
+A `ValueTuple` is one CBOR array holding its elements in order, at any arity:
+
+```csharp
+// (1, "two")                        -> 82 01 63 74776F
+// (1, 2, 3, 4, 5, 6, 7, 8, 9)       -> 89 01 02 03 04 05 06 07 08 09
+// fifteen elements                  -> 8F 01 02 ... 0F
+```
+
+**Past seven elements the array stays flat.** C# represents such a tuple as seven fields plus a `Rest`
+holding the overflow, and nests again every seven after that, but that is a detail of the language: a
+nine-element tuple is nine items, not seven and a nested pair. A one-element `ValueTuple<T>` — which C#
+has no literal for — is an array of one.
+
+Reading is exact about arity: an array of the wrong length is a `CborException` naming the arity
+expected, in both the definite and indefinite-length forms, and a failure inside an element names its
+flattened position, so `$[8]` rather than a path through a `Rest` the document knows nothing about.
+
+`System.Tuple<…>` — the class, not the struct — is not a tuple to this library and is treated as an
+ordinary object.
+
+#### Under Native AOT
+
+Tuples work in a source-generated context, at every arity:
+
+```csharp
+[CborSerializable(typeof(Reading))]
+public partial class MyContext : CborSerializerContext { }
+```
+
+The generated context names each converter instantiation in source — `Tuple2Converter<int, string>`, and
+for a longer tuple `Tuple8Converter<…, ValueTuple<int, int>>` together with the `Rest`'s own converter —
+so nothing is constructed reflectively and the bytes are identical to the reflection path's.
+
+**Without a context, a tuple needs the reflection path, which Native AOT cannot serve.** The provider
+resolves a tuple's converter through `Type.MakeGenericType`, as it does for every generic converter —
+collections, dictionaries, nullables — so a trimmed or AOT-published application must declare the types
+it serializes on a context. That is the same requirement as for any other generic type here, not
+something specific to tuples.
 
 ### Custom converters
 

--- a/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
+++ b/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
@@ -139,6 +139,29 @@ namespace Dahomey.Cbor.Generator
                     break;
                 }
 
+                // A fixed, heterogeneous array: one entry per element, in order, with the Rest chain
+                // flattened because that is what the writer emits -- a nine-element tuple is nine items.
+                // Not `[* X]`, which would say any length of one type.
+                case TypeKind.Tuple:
+                {
+                    List<string> elements = new List<string>();
+
+                    foreach (ITypeSymbol element in TypeCollector.FlattenTupleElements((INamedTypeSymbol)type))
+                    {
+                        string? renderedElement = Render(element, byKey, ruleNames, options, Position.Value);
+
+                        if (renderedElement is null)
+                        {
+                            return null;
+                        }
+
+                        elements.Add(renderedElement);
+                    }
+
+                    rendered = "[" + string.Join(", ", elements) + "]";
+                    break;
+                }
+
                 default:
                     return null;
             }

--- a/src/Dahomey.Cbor.Generator/Emitter.cs
+++ b/src/Dahomey.Cbor.Generator/Emitter.cs
@@ -263,6 +263,21 @@ namespace Dahomey.Cbor.Generator
                             $"new DictionaryConverter<{FullName(model.Symbol)}, {FullName(model.ElementType!)}, {FullName(model.ValueType!)}>(options)");
                         break;
 
+                    // One converter per arity, named with the tuple's own type arguments -- so the
+                    // instantiation is written out here rather than made at run time, which is the whole
+                    // point: the reflection provider reaches MakeGenericType, and a tuple was therefore
+                    // the one shape a generated context had to refuse.
+                    //
+                    // The eighth argument is the Rest rather than an eighth element, and Tuple8Converter
+                    // recurses into it. The Rest is registered too, by its own model, which the
+                    // dependency ordering puts first.
+                    case TypeKind.Tuple:
+                        EmitSimpleRegistration(builder, indent, model.Symbol,
+                            $"new Tuple{model.TupleArguments.Count}Converter<"
+                                + string.Join(", ", model.TupleArguments.Select(FullName))
+                                + ">(options)");
+                        break;
+
                     case TypeKind.Object:
                         EmitObjectRegistration(builder, indent, model);
                         break;

--- a/src/Dahomey.Cbor.Generator/TypeCollector.cs
+++ b/src/Dahomey.Cbor.Generator/TypeCollector.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Dahomey.Cbor.Generator
@@ -83,9 +84,75 @@ namespace Dahomey.Cbor.Generator
                     model.Dependencies.Add(value!);
                     break;
 
+                case TypeKind.Tuple:
+                    CollectTuple((INamedTypeSymbol)type, model);
+                    break;
+
                 case TypeKind.Object:
                     CollectObject(type, model);
                     break;
+            }
+        }
+
+        /// <summary>
+        /// A tuple's type arguments, each of which needs a converter of its own before this one can be
+        /// constructed.
+        /// </summary>
+        /// <remarks>
+        /// For an arity past seven the eighth argument is the <c>Rest</c>, a tuple in its own right, so
+        /// collecting it recurses and the chain terminates at seven or fewer. That is also why the
+        /// dependency has to be recorded: <c>Tuple8Converter</c> asks the registry for the <c>Rest</c>'s
+        /// converter while it is being constructed, so the <c>Rest</c> must be registered first.
+        /// </remarks>
+        private void CollectTuple(INamedTypeSymbol type, TypeModel model)
+        {
+            foreach (ITypeSymbol argument in type.TypeArguments)
+            {
+                model.TupleArguments.Add(argument);
+
+                Collect(argument);
+                model.Dependencies.Add(argument);
+            }
+        }
+
+        /// <summary>
+        /// Whether this is one of the <c>System.ValueTuple</c> types.
+        /// </summary>
+        /// <remarks>
+        /// By metadata name rather than by <c>IsTupleType</c>, which is false for the one-element
+        /// <c>ValueTuple&lt;T&gt;</c> -- C# has no tuple syntax for a single element -- and that arity is
+        /// exactly what an eight-element tuple's <c>Rest</c> is.
+        /// </remarks>
+        private static bool IsValueTuple(INamedTypeSymbol type)
+        {
+            return type.MetadataName.StartsWith("ValueTuple`", System.StringComparison.Ordinal)
+                && type.ContainingNamespace is { Name: "System" }
+                && type.ContainingNamespace.ContainingNamespace is { IsGlobalNamespace: true };
+        }
+
+        /// <summary>
+        /// A tuple's elements with the <c>Rest</c> chain flattened, which is what the wire form is and
+        /// therefore what a schema has to describe.
+        /// </summary>
+        public static IEnumerable<ITypeSymbol> FlattenTupleElements(INamedTypeSymbol type)
+        {
+            ImmutableArray<ITypeSymbol> arguments = type.TypeArguments;
+
+            for (int index = 0; index < arguments.Length; index++)
+            {
+                if (index == 7
+                    && arguments[index] is INamedTypeSymbol rest
+                    && IsValueTuple(rest))
+                {
+                    foreach (ITypeSymbol nested in FlattenTupleElements(rest))
+                    {
+                        yield return nested;
+                    }
+
+                    continue;
+                }
+
+                yield return arguments[index];
             }
         }
 
@@ -528,6 +595,13 @@ namespace Dahomey.Cbor.Generator
                 {
                     underlying = named.TypeArguments[0];
                     return TypeKind.Nullable;
+                }
+
+                // Before the collection tests: a tuple implements none of those interfaces, but it is
+                // the more specific shape and reads better stated first.
+                if (IsValueTuple(named))
+                {
+                    return TypeKind.Tuple;
                 }
 
                 // Dictionary<K,V> and anything implementing IDictionary<K,V>.

--- a/src/Dahomey.Cbor.Generator/TypeModel.cs
+++ b/src/Dahomey.Cbor.Generator/TypeModel.cs
@@ -23,6 +23,13 @@ namespace Dahomey.Cbor.Generator
         Dictionary,
         Object,
 
+        /// <summary>
+        /// A <c>ValueTuple</c>, which is one flat CBOR array of its elements. Kept apart from
+        /// <see cref="Collection"/> because its elements are heterogeneous and its converter takes one
+        /// type argument per element rather than a single element type.
+        /// </summary>
+        Tuple,
+
         /// <summary>Cannot be handled; the caller reports a diagnostic.</summary>
         Unsupported,
     }
@@ -92,6 +99,15 @@ namespace Dahomey.Cbor.Generator
 
         /// <summary>Object format, when <see cref="Kind"/> is <see cref="TypeKind.Object"/>.</summary>
         public string ObjectFormat { get; set; } = "StringKeyMap";
+
+        /// <summary>
+        /// A tuple's type arguments, when <see cref="Kind"/> is <see cref="TypeKind.Tuple"/>: one per
+        /// element up to seven, and for a longer tuple the seven plus the <c>Rest</c> holding the
+        /// overflow. These are the converter's type arguments, so the eighth is the <c>Rest</c>'s own
+        /// type rather than an element -- <c>Tuple8Converter</c> recurses into it, which is what covers
+        /// every arity with eight converters.
+        /// </summary>
+        public List<ITypeSymbol> TupleArguments { get; } = new List<ITypeSymbol>();
 
         /// <summary>Rendered C# literal for the discriminator, or null when the type has none.</summary>
         public string? Discriminator { get; set; }

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlScalarMappingTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlScalarMappingTests.cs
@@ -18,6 +18,12 @@ namespace Dahomey.Cbor.Tests.Cddl
         public BigInteger Big { get; set; }
         public CborDecimalFraction Price { get; set; }
         public CborBigFloat Scale { get; set; }
+
+        /// <summary>
+        /// A tuple, which is a fixed heterogeneous array rather than a collection of one type -- the one
+        /// shape <c>[* X]</c> cannot describe.
+        /// </summary>
+        public (int, string) Pair { get; set; }
     }
 
     [CborSerializable(typeof(CddlScalars))]
@@ -70,6 +76,24 @@ namespace Dahomey.Cbor.Tests.Cddl
             Assert.Contains("\"Scale\": #6.5([int, (int / #6.2(bstr) / #6.3(bstr))]),", schema);
         }
 
+        /// <summary>
+        /// A tuple is a fixed, heterogeneous array: one entry per element, in order, with the
+        /// <c>Rest</c> chain flattened because that is what the writer emits. <c>[* X]</c> would say any
+        /// length of one type, which is the one shape a tuple is not.
+        /// </summary>
+        /// <remarks>
+        /// The <c>string</c> element renders <c>tstr / nil</c> because this test project is
+        /// nullable-oblivious, and an element inside a tuple follows the same rule as a member: the
+        /// annotation is the contract, and its absence admits null.
+        /// </remarks>
+        [Fact]
+        public void ATupleIsAFixedHeterogeneousArray()
+        {
+            Assert.Contains(
+                "\"Pair\": [-2147483648..2147483647, tstr / nil],",
+                CddlScalarsContext.CddlSchema.Replace("\r\n", "\n"));
+        }
+
         [CddlFact]
         public void SerializerOutputValidatesAgainstTheSchema()
         {
@@ -81,6 +105,7 @@ namespace Dahomey.Cbor.Tests.Cddl
                 // A mantissa past a basic integer, so the instance exercises the bignum arm of the
                 // mantissa's choice rather than only the int one.
                 Scale = new CborBigFloat(BigInteger.Parse("18446744073709551616"), -1),
+                Pair = (7, "seven"),
             };
 
             byte[] cbor = Helper.Write(value, Context.Options).HexToBytes();

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -194,6 +194,14 @@ namespace Dahomey.Cbor.Tests
                 };
             }
 
+            // Tuples at three shapes: within seven, past seven so the converter carries a Rest, and
+            // nested twice. The comparison is what catches a generated context that named a different
+            // converter or the wrong type arguments -- both would still produce valid CBOR.
+            if (type == typeof(GeneratedTupleHolder))
+            {
+                return GeneratedTupleTests.Sample();
+            }
+
             if (type == typeof(float[]))
             {
                 return new[] { 1.5f, -2.25f };
@@ -459,6 +467,7 @@ namespace Dahomey.Cbor.Tests
                 {
                     Initial = 'A',
                     Big = new System.Numerics.BigInteger(ulong.MaxValue) + System.Numerics.BigInteger.One,
+                    Pair = (7, "seven"),
                 };
             }
 

--- a/src/Dahomey.Cbor.Tests/GeneratedTupleTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedTupleTests.cs
@@ -1,0 +1,91 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    public class GeneratedTupleHolder
+    {
+        /// <summary>Seven or fewer: one converter, one type argument per element.</summary>
+        public (int, string) Pair { get; set; }
+
+        /// <summary>Past seven, so the converter's eighth argument is the <c>Rest</c>.</summary>
+        public (int, int, int, int, int, int, int, int, int) Nine { get; set; }
+
+        /// <summary>Nested twice, so the <c>Rest</c>'s own <c>Rest</c> is a one-element tuple.</summary>
+        public (int, int, int, int, int, int, int, int, int, int, int, int, int, int, int) Fifteen { get; set; }
+
+        /// <summary>Through <c>NullableConverter</c>, which resolves the tuple's converter itself.</summary>
+        public (int, string)? Optional { get; set; }
+    }
+
+    [CborSerializable(typeof(GeneratedTupleHolder))]
+    public partial class TupleContext : CborSerializerContext
+    {
+    }
+
+    /// <summary>
+    /// Tuples on the source-generated path, which is what makes them usable under Native AOT: the
+    /// reflection provider builds a tuple's converter with <c>MakeGenericType</c>, and a generated
+    /// context names the instantiation in source instead.
+    /// </summary>
+    /// <remarks>
+    /// Before this, a tuple member was <c>CBOR1002</c> — the generator classified it as an unrecognised
+    /// generic type and refused to build. So the coverage that matters is the corpus comparison against
+    /// the reflection path, since a generated context that resolved a different converter would still
+    /// produce valid CBOR.
+    /// </remarks>
+    public class GeneratedTupleTests
+    {
+        [Fact]
+        public void AGeneratedContextWritesWhatTheReflectionPathWrites()
+        {
+            TupleContext context = new TupleContext();
+            GeneratedTupleHolder holder = Sample();
+
+            string generated = Helper.Write(holder, context.Options);
+
+            Assert.Equal(Helper.Write(holder), generated, ignoreCase: true);
+        }
+
+        [Fact]
+        public void AGeneratedContextReadsBackWhatItWrote()
+        {
+            TupleContext context = new TupleContext();
+            GeneratedTupleHolder holder = Sample();
+
+            GeneratedTupleHolder read = Helper.Read<GeneratedTupleHolder>(
+                Helper.Write(holder, context.Options), context.Options);
+
+            Assert.Equal(holder.Pair, read.Pair);
+            Assert.Equal(holder.Nine, read.Nine);
+            Assert.Equal(holder.Fifteen, read.Fifteen);
+            Assert.Equal(holder.Optional, read.Optional);
+        }
+
+        /// <summary>
+        /// The arity past seven is flat on the generated path too, which is the assertion that would
+        /// fail if the emitted registration named the wrong converter or the wrong type arguments.
+        /// </summary>
+        [Fact]
+        public void AnArityPastSevenIsFlatOnTheGeneratedPath()
+        {
+            TupleContext context = new TupleContext();
+
+            Assert.Contains(
+                "89010203040506070809",
+                Helper.Write(Sample(), context.Options).ToUpperInvariant());
+        }
+
+        internal static GeneratedTupleHolder Sample()
+        {
+            return new GeneratedTupleHolder
+            {
+                Pair = (1, "two"),
+                Nine = (1, 2, 3, 4, 5, 6, 7, 8, 9),
+                Fifteen = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+                Optional = (7, "seven"),
+            };
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/TupleTests.cs
+++ b/src/Dahomey.Cbor.Tests/TupleTests.cs
@@ -1,5 +1,7 @@
 using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.Tests.Extensions;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Dahomey.Cbor.Tests
@@ -153,6 +155,154 @@ namespace Dahomey.Cbor.Tests
 
             Assert.Contains("Expected major type Array", exception.Message);
             Assert.Equal("$.a", exception.Path);
+        }
+
+        /// <summary>
+        /// A tuple of more than seven elements is one flat array of that many items.
+        /// </summary>
+        /// <remarks>
+        /// C# represents such a tuple as seven fields plus a <c>Rest</c> holding the overflow, and that
+        /// nesting is an implementation detail of the language rather than anything the format knows: a
+        /// nine-element tuple is <c>[1, …, 9]</c>, not <c>[1, …, 7, [8, 9]]</c>. Fifteen elements nest
+        /// twice — <c>Rest</c> is itself an eight-field tuple — and are still fifteen items.
+        /// </remarks>
+        [Fact]
+        public void ATupleOfMoreThanSevenElementsIsOneFlatArray()
+        {
+            Helper.TestWrite((1, 2, 3, 4, 5, 6, 7, 8), "880102030405060708");
+            Helper.TestWrite((1, 2, 3, 4, 5, 6, 7, 8, 9), "89010203040506070809");
+            Helper.TestWrite((1, 2, 3, 4, 5, 6, 7, 8, 9, 10), "8A0102030405060708090A");
+            Helper.TestWrite(
+                (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+                "8F0102030405060708090A0B0C0D0E0F");
+        }
+
+        [Fact]
+        public void ATupleOfMoreThanSevenElementsReadsBack()
+        {
+            Assert.Equal(
+                (1, 2, 3, 4, 5, 6, 7, 8),
+                Helper.Read<(int, int, int, int, int, int, int, int)>("880102030405060708"));
+            Assert.Equal(
+                (1, 2, 3, 4, 5, 6, 7, 8, 9),
+                Helper.Read<(int, int, int, int, int, int, int, int, int)>("89010203040506070809"));
+            Assert.Equal(
+                (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+                Helper.Read<(int, int, int, int, int, int, int, int, int, int, int, int, int, int, int)>(
+                    "8F0102030405060708090A0B0C0D0E0F"));
+        }
+
+        /// <summary>
+        /// The items keep their order across the <c>Rest</c> boundary, which a tuple of one type cannot
+        /// show: every element here is a different type, so a misordered read fails on major type.
+        /// </summary>
+        [Fact]
+        public void TheItemsPastSevenKeepTheirOrder()
+        {
+            (int, string, bool, double, int, string, bool, int, string) value =
+                (1, "two", true, 4.5, 5, "six", false, 8, "nine");
+
+            string hexBuffer = Helper.Write(value);
+
+            Assert.Equal(
+                value,
+                Helper.Read<(int, string, bool, double, int, string, bool, int, string)>(hexBuffer));
+        }
+
+        /// <summary>
+        /// An arity past seven is refused for the same reasons a shorter one is, and the message names
+        /// the flattened arity rather than the seven-plus-<c>Rest</c> shape behind it.
+        /// </summary>
+        [Fact]
+        public void AWrongArityPastSevenIsRefused()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<(int, int, int, int, int, int, int, int, int)>(
+                    "880102030405060708".HexToBytes()));
+
+            Assert.Contains("Expected CBOR Array of size 9", exception.Message);
+
+            // Too many, and the indefinite-length form of both.
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int, int, int, int)>(
+                "89010203040506070809".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int, int, int, int, int)>(
+                "9F0102030405060708FF".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int, int, int, int)>(
+                "9F010203040506070809FF".HexToBytes()));
+
+            // And a non-array, which the arity past seven reaches through the same entry point.
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int, int, int, int)>(
+                "480102030405060708".HexToBytes()));
+        }
+
+        [Fact]
+        public void AnIndefiniteLengthTuplePastSevenIsReadAndLeavesNothingBehind()
+        {
+            Assert.Equal(
+                (1, 2, 3, 4, 5, 6, 7, 8, 9),
+                Helper.Read<(int, int, int, int, int, int, int, int, int)>("9F010203040506070809FF"));
+
+            // [[_ 1..9], [_ 1..9]] -- the second element only reads if the first consumed its break.
+            List<(int, int, int, int, int, int, int, int, int)> list =
+                Cbor.Deserialize<List<(int, int, int, int, int, int, int, int, int)>>(
+                    ("82" + "9F010203040506070809FF" + "9F010203040506070809FF").HexToBytes());
+
+            Assert.Equal(2, list.Count);
+            Assert.Equal((1, 2, 3, 4, 5, 6, 7, 8, 9), list[1]);
+        }
+
+        /// <summary>
+        /// A failure inside the overflow names the item's flattened position, so <c>$[8]</c> rather than
+        /// a path through a <c>Rest</c> the document knows nothing about.
+        /// </summary>
+        [Fact]
+        public void AnItemPastSevenIsNamedByItsFlattenedIndex()
+        {
+            // [1, 2, 3, 4, 5, 6, 7, 8, "x"] into nine ints
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<(int, int, int, int, int, int, int, int, int)>(
+                    "89010203040506070861 78".Replace(" ", "").HexToBytes()));
+
+            Assert.Equal("$[8]", exception.Path);
+        }
+
+        /// <summary>
+        /// A one-element tuple, which C# has no literal for and which an eight-element tuple's
+        /// <c>Rest</c> is. It is an array of one item like any other tuple.
+        /// </summary>
+        [Fact]
+        public void AOneElementTupleIsAnArrayOfOne()
+        {
+            Helper.TestWrite(new ValueTuple<int>(1), "8101");
+            Assert.Equal(new ValueTuple<int>(1), Helper.Read<ValueTuple<int>>("8101"));
+        }
+
+        public class LongTupleMember
+        {
+            [CborProperty("a")]
+            public (int, int, int, int, int, int, int, int, int) A { get; set; }
+
+            [CborProperty("b")]
+            public int B { get; set; }
+        }
+
+        /// <summary>
+        /// As a member and as a nullable, which reach the converter through
+        /// <c>MemberConverter</c> and <c>NullableConverter</c> rather than directly.
+        /// </summary>
+        [Fact]
+        public void ATuplePastSevenWorksAsAMemberAndAsANullable()
+        {
+            LongTupleMember member = Cbor.Deserialize<LongTupleMember>(
+                ("A2" + "6161" + "89010203040506070809" + "6162" + "07").HexToBytes());
+
+            Assert.Equal((1, 2, 3, 4, 5, 6, 7, 8, 9), member.A);
+            Assert.Equal(7, member.B);
+
+            Assert.Equal(
+                (1, 2, 3, 4, 5, 6, 7, 8, 9),
+                Helper.Read<(int, int, int, int, int, int, int, int, int)?>("89010203040506070809"));
+            Assert.Null(Helper.Read<(int, int, int, int, int, int, int, int, int)?>("F6"));
         }
 
         [Fact]

--- a/src/Dahomey.Cbor.Tests/TupleTests.cs
+++ b/src/Dahomey.Cbor.Tests/TupleTests.cs
@@ -305,6 +305,108 @@ namespace Dahomey.Cbor.Tests
             Assert.Null(Helper.Read<(int, int, int, int, int, int, int, int, int)?>("F6"));
         }
 
+        /// <summary>
+        /// An indefinite-length tuple ends where its arity says it does, at every arity and in both
+        /// length forms. The definite-length half already held, from <c>size != N</c>; the
+        /// indefinite-length half had no check after the last item at all, so the extra items were
+        /// silently dropped.
+        /// </summary>
+        /// <remarks>
+        /// Ported from #210 unchanged. The check itself is stated once here, in
+        /// <c>TupleReader.ReadEndArray</c>, rather than once per arity — but it applies at arities two
+        /// through seven exactly as it does past seven, and
+        /// <see cref="AnIndefiniteLengthTuplePastSevenIsReadAndLeavesNothingBehind"/> only covers the
+        /// new ground.
+        /// </remarks>
+        [Fact]
+        public void ATupleWithTooManyItemsIsRefusedAtEveryArity()
+        {
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int)>("9F010203FF".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int)>("9F01020304FF".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int)>("9F0102030405FF".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int)>("9F010203040506FF".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int, int)>("9F01020304050607FF".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int, int, int, int, int)>("9F0102030405060708FF".HexToBytes()));
+
+            // The definite-length form of the same document, which the arity check already refused.
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int)>("83010203".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int)>("8401020304".HexToBytes()));
+
+            // And too few, which the per-item break check refuses — the mirror of the end check, and
+            // the reason the end check can assume anything that is not a break is an item too many.
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int)>("9F01FF".HexToBytes()));
+            Assert.Throws<CborException>(() => Cbor.Deserialize<(int, int, int)>("9F0102FF".HexToBytes()));
+        }
+
+        /// <summary>
+        /// The other side of that check: a well-formed indefinite-length tuple still reads, at every
+        /// arity. Refusing one would be the easy way to make the test above pass.
+        /// </summary>
+        /// <remarks>Ported from #210 unchanged.</remarks>
+        [Fact]
+        public void AnIndefiniteLengthTupleIsStillReadAtEveryArity()
+        {
+            Assert.Equal((1, 2), Helper.Read<(int, int)>("9F0102FF"));
+            Assert.Equal((1, 2, 3), Helper.Read<(int, int, int)>("9F010203FF"));
+            Assert.Equal((1, 2, 3, 4), Helper.Read<(int, int, int, int)>("9F01020304FF"));
+            Assert.Equal((1, 2, 3, 4, 5), Helper.Read<(int, int, int, int, int)>("9F0102030405FF"));
+            Assert.Equal((1, 2, 3, 4, 5, 6), Helper.Read<(int, int, int, int, int, int)>("9F010203040506FF"));
+            Assert.Equal((1, 2, 3, 4, 5, 6, 7), Helper.Read<(int, int, int, int, int, int, int)>("9F01020304050607FF"));
+        }
+
+        /// <summary>
+        /// Where the unconsumed break did its damage: the closing <c>FF</c> was left in the buffer, so
+        /// whatever followed the tuple read it instead. An indefinite-length tuple was therefore only
+        /// usable as a whole document — as a map member the break was read as the next key, and as an
+        /// array element as the next element's head.
+        /// </summary>
+        /// <remarks>Ported from #210 unchanged.</remarks>
+        [Fact]
+        public void AnIndefiniteLengthTupleLeavesNothingBehind()
+        {
+            // {"a": [_ 1, 2], "b": 7}
+            TupleMember member = Cbor.Deserialize<TupleMember>("A261619F0102FF616207".HexToBytes());
+
+            Assert.Equal((1, 2), member.A);
+            Assert.Equal(7, member.B);
+
+            // [[_ 1, 2], [_ 3, 4]]
+            List<(int, int)> list = Cbor.Deserialize<List<(int, int)>>("829F0102FF9F0304FF".HexToBytes());
+
+            Assert.Equal(new[] { (1, 2), (3, 4) }, list);
+        }
+
+        /// <summary>
+        /// The sharpest statement of what the unconsumed break cost: with
+        /// <c>ArrayLengthMode.IndefiniteLength</c> the library could not read back what it had just
+        /// written, for any tuple in any container, with nothing hand-written involved.
+        /// </summary>
+        /// <remarks>
+        /// The documents in the tests above are typed by hand, so they say the reader is wrong without
+        /// saying that the writer produces exactly those documents. This is the only case here where
+        /// both halves are the library's own.
+        /// </remarks>
+        [Fact]
+        public void ATupleWrittenIndefiniteLengthReadsBack()
+        {
+            CborOptions options = new CborOptions { ArrayLengthMode = LengthMode.IndefiniteLength };
+            List<(int, int)> value = new List<(int, int)> { (1, 2), (3, 4) };
+
+            string hex = Helper.Write(value, options);
+
+            Assert.Equal("9F9F0102FF9F0304FFFF", hex, ignoreCase: true);
+            Assert.Equal(value, Cbor.Deserialize<List<(int, int)>>(hex.HexToBytes()));
+
+            // Past seven as well, where the flattening and the break meet: one array, nine items, and
+            // the break that ends it consumed by the tuple that opened it.
+            string longHex = Helper.Write((1, 2, 3, 4, 5, 6, 7, 8, 9), options);
+
+            Assert.Equal("9F010203040506070809FF", longHex, ignoreCase: true);
+            Assert.Equal(
+                (1, 2, 3, 4, 5, 6, 7, 8, 9),
+                Cbor.Deserialize<(int, int, int, int, int, int, int, int, int)>(longHex.HexToBytes()));
+        }
+
         [Fact]
         public void WriteTuple()
         {

--- a/src/Dahomey.Cbor/Serialization/CborReader.cs
+++ b/src/Dahomey.Cbor/Serialization/CborReader.cs
@@ -1470,7 +1470,7 @@ namespace Dahomey.Cbor.Serialization
         /// been consumed". <c>Data</c> matches what <see cref="SkipDataItem"/> does for a break.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void ConsumeBreak()
+        internal void ConsumeBreak()
         {
             GetHeader();
             _state = CborReaderState.Data;

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/TupleConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/TupleConverterProvider.cs
@@ -26,6 +26,12 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
                 FieldInfo[] fields = type.GetFields();
                 switch (fields.Length)
                 {
+                    // Only reachable as the Rest of an eight-element tuple: C# has no one-element
+                    // tuple literal. It is a tuple all the same, and its converter is what the arity
+                    // below delegates to.
+                    case 1:
+                        return CreateGenericConverter(options, typeof(Tuple1Converter<>), fields[0].FieldType);
+
                     case 2:
                         return CreateGenericConverter(options, typeof(Tuple2Converter<,>), fields.Select(field => field.FieldType).ToArray());
 
@@ -50,12 +56,6 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
                     // never exceeds eight because that is how C# represents a tuple.
                     case 8:
                         return CreateGenericConverter(options, typeof(Tuple8Converter<,,,,,,,>), fields.Select(field => field.FieldType).ToArray());
-
-                    // Only reachable as the Rest of an eight-element tuple: C# has no one-element
-                    // tuple literal. It is a tuple all the same, and its converter is what the arity
-                    // above delegates to.
-                    case 1:
-                        return CreateGenericConverter(options, typeof(Tuple1Converter<>), fields[0].FieldType);
 
                     default:
                         throw new CborException($"Tuples of length {fields.Length} are not supported");

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/TupleConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/TupleConverterProvider.cs
@@ -44,9 +44,19 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
                     case 7:
                         return CreateGenericConverter(options, typeof(Tuple7Converter<,,,,,,>), fields.Select(field => field.FieldType).ToArray());
 
+                    // Eight fields is seven items and a Rest, whatever the tuple's real arity: the
+                    // eighth type argument is the Rest's own type, and Tuple8Converter recurses into
+                    // it. So this case covers every arity from eight upwards, and the field count
+                    // never exceeds eight because that is how C# represents a tuple.
                     case 8:
                         return CreateGenericConverter(options, typeof(Tuple8Converter<,,,,,,,>), fields.Select(field => field.FieldType).ToArray());
-                    
+
+                    // Only reachable as the Rest of an eight-element tuple: C# has no one-element
+                    // tuple literal. It is a tuple all the same, and its converter is what the arity
+                    // above delegates to.
+                    case 1:
+                        return CreateGenericConverter(options, typeof(Tuple1Converter<>), fields[0].FieldType);
+
                     default:
                         throw new CborException($"Tuples of length {fields.Length} are not supported");
                 }

--- a/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TupleConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace Dahomey.Cbor.Serialization.Converters
+﻿using System;
+
+namespace Dahomey.Cbor.Serialization.Converters
 {
     /// <summary>
     /// Reads one item of a tuple, naming its position in <see cref="CborException.Path"/> if it fails.
@@ -22,22 +24,98 @@
                 throw;
             }
         }
+
+        /// <summary>
+        /// Reads one item at <paramref name="index"/> of a tuple of <paramref name="arity"/> items,
+        /// advancing the index. The break check before it is what catches an indefinite-length array
+        /// that ends early.
+        /// </summary>
+        public static T ReadItem<T>(
+            ref CborReader reader, ICborConverter<T> converter, int size, int arity, ref int index)
+        {
+            if (size == -1 && reader.IsBreak())
+            {
+                throw new CborException($"Expected CBOR Array of size {arity}");
+            }
+
+            T value = Read(ref reader, converter, index);
+            index++;
+
+            return value;
+        }
     }
 
-    public class Tuple2Converter<T1, T2> : CborConverterBase<(T1, T2)>
+    /// <summary>
+    /// A tuple's items, written into an array someone else opened and read from one someone else
+    /// entered.
+    /// </summary>
+    /// <remarks>
+    /// This is what keeps an arity past seven flat on the wire. C# represents such a tuple as seven
+    /// fields plus a <c>Rest</c> holding the overflow, and that nesting is an implementation detail of
+    /// the language: a nine-element tuple is nine items, <c>[1, …, 9]</c>, not <c>[1, …, 7, [8, 9]]</c>.
+    /// So the converter for the overflow contributes its items to the enclosing array rather than
+    /// opening one, and <see cref="ItemCount"/> is the flattened arity that array is sized by.
+    /// <para>
+    /// Recursion rather than a class per arity: the nesting repeats every seven elements without limit,
+    /// so a converter that delegates to its <c>Rest</c>'s items handles every arity there is with the
+    /// eight classes already here.
+    /// </para>
+    /// </remarks>
+    internal interface ICborTupleItems<T>
+    {
+        /// <summary>Items this contributes, counting everything nested inside a <c>Rest</c>.</summary>
+        int ItemCount { get; }
+
+        void WriteItems(ref CborWriter writer, T value);
+
+        T ReadItems(ref CborReader reader, int size, int arity, ref int index);
+    }
+
+    /// <summary>
+    /// A one-element tuple. Not reachable as a C# tuple literal, and needed because an eight-element
+    /// tuple's <c>Rest</c> is exactly this.
+    /// </summary>
+    public class Tuple1Converter<T1> : CborConverterBase<ValueTuple<T1>>, ICborTupleItems<ValueTuple<T1>>
     {
         private readonly CborOptions _options;
         private readonly ICborConverter<T1> _item1Converter;
-        private readonly ICborConverter<T2> _item2Converter;
 
-        public Tuple2Converter(CborOptions options)
+        public Tuple1Converter(CborOptions options)
         {
             _options = options;
             _item1Converter = options.Registry.ConverterRegistry.Lookup<T1>();
-            _item2Converter = options.Registry.ConverterRegistry.Lookup<T2>();
         }
 
-        public override (T1, T2) Read(ref CborReader reader)
+        public int ItemCount => 1;
+
+        public override ValueTuple<T1> Read(ref CborReader reader)
+        {
+            return TupleReader.Read<ValueTuple<T1>>(ref reader, this);
+        }
+
+        public ValueTuple<T1> ReadItems(ref CborReader reader, int size, int arity, ref int index)
+        {
+            return new ValueTuple<T1>(
+                TupleItemReader.ReadItem(ref reader, _item1Converter, size, arity, ref index));
+        }
+
+        public override void Write(ref CborWriter writer, ValueTuple<T1> value, LengthMode lengthMode)
+        {
+            TupleWriter.Write(ref writer, this, value, lengthMode, _options);
+        }
+
+        public void WriteItems(ref CborWriter writer, ValueTuple<T1> value)
+        {
+            _item1Converter.Write(ref writer, value.Item1);
+        }
+    }
+
+    /// <summary>
+    /// The array around a tuple's items: the part every arity shares, so no arity states it twice.
+    /// </summary>
+    internal static class TupleReader
+    {
+        public static T Read<T>(ref CborReader reader, ICborTupleItems<T> items)
         {
             // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
             // value off whatever header is current without asking which major type it belongs to, so
@@ -50,41 +128,85 @@
             // else.
             reader.ReadBeginArray();
 
+            int arity = items.ItemCount;
             int size = reader.ReadSize();
 
-            if (size != -1 && size != 2)
+            if (size != -1 && size != arity)
             {
-                throw new CborException("Expected CBOR Array of size 2");
+                throw new CborException($"Expected CBOR Array of size {arity}");
             }
 
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 2");
-            }
-            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
+            int index = 0;
+            T value = items.ReadItems(ref reader, size, arity, ref index);
 
-            if (size == -1 && reader.IsBreak())
+            if (size == -1)
             {
-                throw new CborException("Expected CBOR Array of size 2");
-            }
-            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
+                if (!reader.IsBreak())
+                {
+                    throw new CborException($"Expected CBOR Array of size {arity}");
+                }
 
-            return (item1, item2);
+                reader.ConsumeBreak();
+            }
+
+            return value;
         }
+    }
 
-        public override void Write(ref CborWriter writer, (T1, T2) value, LengthMode lengthMode)
+    internal static class TupleWriter
+    {
+        public static void Write<T>(
+            ref CborWriter writer, ICborTupleItems<T> items, T value, LengthMode lengthMode, CborOptions options)
         {
-            lengthMode = lengthMode != LengthMode.Default ? lengthMode : _options.ArrayLengthMode;
-            int size = lengthMode == LengthMode.IndefiniteLength ? -1 : 2;
+            lengthMode = lengthMode != LengthMode.Default ? lengthMode : options.ArrayLengthMode;
+            int size = lengthMode == LengthMode.IndefiniteLength ? -1 : items.ItemCount;
 
             writer.WriteBeginArray(size);
-            _item1Converter.Write(ref writer, value.Item1);
-            _item2Converter.Write(ref writer, value.Item2);
+            items.WriteItems(ref writer, value);
             writer.WriteEndArray(size);
         }
     }
 
-    public class Tuple3Converter<T1, T2, T3> : CborConverterBase<(T1, T2, T3)>
+    public class Tuple2Converter<T1, T2> : CborConverterBase<(T1, T2)>, ICborTupleItems<(T1, T2)>
+    {
+        private readonly CborOptions _options;
+        private readonly ICborConverter<T1> _item1Converter;
+        private readonly ICborConverter<T2> _item2Converter;
+
+        public Tuple2Converter(CborOptions options)
+        {
+            _options = options;
+            _item1Converter = options.Registry.ConverterRegistry.Lookup<T1>();
+            _item2Converter = options.Registry.ConverterRegistry.Lookup<T2>();
+        }
+
+        public int ItemCount => 2;
+
+        public override (T1, T2) Read(ref CborReader reader)
+        {
+            return TupleReader.Read<(T1, T2)>(ref reader, this);
+        }
+
+        public (T1, T2) ReadItems(ref CborReader reader, int size, int arity, ref int index)
+        {
+            return (
+                TupleItemReader.ReadItem(ref reader, _item1Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item2Converter, size, arity, ref index));
+        }
+
+        public override void Write(ref CborWriter writer, (T1, T2) value, LengthMode lengthMode)
+        {
+            TupleWriter.Write(ref writer, this, value, lengthMode, _options);
+        }
+
+        public void WriteItems(ref CborWriter writer, (T1, T2) value)
+        {
+            _item1Converter.Write(ref writer, value.Item1);
+            _item2Converter.Write(ref writer, value.Item2);
+        }
+    }
+
+    public class Tuple3Converter<T1, T2, T3> : CborConverterBase<(T1, T2, T3)>, ICborTupleItems<(T1, T2, T3)>
     {
         private readonly CborOptions _options;
         private readonly ICborConverter<T1> _item1Converter;
@@ -99,61 +221,35 @@
             _item3Converter = options.Registry.ConverterRegistry.Lookup<T3>();
         }
 
+        public int ItemCount => 3;
+
         public override (T1, T2, T3) Read(ref CborReader reader)
         {
-            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
-            // value off whatever header is current without asking which major type it belongs to, so
-            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
-            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
-            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
-            // and which this converter needs, being the only one that reaches the reader below its
-            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
-            // fraction under an outer tag reads as a two-element array here as it does everywhere
-            // else.
-            reader.ReadBeginArray();
+            return TupleReader.Read<(T1, T2, T3)>(ref reader, this);
+        }
 
-            int size = reader.ReadSize();
-
-            if (size != -1 && size != 3)
-            {
-                throw new CborException("Expected CBOR Array of size 3");
-            }
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 3");
-            }
-            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 3");
-            }
-            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 3");
-            }
-            T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
-
-            return (item1, item2, item3);
+        public (T1, T2, T3) ReadItems(ref CborReader reader, int size, int arity, ref int index)
+        {
+            return (
+                TupleItemReader.ReadItem(ref reader, _item1Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item2Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item3Converter, size, arity, ref index));
         }
 
         public override void Write(ref CborWriter writer, (T1, T2, T3) value, LengthMode lengthMode)
         {
-            lengthMode = lengthMode != LengthMode.Default ? lengthMode : _options.ArrayLengthMode;
-            int size = lengthMode == LengthMode.IndefiniteLength ? -1 : 3;
+            TupleWriter.Write(ref writer, this, value, lengthMode, _options);
+        }
 
-            writer.WriteBeginArray(size);
+        public void WriteItems(ref CborWriter writer, (T1, T2, T3) value)
+        {
             _item1Converter.Write(ref writer, value.Item1);
             _item2Converter.Write(ref writer, value.Item2);
             _item3Converter.Write(ref writer, value.Item3);
-            writer.WriteEndArray(size);
         }
     }
 
-    public class Tuple4Converter<T1, T2, T3, T4> : CborConverterBase<(T1, T2, T3, T4)>
+    public class Tuple4Converter<T1, T2, T3, T4> : CborConverterBase<(T1, T2, T3, T4)>, ICborTupleItems<(T1, T2, T3, T4)>
     {
         private readonly CborOptions _options;
         private readonly ICborConverter<T1> _item1Converter;
@@ -170,68 +266,37 @@
             _item4Converter = options.Registry.ConverterRegistry.Lookup<T4>();
         }
 
+        public int ItemCount => 4;
+
         public override (T1, T2, T3, T4) Read(ref CborReader reader)
         {
-            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
-            // value off whatever header is current without asking which major type it belongs to, so
-            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
-            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
-            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
-            // and which this converter needs, being the only one that reaches the reader below its
-            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
-            // fraction under an outer tag reads as a two-element array here as it does everywhere
-            // else.
-            reader.ReadBeginArray();
+            return TupleReader.Read<(T1, T2, T3, T4)>(ref reader, this);
+        }
 
-            int size = reader.ReadSize();
-
-            if (size != -1 && size != 4)
-            {
-                throw new CborException("Expected CBOR Array of size 4");
-            }
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 4");
-            }
-            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 4");
-            }
-            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 4");
-            }
-            T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 4");
-            }
-            T4 item4 = TupleItemReader.Read(ref reader, _item4Converter, 3);
-
-            return (item1, item2, item3, item4);
+        public (T1, T2, T3, T4) ReadItems(ref CborReader reader, int size, int arity, ref int index)
+        {
+            return (
+                TupleItemReader.ReadItem(ref reader, _item1Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item2Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item3Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item4Converter, size, arity, ref index));
         }
 
         public override void Write(ref CborWriter writer, (T1, T2, T3, T4) value, LengthMode lengthMode)
         {
-            lengthMode = lengthMode != LengthMode.Default ? lengthMode : _options.ArrayLengthMode;
-            int size = lengthMode == LengthMode.IndefiniteLength ? -1 : 4;
+            TupleWriter.Write(ref writer, this, value, lengthMode, _options);
+        }
 
-            writer.WriteBeginArray(size);
+        public void WriteItems(ref CborWriter writer, (T1, T2, T3, T4) value)
+        {
             _item1Converter.Write(ref writer, value.Item1);
             _item2Converter.Write(ref writer, value.Item2);
             _item3Converter.Write(ref writer, value.Item3);
             _item4Converter.Write(ref writer, value.Item4);
-            writer.WriteEndArray(size);
         }
     }
 
-    public class Tuple5Converter<T1, T2, T3, T4, T5> : CborConverterBase<(T1, T2, T3, T4, T5)>
+    public class Tuple5Converter<T1, T2, T3, T4, T5> : CborConverterBase<(T1, T2, T3, T4, T5)>, ICborTupleItems<(T1, T2, T3, T4, T5)>
     {
         private readonly CborOptions _options;
         private readonly ICborConverter<T1> _item1Converter;
@@ -250,75 +315,39 @@
             _item5Converter = options.Registry.ConverterRegistry.Lookup<T5>();
         }
 
+        public int ItemCount => 5;
+
         public override (T1, T2, T3, T4, T5) Read(ref CborReader reader)
         {
-            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
-            // value off whatever header is current without asking which major type it belongs to, so
-            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
-            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
-            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
-            // and which this converter needs, being the only one that reaches the reader below its
-            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
-            // fraction under an outer tag reads as a two-element array here as it does everywhere
-            // else.
-            reader.ReadBeginArray();
+            return TupleReader.Read<(T1, T2, T3, T4, T5)>(ref reader, this);
+        }
 
-            int size = reader.ReadSize();
-
-            if (size != -1 && size != 5)
-            {
-                throw new CborException("Expected CBOR Array of size 5");
-            }
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 5");
-            }
-            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 5");
-            }
-            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 5");
-            }
-            T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 5");
-            }
-            T4 item4 = TupleItemReader.Read(ref reader, _item4Converter, 3);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 5");
-            }
-            T5 item5 = TupleItemReader.Read(ref reader, _item5Converter, 4);
-
-            return (item1, item2, item3, item4, item5);
+        public (T1, T2, T3, T4, T5) ReadItems(ref CborReader reader, int size, int arity, ref int index)
+        {
+            return (
+                TupleItemReader.ReadItem(ref reader, _item1Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item2Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item3Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item4Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item5Converter, size, arity, ref index));
         }
 
         public override void Write(ref CborWriter writer, (T1, T2, T3, T4, T5) value, LengthMode lengthMode)
         {
-            lengthMode = lengthMode != LengthMode.Default ? lengthMode : _options.ArrayLengthMode;
-            int size = lengthMode == LengthMode.IndefiniteLength ? -1 : 5;
+            TupleWriter.Write(ref writer, this, value, lengthMode, _options);
+        }
 
-            writer.WriteBeginArray(size);
+        public void WriteItems(ref CborWriter writer, (T1, T2, T3, T4, T5) value)
+        {
             _item1Converter.Write(ref writer, value.Item1);
             _item2Converter.Write(ref writer, value.Item2);
             _item3Converter.Write(ref writer, value.Item3);
             _item4Converter.Write(ref writer, value.Item4);
             _item5Converter.Write(ref writer, value.Item5);
-            writer.WriteEndArray(size);
         }
     }
 
-    public class Tuple6Converter<T1, T2, T3, T4, T5, T6> : CborConverterBase<(T1, T2, T3, T4, T5, T6)>
+    public class Tuple6Converter<T1, T2, T3, T4, T5, T6> : CborConverterBase<(T1, T2, T3, T4, T5, T6)>, ICborTupleItems<(T1, T2, T3, T4, T5, T6)>
     {
         private readonly CborOptions _options;
         private readonly ICborConverter<T1> _item1Converter;
@@ -339,82 +368,41 @@
             _item6Converter = options.Registry.ConverterRegistry.Lookup<T6>();
         }
 
+        public int ItemCount => 6;
+
         public override (T1, T2, T3, T4, T5, T6) Read(ref CborReader reader)
         {
-            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
-            // value off whatever header is current without asking which major type it belongs to, so
-            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
-            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
-            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
-            // and which this converter needs, being the only one that reaches the reader below its
-            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
-            // fraction under an outer tag reads as a two-element array here as it does everywhere
-            // else.
-            reader.ReadBeginArray();
+            return TupleReader.Read<(T1, T2, T3, T4, T5, T6)>(ref reader, this);
+        }
 
-            int size = reader.ReadSize();
-
-            if (size != -1 && size != 6)
-            {
-                throw new CborException("Expected CBOR Array of size 6");
-            }
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 6");
-            }
-            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 6");
-            }
-            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 6");
-            }
-            T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 6");
-            }
-            T4 item4 = TupleItemReader.Read(ref reader, _item4Converter, 3);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 6");
-            }
-            T5 item5 = TupleItemReader.Read(ref reader, _item5Converter, 4);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 6");
-            }
-            T6 item6 = TupleItemReader.Read(ref reader, _item6Converter, 5);
-
-            return (item1, item2, item3, item4, item5, item6);
+        public (T1, T2, T3, T4, T5, T6) ReadItems(ref CborReader reader, int size, int arity, ref int index)
+        {
+            return (
+                TupleItemReader.ReadItem(ref reader, _item1Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item2Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item3Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item4Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item5Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item6Converter, size, arity, ref index));
         }
 
         public override void Write(ref CborWriter writer, (T1, T2, T3, T4, T5, T6) value, LengthMode lengthMode)
         {
-            lengthMode = lengthMode != LengthMode.Default ? lengthMode : _options.ArrayLengthMode;
-            int size = lengthMode == LengthMode.IndefiniteLength ? -1 : 6;
+            TupleWriter.Write(ref writer, this, value, lengthMode, _options);
+        }
 
-            writer.WriteBeginArray(size);
+        public void WriteItems(ref CborWriter writer, (T1, T2, T3, T4, T5, T6) value)
+        {
             _item1Converter.Write(ref writer, value.Item1);
             _item2Converter.Write(ref writer, value.Item2);
             _item3Converter.Write(ref writer, value.Item3);
             _item4Converter.Write(ref writer, value.Item4);
             _item5Converter.Write(ref writer, value.Item5);
             _item6Converter.Write(ref writer, value.Item6);
-            writer.WriteEndArray(size);
         }
     }
 
-    public class Tuple7Converter<T1, T2, T3, T4, T5, T6, T7> : CborConverterBase<(T1, T2, T3, T4, T5, T6, T7)>
+    public class Tuple7Converter<T1, T2, T3, T4, T5, T6, T7> : CborConverterBase<(T1, T2, T3, T4, T5, T6, T7)>, ICborTupleItems<(T1, T2, T3, T4, T5, T6, T7)>
     {
         private readonly CborOptions _options;
         private readonly ICborConverter<T1> _item1Converter;
@@ -437,77 +425,32 @@
             _item7Converter = options.Registry.ConverterRegistry.Lookup<T7>();
         }
 
+        public int ItemCount => 7;
+
         public override (T1, T2, T3, T4, T5, T6, T7) Read(ref CborReader reader)
         {
-            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
-            // value off whatever header is current without asking which major type it belongs to, so
-            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
-            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
-            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
-            // and which this converter needs, being the only one that reaches the reader below its
-            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
-            // fraction under an outer tag reads as a two-element array here as it does everywhere
-            // else.
-            reader.ReadBeginArray();
+            return TupleReader.Read<(T1, T2, T3, T4, T5, T6, T7)>(ref reader, this);
+        }
 
-            int size = reader.ReadSize();
-
-            if (size != -1 && size != 7)
-            {
-                throw new CborException("Expected CBOR Array of size 7");
-            }
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 7");
-            }
-            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 7");
-            }
-            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 7");
-            }
-            T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 7");
-            }
-            T4 item4 = TupleItemReader.Read(ref reader, _item4Converter, 3);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 7");
-            }
-            T5 item5 = TupleItemReader.Read(ref reader, _item5Converter, 4);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 7");
-            }
-            T6 item6 = TupleItemReader.Read(ref reader, _item6Converter, 5);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 7");
-            }
-            T7 item7 = TupleItemReader.Read(ref reader, _item7Converter, 6);
-
-            return (item1, item2, item3, item4, item5, item6, item7);
+        public (T1, T2, T3, T4, T5, T6, T7) ReadItems(ref CborReader reader, int size, int arity, ref int index)
+        {
+            return (
+                TupleItemReader.ReadItem(ref reader, _item1Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item2Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item3Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item4Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item5Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item6Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item7Converter, size, arity, ref index));
         }
 
         public override void Write(ref CborWriter writer, (T1, T2, T3, T4, T5, T6, T7) value, LengthMode lengthMode)
         {
-            lengthMode = lengthMode != LengthMode.Default ? lengthMode : _options.ArrayLengthMode;
-            int size = lengthMode == LengthMode.IndefiniteLength ? -1 : 7;
+            TupleWriter.Write(ref writer, this, value, lengthMode, _options);
+        }
 
-            writer.WriteBeginArray(size);
+        public void WriteItems(ref CborWriter writer, (T1, T2, T3, T4, T5, T6, T7) value)
+        {
             _item1Converter.Write(ref writer, value.Item1);
             _item2Converter.Write(ref writer, value.Item2);
             _item3Converter.Write(ref writer, value.Item3);
@@ -515,11 +458,29 @@
             _item5Converter.Write(ref writer, value.Item5);
             _item6Converter.Write(ref writer, value.Item6);
             _item7Converter.Write(ref writer, value.Item7);
-            writer.WriteEndArray(size);
         }
     }
 
-    public class Tuple8Converter<T1, T2, T3, T4, T5, T6, T7, T8> : CborConverterBase<(T1, T2, T3, T4, T5, T6, T7, T8)>
+    /// <summary>
+    /// Seven items and a <c>Rest</c> holding the overflow: how C# represents every tuple of more than
+    /// seven elements, at every arity, since a <c>Rest</c> of more than seven nests again.
+    /// </summary>
+    /// <remarks>
+    /// The base type is spelled <c>ValueTuple&lt;...&gt;</c> rather than <c>(T1, ..., TRest)</c>
+    /// deliberately. The tuple syntax would expand to
+    /// <c>ValueTuple&lt;T1, ..., T7, ValueTuple&lt;TRest&gt;&gt;</c> -- one level deeper than the type
+    /// being converted -- which is exactly how this class came to be unreachable: the provider handed it
+    /// the <c>Rest</c> field's type as an eighth element, so the converter built was for a different
+    /// closed type than the one asked for, and the cast to it failed.
+    /// <para>
+    /// Delegating to the <c>Rest</c>'s own items is what makes every arity work with these eight
+    /// classes and keeps the encoding flat: a nine-element tuple is <c>[1, ..., 9]</c>.
+    /// </para>
+    /// </remarks>
+    public class Tuple8Converter<T1, T2, T3, T4, T5, T6, T7, TRest>
+        : CborConverterBase<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>,
+          ICborTupleItems<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>
+        where TRest : struct
     {
         private readonly CborOptions _options;
         private readonly ICborConverter<T1> _item1Converter;
@@ -529,7 +490,7 @@
         private readonly ICborConverter<T5> _item5Converter;
         private readonly ICborConverter<T6> _item6Converter;
         private readonly ICborConverter<T7> _item7Converter;
-        private readonly ICborConverter<T8> _item8Converter;
+        private readonly ICborTupleItems<TRest> _restItems;
 
         public Tuple8Converter(CborOptions options)
         {
@@ -541,86 +502,45 @@
             _item5Converter = options.Registry.ConverterRegistry.Lookup<T5>();
             _item6Converter = options.Registry.ConverterRegistry.Lookup<T6>();
             _item7Converter = options.Registry.ConverterRegistry.Lookup<T7>();
-            _item8Converter = options.Registry.ConverterRegistry.Lookup<T8>();
-        }
-        public override (T1, T2, T3, T4, T5, T6, T7, T8) Read(ref CborReader reader)
-        {
-            // ReadBeginArray rather than going straight to ReadSize. ReadSize takes the additional
-            // value off whatever header is current without asking which major type it belongs to, so
-            // bytes(3), text(3), map(3) and even the bare unsigned integer 3 all yielded an arity of
-            // 3 and decoded as a tuple; ReadBeginArray is where every other array reader gets that
-            // check. It also steps over the whole stack of semantic tags, which ReadSize does not
-            // and which this converter needs, being the only one that reaches the reader below its
-            // tag-skipping entry points - a tagged tuple stays readable, and a tag 4 decimal
-            // fraction under an outer tag reads as a two-element array here as it does everywhere
-            // else.
-            reader.ReadBeginArray();
 
-            int size = reader.ReadSize();
-
-            if (size != -1 && size != 8)
-            {
-                throw new CborException("Expected CBOR Array of size 8");
-            }
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 8");
-            }
-            T1 item1 = TupleItemReader.Read(ref reader, _item1Converter, 0);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 8");
-            }
-            T2 item2 = TupleItemReader.Read(ref reader, _item2Converter, 1);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 8");
-            }
-            T3 item3 = TupleItemReader.Read(ref reader, _item3Converter, 2);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 8");
-            }
-            T4 item4 = TupleItemReader.Read(ref reader, _item4Converter, 3);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 8");
-            }
-            T5 item5 = TupleItemReader.Read(ref reader, _item5Converter, 4);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 8");
-            }
-            T6 item6 = TupleItemReader.Read(ref reader, _item6Converter, 5);
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 8");
-            }
-            T7 item7 = TupleItemReader.Read(ref reader, _item7Converter, 6);
-
-
-            if (size == -1 && reader.IsBreak())
-            {
-                throw new CborException("Expected CBOR Array of size 8");
-            }
-            T8 item8 = TupleItemReader.Read(ref reader, _item8Converter, 7);
-
-            return (item1, item2, item3, item4, item5, item6, item7, item8);
+            // The overflow is a tuple in its own right, and its converter contributes items to the array
+            // this one opens rather than opening another. Asking the registry and then testing for the
+            // internal interface is the shape AbstractCollectionConverter uses to find a typed array's
+            // reader, for the same reason: the constraint the interface needs cannot be stated here.
+            _restItems = options.Registry.ConverterRegistry.Lookup<TRest>() as ICborTupleItems<TRest>
+                ?? throw new CborException(
+                    $"A tuple's Rest must itself be a tuple, and {typeof(TRest)} is not");
         }
 
-        public override void Write(ref CborWriter writer, (T1, T2, T3, T4, T5, T6, T7, T8) value, LengthMode lengthMode)
-        {
-            lengthMode = lengthMode != LengthMode.Default ? lengthMode : _options.ArrayLengthMode;
-            int size = lengthMode == LengthMode.IndefiniteLength ? -1 : 8;
+        public int ItemCount => 7 + _restItems.ItemCount;
 
-            writer.WriteBeginArray(size);
+        public override ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> Read(ref CborReader reader)
+        {
+            return TupleReader.Read<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>(ref reader, this);
+        }
+
+        public ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> ReadItems(
+            ref CborReader reader, int size, int arity, ref int index)
+        {
+            return new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(
+                TupleItemReader.ReadItem(ref reader, _item1Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item2Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item3Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item4Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item5Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item6Converter, size, arity, ref index),
+                TupleItemReader.ReadItem(ref reader, _item7Converter, size, arity, ref index),
+                _restItems.ReadItems(ref reader, size, arity, ref index));
+        }
+
+        public override void Write(
+            ref CborWriter writer, ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> value, LengthMode lengthMode)
+        {
+            TupleWriter.Write(ref writer, this, value, lengthMode, _options);
+        }
+
+        public void WriteItems(ref CborWriter writer, ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> value)
+        {
             _item1Converter.Write(ref writer, value.Item1);
             _item2Converter.Write(ref writer, value.Item2);
             _item3Converter.Write(ref writer, value.Item3);
@@ -628,8 +548,7 @@
             _item5Converter.Write(ref writer, value.Item5);
             _item6Converter.Write(ref writer, value.Item6);
             _item7Converter.Write(ref writer, value.Item7);
-            _item8Converter.Write(ref writer, value.Item8);
-            writer.WriteEndArray(size);
+            _restItems.WriteItems(ref writer, value.Rest);
         }
     }
 }


### PR DESCRIPTION
Closes #198, taking the flat encoding from the [investigation](https://github.com/dahomey-technologies/Dahomey.Cbor/issues/198#issuecomment-5280922038), and makes tuples work under Native AOT while it is there. **1900 library tests plus 35 generator tests**, green on net10.0; all four TFMs build.

Two commits, each standing on its own: the runtime fix, then the generator.

## The wire form

```
(1, "two")                    ->  82 01 63 74776F
(1, …, 9)                     ->  89 01 02 03 04 05 06 07 08 09
fifteen elements              ->  8F 01 … 0F
```

C# represents a tuple past seven elements as seven fields plus a `Rest`, and nests again every seven after that. That is a detail of the language, not something the format knows, so the overflow's converter contributes its items to the array the outer one opened rather than opening one of its own. A nine-element tuple is nine items.

## Why the eight converters cover every arity

This is the part that made it cheap. `Tuple8Converter<T1, …, T7, TRest>` delegates to `TRest`'s own items, so it handles arity 8 through 14 with a flat `Rest`, then 15 through 21 by recursing into itself, and so on without limit. **The provider's `default:` is now unreachable for a real tuple** — C# never gives one more than eight fields.

That is variadic in the only sense C# offers, and it is how the BCL states the same thing: `ValueTuple` has seven flat arities plus a recursive eighth, and so now do the converters. The two genuinely variadic alternatives are both worse here — `ITuple` boxes every element and cannot construct one back, and reflection over the fields is what a generated context exists to avoid.

`Tuple1Converter` is new because an eight-element tuple's `Rest` is exactly a one-element tuple. C# has no literal for one; it is an array of one item like any other tuple.

## It is a net deletion

The array around the items is now stated once, in `TupleReader` and `TupleWriter`: `ReadBeginArray`, the size check, the break checks between items, the trailing break, and the length mode. Each arity keeps only its items. **`TupleConverter.cs` is 80 lines shorter than when it covered seven arities**, and `Tuple2Converter` went from 58 lines to 37.

The eighth element was never wrong in the converter, incidentally — `Tuple8Converter` already declared `CborConverterBase<(T1, …, T8)>` and read eight items. Only what the provider handed it was.

## Native AOT

A tuple member on a `[CborSerializable]` type was `CBOR1002`: the generator saw an unrecognised generic type and refused to build. So tuples were unavailable to exactly the applications the generated path exists for, since the reflection provider resolves their converters through `Type.MakeGenericType`.

The generator now classifies a `ValueTuple` as its own kind and writes the instantiation out — `new Tuple2Converter<int, string>`, and for a longer tuple `new Tuple8Converter<…, ValueTuple<int, int>>` together with the `Rest`'s own converter, which the dependency ordering registers first because `Tuple8Converter` asks the registry for it while being constructed.

Detection is by metadata name rather than `IsTupleType`, which is **false** for the one-element `ValueTuple<T>` — C# has no tuple syntax for a single element, and that arity is exactly what an eight-element tuple's `Rest` is.

**Proven on a real native binary**, not on the analyzers: a probe with `PublishAot` inside the csproj and gcc as the linker, over a context carrying arity 2, 9 and 15 plus a nullable tuple.

```
written : A4645061697282016374776F644E696E6589010203040506070809674669667465656E8F01…0F684F7074696F6E616C820765736576656E
expected: A4645061697282016374776F644E696E6589010203040506070809674669667465656E8F01…0F684F7074696F6E616C820765736576656E
ROUND TRIP OK
```

The expected bytes are the reflection path's, captured on CoreCLR, so the native binary is held to byte identity rather than to merely producing something. The probe exercises only the generated path, since a plain `CborOptions` over the same model is the failure the context exists to prevent.

## What still cannot be AOT, and why

Documented in the README rather than left implicit. **Without a context, a tuple needs the reflection provider, which Native AOT cannot serve** — `TupleConverterProvider` reads the fields and calls `MakeGenericType`, and the AOT analyzer says so (`IL2070` on `GetFields`, `IL3050` on `MakeGenericType`). That is the same requirement as for every other generic converter here — collections, dictionaries, nullables — and not specific to tuples, so the README says it that way. `System.Tuple<…>`, the class, is not a tuple to this library at all and is unchanged.

## CDDL

A tuple renders as a fixed heterogeneous array with the `Rest` chain flattened — `[int, tstr]` — because that is what the writer emits. Not `[* X]`, which would say any length of one type. Validated with the gem against a real instance.

## Interaction with #210

This supersedes it: the trailing-break check #199 asked for now lives in `TupleReader.Read` instead of in each of the seven arities, and `ConsumeBreak` becomes `internal` here too. Happy to close #210, or to rebase this on top of it if you would rather have that one first — say which.

---
_Generated by [Claude Code](https://claude.ai/code)_
