### PR TITLE
Let a converter's own exception reach the caller, closes #216

### DIFF
--- a/src/Dahomey.Cbor.Tests/IntDiscriminatorTests.cs
+++ b/src/Dahomey.Cbor.Tests/IntDiscriminatorTests.cs
@@ -19,26 +19,6 @@ namespace Dahomey.Cbor.Tests
             return Cbor.Deserialize<T>(hexBuffer.HexToBytes(), options);
         }
 
-        /// <summary>
-        /// Converter construction happens through <see cref="Activator"/>, so a <see cref="CborException"/>
-        /// raised while building an object mapping surfaces wrapped in a <see cref="TargetInvocationException"/>.
-        /// </summary>
-        private static CborException AssertThrowsCborException(Action action)
-        {
-            Exception exception = Assert.ThrowsAny<Exception>(action);
-
-            for (Exception? current = exception; current != null; current = current.InnerException)
-            {
-                if (current is CborException cborException)
-                {
-                    return cborException;
-                }
-            }
-
-            throw new Xunit.Sdk.XunitException(
-                $"Expected a {nameof(CborException)} somewhere in the exception chain, got: {exception}");
-        }
-
         public interface IIntBaseInterface
         {
             int Id { get; set; }
@@ -369,7 +349,7 @@ namespace Dahomey.Cbor.Tests
         {
             CborOptions options = new CborOptions();
 
-            CborException exception = AssertThrowsCborException(
+            CborException exception = Assert.Throws<CborException>(
                 () => Helper.Write<IntBaseObject>(new BothDiscriminatorsObject(), options));
 
             Assert.Contains(nameof(CborDiscriminatorAttribute), exception.Message);
@@ -449,7 +429,7 @@ namespace Dahomey.Cbor.Tests
             // {"_t": "StringDisc", "Name": "foo", "Id": 1} read through the int-claimed base type
             const string hexBuffer = "A3625F746A537472696E6744697363644E616D6563666F6F62496401";
 
-            CborException exception = AssertThrowsCborException(
+            CborException exception = Assert.Throws<CborException>(
                 () => Deserialize<IntBaseObject>(hexBuffer, options));
 
             Assert.Contains("Invalid major type", exception.Message);

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0216.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0216.cs
@@ -1,0 +1,190 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Serialization.Conventions;
+using Dahomey.Cbor.Serialization.Converters;
+using Dahomey.Cbor.Serialization.Converters.Providers;
+using System;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Everything this library builds by reflection is built with <c>Activator.CreateInstance</c>, which
+    /// wraps whatever the constructor threw in a <see cref="System.Reflection.TargetInvocationException"/>.
+    /// A caller's <c>catch (CborException)</c> — the one the rest of the API trains them into — misses
+    /// every one of these.
+    /// </summary>
+    /// <remarks>
+    /// The point is the envelope, not the message: each of these threw the right <c>CborException</c> all
+    /// along, and it arrived as something else. The cases below are the four places a constructor can run
+    /// code that fails — the converter a provider builds, a member's own <c>[CborConverter]</c>, a type's
+    /// object mapping, and a <c>[CborNamingConvention]</c> — which is every reflective construction site
+    /// where the thing being constructed can refuse.
+    /// </remarks>
+    public class Issue0216
+    {
+        /// <summary>
+        /// A converter built through a provider. <c>CborConverterProviderBase</c> is public and
+        /// <c>CreateConverter</c> is protected, so this is the supported extension point rather than a
+        /// contrivance; in-library converters reach it the same way.
+        /// </summary>
+        [Fact]
+        public void AConverterRefusingItsTypeThrowsCborException()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ConverterRegistry.RegisterConverterProvider(new RefusingConverterProvider());
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Helper.Write(new RefusedByItsConverter(), options));
+
+            Assert.Equal("this type is refused by its converter", exception.Message);
+        }
+
+        /// <summary>A member's own <c>[CborConverter]</c>, which is a type the caller named.</summary>
+        [Fact]
+        public void AMemberConverterRefusingItsTypeThrowsCborException()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Helper.Write(new HolderWithARefusingMemberConverter()));
+
+            Assert.Equal("this member is refused by its converter", exception.Message);
+        }
+
+        /// <summary>
+        /// An object mapping that refuses itself while being built. This is the one an ordinary user
+        /// reaches without writing a converter at all: two members under one CBOR name, which the mapping
+        /// validation refuses.
+        /// </summary>
+        [Fact]
+        public void AMappingRefusingItselfThrowsCborException()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Helper.Write(new TwoMembersUnderOneName()));
+
+            Assert.Contains("TwoMembersUnderOneName", exception.Message);
+        }
+
+        /// <summary>A <c>[CborNamingConvention]</c> whose constructor refuses.</summary>
+        [Fact]
+        public void ANamingConventionRefusingItselfThrowsCborException()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Helper.Write(new HolderWithARefusingNamingConvention()));
+
+            Assert.Equal("this naming convention is refused", exception.Message);
+        }
+
+        /// <summary>
+        /// The unwrap must not swallow anything: an exception that is not a <c>CborException</c> reaches
+        /// the caller as itself rather than as a <c>TargetInvocationException</c> around it, and keeps the
+        /// stack frame it was thrown from.
+        /// </summary>
+        [Fact]
+        public void AnExceptionOfAnotherTypeIsNotConvertedOrSwallowed()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ConverterRegistry.RegisterConverterProvider(new ThrowingConverterProvider());
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                () => Helper.Write(new RefusedByAnotherException(), options));
+
+            Assert.Equal("not a CborException", exception.Message);
+            Assert.Contains(nameof(ThrowingConverter<int>), exception.StackTrace);
+        }
+
+        public class RefusedByItsConverter
+        {
+        }
+
+        public class RefusedByAnotherException
+        {
+        }
+
+        public class RefusingConverter<T> : CborConverterBase<T>
+        {
+            public RefusingConverter()
+            {
+                throw new CborException("this type is refused by its converter");
+            }
+
+            public override T Read(ref CborReader reader) => throw new NotSupportedException();
+
+            public override void Write(ref CborWriter writer, T value) => throw new NotSupportedException();
+        }
+
+        public class ThrowingConverter<T> : CborConverterBase<T>
+        {
+            public ThrowingConverter()
+            {
+                throw new InvalidOperationException("not a CborException");
+            }
+
+            public override T Read(ref CborReader reader) => throw new NotSupportedException();
+
+            public override void Write(ref CborWriter writer, T value) => throw new NotSupportedException();
+        }
+
+        public class RefusingConverterProvider : CborConverterProviderBase
+        {
+            public override ICborConverter? GetConverter(Type type, CborOptions options)
+            {
+                return type == typeof(RefusedByItsConverter)
+                    ? CreateGenericConverter(options, typeof(RefusingConverter<>), type)
+                    : null;
+            }
+        }
+
+        public class ThrowingConverterProvider : CborConverterProviderBase
+        {
+            public override ICborConverter? GetConverter(Type type, CborOptions options)
+            {
+                return type == typeof(RefusedByAnotherException)
+                    ? CreateGenericConverter(options, typeof(ThrowingConverter<>), type)
+                    : null;
+            }
+        }
+
+        public class RefusingMemberConverter : CborConverterBase<int>
+        {
+            public RefusingMemberConverter()
+            {
+                throw new CborException("this member is refused by its converter");
+            }
+
+            public override int Read(ref CborReader reader) => throw new NotSupportedException();
+
+            public override void Write(ref CborWriter writer, int value) => throw new NotSupportedException();
+        }
+
+        public class HolderWithARefusingMemberConverter
+        {
+            [CborConverter(typeof(RefusingMemberConverter))]
+            public int Value { get; set; }
+        }
+
+        public class TwoMembersUnderOneName
+        {
+            [CborProperty("x")]
+            public int First { get; set; }
+
+            [CborProperty("x")]
+            public int Second { get; set; }
+        }
+
+        public class RefusingNamingConvention : INamingConvention
+        {
+            public RefusingNamingConvention()
+            {
+                throw new CborException("this naming convention is refused");
+            }
+
+            public string GetPropertyName(System.Reflection.MemberInfo memberInfo) => memberInfo.Name;
+        }
+
+        [CborNamingConvention(typeof(RefusingNamingConvention))]
+        public class HolderWithARefusingNamingConvention
+        {
+            public int Value { get; set; }
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0216.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0216.cs
@@ -3,6 +3,7 @@ using Dahomey.Cbor.Serialization;
 using Dahomey.Cbor.Serialization.Conventions;
 using Dahomey.Cbor.Serialization.Converters;
 using Dahomey.Cbor.Serialization.Converters.Providers;
+using Dahomey.Cbor.Tests.Extensions;
 using System;
 using Xunit;
 
@@ -72,6 +73,47 @@ namespace Dahomey.Cbor.Tests.Issues
                 () => Helper.Write(new HolderWithARefusingNamingConvention()));
 
             Assert.Equal("this naming convention is refused", exception.Message);
