### PR TITLE
Exclude a CDDL comment from the rule-name scan by its own syntax

### DIFF
--- a/src/Dahomey.Cbor.Tests/Cddl/CddlIdentifierSyntaxTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlIdentifierSyntaxTests.cs
@@ -96,13 +96,25 @@ namespace Dahomey.Cbor.Tests.Cddl
         }
 
         /// <summary>The left-hand side of every rule in the schema.</summary>
+        /// <remarks>
+        /// A comment is excluded by its leading <c>;</c> rather than by the assumption that no comment
+        /// contains <c>" = "</c>. None does today, so this changes nothing now; it stops the day a header
+        /// line gains one, at which point the comment would be scanned as a rule name and the assertion
+        /// would fail for a reason that has nothing to do with rule names.
+        /// </remarks>
         private static IEnumerable<string> RuleNames(string schema)
         {
             foreach (string line in schema.Split('\n'))
             {
+                if (line.StartsWith(" ", StringComparison.Ordinal)
+                    || line.StartsWith(";", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
                 int assignment = line.IndexOf(" = ", StringComparison.Ordinal);
 
-                if (assignment > 0 && !line.StartsWith(" ", StringComparison.Ordinal))
+                if (assignment > 0)
                 {
                     yield return line.Substring(0, assignment);
                 }


### PR DESCRIPTION
The non-blocking nit from your #208 approval, as its own change since that PR has merged.

`RuleNames` treated any line containing `" = "` that did not start with a space as a rule. That is correct today only because no header comment happens to contain one — so it rests on the current header's wording rather than on CDDL's syntax. Excluding a comment by its leading `;` closes it:

```csharp
if (line.StartsWith(" ", StringComparison.Ordinal)
    || line.StartsWith(";", StringComparison.Ordinal))
{
    continue;
}
```

**No behaviour change today, and none is testable** — the condition cannot arise from the emitter as it stands, which is exactly why it would go unnoticed if a header line ever gained an `=`. What it prevents is `EveryCharacterOutsideAsciiIsEscapedInARuleName` failing on a comment it scanned as a rule name, which would point at the escaping rather than at the line that actually changed.

117 CDDL tests green on net10.0 with `CDDL_REQUIRED=1` and gem 0.12.14; all four TFMs build.

Take or leave — it is a test-helper robustness change and nothing depends on it.

---
_Generated by [Claude Code](https://claude.ai/code)_