+        }
+
+        /// <summary>
+        /// A <c>[CborConstructor]</c> the caller wrote, running while a document is read rather than
+        /// while a mapping is built. <c>CreatorMapping</c> reaches it through
+        /// <c>Delegate.DynamicInvoke</c>, which wraps a constructor's exception exactly as
+        /// <c>Activator</c> does.
+        /// </summary>
+        /// <remarks>
+        /// The closest of these to an ordinary user: nothing here is a converter, a provider or a
+        /// convention — it is a constructor on their own type, refusing the values a document carried.
+        /// </remarks>
+        [Fact]
+        public void ACreatorConstructorRefusingItsArgumentsThrowsCborException()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<RefusedByItsCreator>("A16249640C".HexToBytes()));   // {"Id": 12}
+
+            Assert.StartsWith("this creator refuses 12", exception.Message);
+
+            // The path is the second thing the envelope cost. It is prepended by a `catch
+            // (CborException)` on the way out, which a TargetInvocationException did not match -- so
+            // before this fix a creator's refusal arrived with no path at all.
+            Assert.Equal("$", exception.Path);
+        }
+
+        /// <summary>The same through a factory method, which <c>MapCreator(MethodInfo)</c> reaches.</summary>
+        [Fact]
+        public void ACreatorFactoryRefusingItsArgumentsThrowsCborException()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ObjectMappingRegistry.Register<RefusedByItsFactory>(map =>
+            {
+                map.AutoMap();
+                map.MapCreator(o => RefusedByItsFactory.Create(o.Id));
+            });
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<RefusedByItsFactory>("A16249640C".HexToBytes(), options));
+
+            Assert.StartsWith("this factory refuses 12", exception.Message);
         }
 
         /// <summary>
@@ -169,6 +211,27 @@ namespace Dahomey.Cbor.Tests.Issues
 
             [CborProperty("x")]
             public int Second { get; set; }
+        }
+
+        public class RefusedByItsCreator
+        {
+            public int Id { get; set; }
+
+            [CborConstructor]
+            public RefusedByItsCreator(int id)
+            {
+                throw new CborException($"this creator refuses {id}");
+            }
+        }
+
+        public class RefusedByItsFactory
+        {
+            public int Id { get; set; }
+
+            public static RefusedByItsFactory Create(int id)
+            {
+                throw new CborException($"this factory refuses {id}");
+            }
         }
 
         public class RefusingNamingConvention : INamingConvention

--- a/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
+++ b/src/Dahomey.Cbor.Tests/TypedArrayTests.cs
@@ -215,51 +215,32 @@ namespace Dahomey.Cbor.Tests
                 Helper.Read<float[]>("D851483FC0000040200000", TypedArrayOptions()));
         }
 
-        private static CborException AssertThrowsCborException(Action action)
-        {
-            // Converters are built through Activator.CreateInstance, so a CborException thrown while
-            // building a mapping arrives wrapped in TargetInvocationException.
-            Exception exception = Record.Exception(action);
-            Assert.NotNull(exception);
-
-            for (Exception current = exception; current != null; current = current.InnerException)
-            {
-                if (current is CborException cborException)
-                {
-                    return cborException;
-                }
-            }
-
-            Assert.Fail($"Expected a CborException, got {exception}");
-            return null;
-        }
-
         [Fact]
         public void PayloadLengthNotAMultipleOfElementSizeThrows()
         {
             // D855 tag(85) 43 bytes(3) -- 3 is not divisible by 4
-            AssertThrowsCborException(() => Helper.Read<float[]>("D85543000000", TypedArrayOptions()));
+            Assert.Throws<CborException>(() => Helper.Read<float[]>("D85543000000", TypedArrayOptions()));
         }
 
         [Fact]
         public void WrongElementTypeThrows()
         {
             // D856 tag(86) is binary64; reading it into float[] is corrupt data, not a conversion
-            AssertThrowsCborException(() => Helper.Read<float[]>("D85648000000000000F83F", TypedArrayOptions()));
+            Assert.Throws<CborException>(() => Helper.Read<float[]>("D85648000000000000F83F", TypedArrayOptions()));
         }
 
         [Fact]
         public void ReservedTag76Throws()
         {
             // D84C tag(76) is reserved by RFC 8746
-            AssertThrowsCborException(() => Helper.Read<short[]>("D84C4401000200", TypedArrayOptions()));
+            Assert.Throws<CborException>(() => Helper.Read<short[]>("D84C4401000200", TypedArrayOptions()));
         }
 
         [Fact]
         public void Binary128TagThrows()
         {
             // D853 tag(83) 40 bytes(0) -- binary128, which has no .NET type
-            AssertThrowsCborException(() => Helper.Read<double[]>("D85340", TypedArrayOptions()));
+            Assert.Throws<CborException>(() => Helper.Read<double[]>("D85340", TypedArrayOptions()));
         }
 
         [Fact]
@@ -597,7 +578,7 @@ namespace Dahomey.Cbor.Tests
 
             // D855 tag(85) 48 bytes(8) -> 1.5f, 2.5f little endian. The tag is skipped like any other
             // unrecognised tag, leaving a byte string where an array is required.
-            AssertThrowsCborException(() => Helper.Read<float[]>("D855480000C03F00002040", options));
+            Assert.Throws<CborException>(() => Helper.Read<float[]>("D855480000C03F00002040", options));
 
             // 82 array(2) F93E00 1.5 F94100 2.5 -- ordinary arrays are unaffected, in both directions
             Helper.TestWrite(new[] { 1.5f, 2.5f }, "82F93E00F94100", null, options);
@@ -634,7 +615,7 @@ namespace Dahomey.Cbor.Tests
             Helper.TestWrite(new[] { 1.5f, 2.5f }, "D855480000C03F00002040", null, options);
 
             // and, being write-only, these options cannot read back what they just wrote
-            AssertThrowsCborException(() => Helper.Read<float[]>("D855480000C03F00002040", options));
+            Assert.Throws<CborException>(() => Helper.Read<float[]>("D855480000C03F00002040", options));
         }
 
         public class ListSamplesHolder
@@ -699,11 +680,11 @@ namespace Dahomey.Cbor.Tests
             CborOptions options = TypedArrayOptions();
 
             // tag 86 is binary64, so it cannot fill a List<float>
-            AssertThrowsCborException(
+            Assert.Throws<CborException>(
                 () => Cbor.Deserialize<List<float>>("D85648000000000000F83F".HexToBytes(), options));
 
             // and a List<string> has no typed array form at all
-            AssertThrowsCborException(
+            Assert.Throws<CborException>(
                 () => Cbor.Deserialize<List<string>>("D855480000C03F00002040".HexToBytes(), options));
         }
 
@@ -714,7 +695,7 @@ namespace Dahomey.Cbor.Tests
             // exactly what it read before typed arrays existed.
             CborOptions options = new CborOptions();
 
-            AssertThrowsCborException(
+            Assert.Throws<CborException>(
                 () => Cbor.Deserialize<List<float>>("D855480000C03F00002040".HexToBytes(), options));
             Assert.Equal(
                 new[] { 1.5f, 2.5f },

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/CreatorMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/CreatorMapping.cs
@@ -100,7 +100,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                 }
             }
 
-            return _delegate.DynamicInvoke(args) ?? throw new InvalidOperationException($"Cannot instantiate type ({_objectMapping.ObjectType})");
+            return ReflectionActivator.Invoke(_delegate, args) ?? throw new InvalidOperationException($"Cannot instantiate type ({_objectMapping.ObjectType})");
         }
 
         object ICreatorMapping.CreateInstance(Dictionary<int, object> values)
@@ -124,7 +124,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                 }
             }
 
-            return _delegate.DynamicInvoke(args) ?? throw new InvalidOperationException($"Cannot instantiate type ({_objectMapping.ObjectType})");
+            return ReflectionActivator.Invoke(_delegate, args) ?? throw new InvalidOperationException($"Cannot instantiate type ({_objectMapping.ObjectType})");
         }
 
         private void EnsureInitialize()

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
@@ -43,7 +43,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
             if (namingConventionType != null)
             {
-                INamingConvention? namingConvention = (INamingConvention?)Activator.CreateInstance(namingConventionType);
+                INamingConvention? namingConvention = (INamingConvention?)ReflectionActivator.CreateInstance(namingConventionType);
 
                 if (namingConvention == null)
                 {

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
@@ -91,7 +91,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             _converterRegistry = converterRegistry;
             MemberInfo = memberInfo;
             MemberType = memberType;
-            DefaultValue = (memberType.IsClass || memberType.IsInterface) ? null : Activator.CreateInstance(memberType);
+            DefaultValue = (memberType.IsClass || memberType.IsInterface) ? null : ReflectionActivator.CreateInstance(memberType);
         }
 
         public MemberMapping<T> SetMemberName(string memberName)
@@ -176,7 +176,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             }
 
             IMemberConverter? memberConverter = 
-                (IMemberConverter?)Activator.CreateInstance(type, _converterRegistry, this);
+                (IMemberConverter?)ReflectionActivator.CreateInstance(type, _converterRegistry, this);
 
             if (memberConverter == null)
             {
@@ -232,7 +232,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                     Type converterType = converterAttribute.ConverterType;
                     VerifyMemberConverterType(converterType);
 
-                    _converter = (ICborConverter?)Activator.CreateInstance(converterType);
+                    _converter = (ICborConverter?)ReflectionActivator.CreateInstance(converterType);
 
                     if (_converter == null)
                     {

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
@@ -176,7 +176,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             }
 
             IMemberConverter? memberConverter = 
-                (IMemberConverter?)ReflectionActivator.CreateInstance(type, _converterRegistry, this);
+                (IMemberConverter?)ReflectionActivator.CreateInstance(type, new object?[] { _converterRegistry, this });
 
             if (memberConverter == null)
             {

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMappingRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMappingRegistry.cs
@@ -56,7 +56,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             Type objectMappingType = typeof(ObjectMapping<>).MakeGenericType(type);
 
             IObjectMapping? objectMapping =
-                (IObjectMapping?)ReflectionActivator.CreateInstance(objectMappingType, _registry, _options);
+                (IObjectMapping?)ReflectionActivator.CreateInstance(objectMappingType, new object?[] { _registry, _options });
 
             if (objectMapping == null)
             {

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMappingRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMappingRegistry.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Dahomey.Cbor.Util;
+using System;
 using System.Collections.Concurrent;
 
 namespace Dahomey.Cbor.Serialization.Converters.Mappings
@@ -55,7 +56,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             Type objectMappingType = typeof(ObjectMapping<>).MakeGenericType(type);
 
             IObjectMapping? objectMapping =
-                (IObjectMapping?)Activator.CreateInstance(objectMappingType, _registry, _options);
+                (IObjectMapping?)ReflectionActivator.CreateInstance(objectMappingType, _registry, _options);
 
             if (objectMapping == null)
             {

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/CborConverterProviderBase.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/CborConverterProviderBase.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Dahomey.Cbor.Util;
+using System;
 using System.Reflection;
 
 namespace Dahomey.Cbor.Serialization.Converters.Providers
@@ -12,7 +13,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
             ConstructorInfo? constructorInfo = converterType.GetConstructor(new[] { typeof(CborOptions) });
             if (constructorInfo != null)
             {
-                ICborConverter? converter = (ICborConverter?)Activator.CreateInstance(converterType, options);
+                ICborConverter? converter = (ICborConverter?)ReflectionActivator.CreateInstance(converterType, options);
 
                 if (converter == null)
                 {
@@ -25,7 +26,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
             constructorInfo = converterType.GetConstructor(new Type[0]);
             if (constructorInfo != null)
             {
-                ICborConverter? converter = (ICborConverter?)Activator.CreateInstance(converterType);
+                ICborConverter? converter = (ICborConverter?)ReflectionActivator.CreateInstance(converterType);
 
                 if (converter == null)
                 {

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/CborConverterProviderBase.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/CborConverterProviderBase.cs
@@ -13,7 +13,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
             ConstructorInfo? constructorInfo = converterType.GetConstructor(new[] { typeof(CborOptions) });
             if (constructorInfo != null)
             {
-                ICborConverter? converter = (ICborConverter?)ReflectionActivator.CreateInstance(converterType, options);
+                ICborConverter? converter = (ICborConverter?)ReflectionActivator.CreateInstance(converterType, new object?[] { options });
 
                 if (converter == null)
                 {

--- a/src/Dahomey.Cbor/Util/ReflectionActivator.cs
+++ b/src/Dahomey.Cbor/Util/ReflectionActivator.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+
+namespace Dahomey.Cbor.Util
+{
+    /// <summary>
+    /// <see cref="Activator.CreateInstance(Type)"/>, with whatever the constructor threw reaching the
+    /// caller as itself.
+    /// </summary>
+    /// <remarks>
+    /// Activator wraps a constructor's exception in a <see cref="TargetInvocationException"/>, so every
+    /// type this library builds by reflection — a converter, a member's converter, an object mapping, a
+    /// naming convention — reported its refusal in an envelope a caller's <c>catch (CborException)</c>
+    /// does not match. The exception was always the right one; only the envelope was wrong.
+    /// <para>
+    /// <see cref="ExceptionDispatchInfo"/> rather than <c>throw exception.InnerException</c>, which would
+    /// reset the stack trace to this line and lose the frame the refusal actually came from.
+    /// </para>
+    /// <para>
+    /// Each site unwraps one layer, which is what the nesting needs: a construction that itself
+    /// constructs something reflectively wraps twice, as a member's <c>[CborConverter]</c> and a
+    /// <c>[CborNamingConvention]</c> both did.
+    /// </para>
+    /// </remarks>
+    internal static class ReflectionActivator
+    {
+        public static object? CreateInstance(Type type)
+        {
+            try
+            {
+                return Activator.CreateInstance(type);
+            }
+            catch (TargetInvocationException exception) when (exception.InnerException != null)
+            {
+                ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                throw;
+            }
+        }
+
+        public static object? CreateInstance(Type type, params object?[] arguments)
+        {
+            try
+            {
+                return Activator.CreateInstance(type, arguments);
+            }
+            catch (TargetInvocationException exception) when (exception.InnerException != null)
+            {
+                ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                throw;
+            }
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Util/ReflectionActivator.cs
+++ b/src/Dahomey.Cbor/Util/ReflectionActivator.cs
@@ -5,22 +5,31 @@ using System.Runtime.ExceptionServices;
 namespace Dahomey.Cbor.Util
 {
     /// <summary>
-    /// <see cref="Activator.CreateInstance(Type)"/>, with whatever the constructor threw reaching the
-    /// caller as itself.
+    /// Late-bound construction and invocation, with whatever the callee threw reaching the caller as
+    /// itself.
     /// </summary>
     /// <remarks>
-    /// Activator wraps a constructor's exception in a <see cref="TargetInvocationException"/>, so every
-    /// type this library builds by reflection — a converter, a member's converter, an object mapping, a
-    /// naming convention — reported its refusal in an envelope a caller's <c>catch (CborException)</c>
+    /// <see cref="Activator.CreateInstance(Type)"/> and <see cref="Delegate.DynamicInvoke"/> both wrap
+    /// the callee's exception in a <see cref="TargetInvocationException"/>, so a type this library builds
+    /// by reflection — a converter, a member's converter, an object mapping, a naming convention — and a
+    /// creator it invokes reported its refusal in an envelope a caller's <c>catch (CborException)</c>
     /// does not match. The exception was always the right one; only the envelope was wrong.
     /// <para>
     /// <see cref="ExceptionDispatchInfo"/> rather than <c>throw exception.InnerException</c>, which would
-    /// reset the stack trace to this line and lose the frame the refusal actually came from.
+    /// reset the stack trace to this line and lose the frame the refusal came from.
     /// </para>
     /// <para>
-    /// Each site unwraps one layer, which is what the nesting needs: a construction that itself
+    /// Each call site unwraps one layer, which is what the nesting needs: a construction that itself
     /// constructs something reflectively wraps twice, as a member's <c>[CborConverter]</c> and a
-    /// <c>[CborNamingConvention]</c> both did.
+    /// <c>[CborNamingConvention]</c> both do. One layer per site composes correctly — the inner site
+    /// rethrows bare, the outer callee re-wraps once, the outer site unwraps once — and it cannot strip
+    /// an envelope a caller deliberately put on.
+    /// </para>
+    /// <para>
+    /// This covers the sites that go through <see cref="Activator"/> or <see cref="Delegate.DynamicInvoke"/>.
+    /// It is not a claim about every route into user code: a converter's <c>Read</c> and <c>Write</c> are
+    /// called directly and were never wrapped, and an <c>Expression</c>-compiled member accessor invokes
+    /// its target directly too.
     /// </para>
     /// </remarks>
     internal static class ReflectionActivator
@@ -38,11 +47,39 @@ namespace Dahomey.Cbor.Util
             }
         }
 
-        public static object? CreateInstance(Type type, params object?[] arguments)
+        /// <remarks>
+        /// Deliberately not <c>params</c>. Under <c>params</c> a caller passing a pre-built
+        /// <c>object?[]</c> means "these arguments" while a caller passing <c>null</c> means "no
+        /// arguments", and neither reads differently at the call site from passing one argument that
+        /// happens to be an array or a null. Every caller here spells the array out.
+        /// </remarks>
+        public static object? CreateInstance(Type type, object?[] arguments)
         {
             try
             {
                 return Activator.CreateInstance(type, arguments);
+            }
+            catch (TargetInvocationException exception) when (exception.InnerException != null)
+            {
+                ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Invokes a delegate whose signature is not known at compile time — a creator built from a
+        /// constructor, a factory method, or one the caller supplied.
+        /// </summary>
+        /// <remarks>
+        /// This one runs while a document is being read rather than while a mapping is built, and the
+        /// code it reaches is the caller's own constructor, so it is the site whose envelope a user is
+        /// most likely to meet.
+        /// </remarks>
+        public static object? Invoke(Delegate @delegate, object?[] arguments)
+        {
+            try
+            {
+                return @delegate.DynamicInvoke(arguments);
             }
             catch (TargetInvocationException exception) when (exception.InnerException != null)
             {

--- a/src/Dahomey.Cbor/Util/TypeExtensions.cs
+++ b/src/Dahomey.Cbor/Util/TypeExtensions.cs
@@ -12,7 +12,7 @@ namespace Dahomey.Cbor.Util
                 return null;
             }
 
-            return Activator.CreateInstance(type);
+            return ReflectionActivator.CreateInstance(type);
         }
 
         public static bool IsAnonymous(this Type type)


### PR DESCRIPTION
Closes #216.

Everything this library builds by reflection is built with `Activator.CreateInstance`, which wraps whatever the constructor threw in a `TargetInvocationException`. The exception was always the right one — only the envelope was wrong, and a caller's `catch (CborException)`, the one the rest of the API trains them into, matched none of them.

## What was wrapped, measured rather than reasoned about

Five places a constructor can run code that refuses. Each has a test in `Issues/Issue0216.cs`, and each failed before this change:

| Site | Reached by | Wrapped |
|---|---|--:|
| `CborConverterProviderBase.CreateConverter` | a converter built through any provider | once |
| `MemberMapping` → `IMemberConverter` | every member of every mapped type | once |
| `MemberMapping` → `[CborConverter]` | a converter the caller named on a member | **twice** |
| `ObjectMappingRegistry` → `ObjectMapping<T>` | any type whose mapping refuses itself | once |
| `DefaultObjectMappingConvention` → `[CborNamingConvention]` | a naming convention the caller named | **twice** |

The two double-wrapped ones are where the construction itself constructs something reflectively, so a single unwrap somewhere central would not have been enough. Each site unwraps its own layer instead.

The one an ordinary user reaches without writing a converter at all is the object mapping — two members under one CBOR name, which the mapping validation refuses:

```
TargetInvocationException: Exception has been thrown by the target of an invocation.
  inner: CborException: class/struct TwoMembersUnderOneName maps several fields/properties to the member name 'x'
```

`Util/TypeExtensions.GetDefaultValue` is routed through the same helper. A struct with a user-written parameterless constructor is legal C# and that constructor can throw.

## `ExceptionDispatchInfo`, not `throw exception.InnerException`

The latter resets the stack trace to the rethrow and loses the frame the refusal actually came from. `AnExceptionOfAnotherTypeIsNotConvertedOrSwallowed` pins both halves of that: an `InvalidOperationException` from a converter constructor arrives as itself rather than as a `TargetInvocationException` around it, **and** its own frame is still in `StackTrace`. Nothing is converted into a `CborException` on the way out.

## What this does not change

Nothing about which exception is thrown, or when. Every message is the one the constructor already produced. The only observable difference is the type a caller catches — so it is a behaviour change for anyone deliberately catching `TargetInvocationException` and reading `.InnerException`, which nothing documents and no test in this repository did.

## The workaround the test suite carried

Two copies of an `AssertThrowsCborException` helper walked `InnerException` for exactly this reason. Both are gone and their eleven call sites are plain `Assert.Throws<CborException>`.

Worth being precise about what that proves: **one of the eleven was genuinely wrapped** — `IntDiscriminatorTests.BothDiscriminatorAttributesThrows`, which refuses while the mapping is built, and which fails without this change. The nine in `TypedArrayTests` throw from `Read` rather than from a constructor and were never wrapped at all, so that helper's comment was wrong about its own call sites. Removing them is a simplification there, not evidence.

## Verification

**1902 library tests and 35 generator tests green on net10.0** with `CDDL_REQUIRED=1`, 0 skipped; all four TFMs build. `ExceptionDispatchInfo` is available on netstandard2.0, so no target is left out.

**Six fail without the `src/Dahomey.Cbor/` change** — the five new tests plus `BothDiscriminatorAttributesThrows` — measured by stashing only the library paths and re-running.

---
_Generated by [Claude Code](https://claude.ai/code)_
