### PR TITLE
Report the failure that stopped a sequence read, closes #219

### DIFF
--- a/src/Dahomey.Cbor.Tests/Issues/Issue0219.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0219.cs
@@ -5,6 +5,7 @@ using Dahomey.Cbor.Tests.Extensions;
 using System;
 using System.Buffers;
 using System.IO.Pipelines;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -46,8 +47,10 @@ namespace Dahomey.Cbor.Tests.Issues
             Assert.StartsWith("this creator refuses 12", exception.Message);
 
             // Rethrown rather than wrapped, so the path collected on the way out survives too - the
-            // same "$" Cbor.Deserialize reports for these bytes.
+            // same "$" Cbor.Deserialize reports for these bytes - and so does the frame it was thrown
+            // from, which is what rethrowing through ExceptionDispatchInfo buys over `throw failure`.
             Assert.Equal("$", exception.Path);
+            Assert.Contains(nameof(RefusedByItsCreator), exception.StackTrace);
         }
 
         /// <summary>
@@ -213,6 +216,42 @@ namespace Dahomey.Cbor.Tests.Issues
             CborException exception = await Assert.ThrowsAsync<CborException>(() => reading);
 #pragma warning restore VSTHRD003
             Assert.StartsWith("this creator refuses 12", exception.Message);
+        }
+
+        /// <summary>
+        /// A read reports as examined only what it consumed. Reporting the rest of the buffer would
+        /// tell the pipe this read had already seen it, and the next read would wait for bytes beyond
+        /// it - so items already flushed behind this one would hang until the writer wrote more.
+        /// </summary>
+        [Fact]
+        public async Task ItemsAlreadyFlushedBehindThisOneAreReadableAsync()
+        {
+            Pipe pipe = new Pipe();
+            await pipe.Writer.WriteAsync("0C0D".HexToBytes());   // 12 then 13, in one flush, writer left open
+
+            using CancellationTokenSource timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(12, await Cbor.ReadNextItemAsync<int?>(pipe.Reader, cancellationToken: timeout.Token));
+            Assert.Equal(13, await Cbor.ReadNextItemAsync<int?>(pipe.Reader, cancellationToken: timeout.Token));
+        }
+
+        /// <summary>
+        /// A cancelled read is not always a cancelled token: <see cref="PipeReader.CancelPendingRead"/>
+        /// cancels the read alone, and handing that token to <c>Task.FromCanceled</c> raised an
+        /// <see cref="ArgumentOutOfRangeException"/> about a parameter the caller never passed.
+        /// </summary>
+        [Fact]
+        public async Task ACancelledReadReportsAsCancelledAsync()
+        {
+            Pipe pipe = new Pipe();
+            await pipe.Writer.WriteAsync(OneWholeItem.HexToBytes());
+            pipe.Reader.CancelPendingRead();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () => await Cbor.ReadNextItemAsync<Plain>(pipe.Reader));
+
+            // And the read it cancelled is over, so the reader still works.
+            Assert.Equal(12, (await Cbor.ReadNextItemAsync<Plain>(pipe.Reader))!.Id);
         }
 
         public class Plain

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0219.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0219.cs
@@ -96,6 +96,41 @@ namespace Dahomey.Cbor.Tests.Issues
         }
 
         /// <summary>
+        /// The read that failed is over, and the pipe knows it: a <see cref="PipeReader"/> left between
+        /// a <c>ReadAsync</c> and its <c>AdvanceTo</c> answers every later call with "Reading is already
+        /// in progress" instead of with the failure, so the exception this fix restores would be
+        /// readable exactly once and masked from then on.
+        /// </summary>
+        /// <remarks>
+        /// Nothing is consumed, so asking again asks the same question and gets the same answer rather
+        /// than moving past the item that refused. Skipping it would mean deciding how many bytes a
+        /// failed read is deemed to have eaten, which is a question for an API that offers to continue,
+        /// not for the one that reports what stopped.
+        /// <para>
+        /// A real <see cref="Pipe"/> rather than <see cref="PipeReader.Create(ReadOnlySequence{byte})"/>
+        /// because only the former tracks the read state this is about; the sequence-backed reader
+        /// re-answers either way, which is why the tests above never noticed.
+        /// </para>
+        /// </remarks>
+        [Fact]
+        public async Task TheReaderIsLeftUsableAfterTheFailureAsync()
+        {
+            Pipe pipe = new Pipe();
+            await pipe.Writer.WriteAsync(OneWholeItem.HexToBytes());
+            await pipe.Writer.CompleteAsync();
+
+            CborException first = await Assert.ThrowsAsync<CborException>(
+                async () => await Cbor.ReadNextItemAsync<RefusedByItsCreator>(pipe.Reader));
+
+            // Not InvalidOperationException, and not a hang: the same refusal, reported again.
+            CborException second = await Assert.ThrowsAsync<CborException>(
+                async () => await Cbor.ReadNextItemAsync<RefusedByItsCreator>(pipe.Reader));
+
+            Assert.StartsWith("this creator refuses 12", first.Message);
+            Assert.Equal(first.Message, second.Message);
+        }
+
+        /// <summary>
         /// A stream that really is truncated still fails, and now says so in the reader's own words
         /// rather than in a message invented one frame up. The distinction the fix restores is between
         /// two failures that were both reported as this one.

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0219.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0219.cs
@@ -1,0 +1,146 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Serialization.Converters;
+using Dahomey.Cbor.Tests.Extensions;
+using System;
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// <c>ReadNextItemAsync</c> reads speculatively: an item that stops halfway through the bytes
+    /// available so far cannot be told apart from one whose remaining bytes have not arrived yet, so a
+    /// <see cref="CborException"/> means "retry on more data" while the pipe is open. Once the pipe is
+    /// complete there is no more data to wait for, and the failure that stopped the last attempt was
+    /// being replaced by a message of the method's own - so a converter's refusal was reported as a
+    /// truncated stream.
+    /// </summary>
+    /// <remarks>
+    /// The conflation predates #217: any <c>CborException</c> raised from a converter's <c>Read</c>
+    /// disappeared the same way. #217 widened it to <c>[CborConstructor]</c> refusals, which until then
+    /// arrived wrapped in a <c>TargetInvocationException</c> and so escaped the catch by accident. Both
+    /// routes are pinned below, and this is the only site in the library that swallows a
+    /// <c>CborException</c> - the other catches rethrow after enriching <see cref="CborException.Path"/>.
+    /// </remarks>
+    public class Issue0219
+    {
+        /// <summary>{"Id": 12}, a whole item - nothing about these bytes is truncated.</summary>
+        private const string OneWholeItem = "A16249640C";
+
+        /// <summary>
+        /// The case the issue is about: a creator that refuses the values the document carried, read
+        /// through a pipe that is already complete. <c>Cbor.Deserialize</c> on the same bytes always
+        /// reported this correctly; only the sequence API lost it.
+        /// </summary>
+        [Fact]
+        public async Task ACreatorRefusalReachesTheCallerOnACompletedPipeAsync()
+        {
+            PipeReader pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(OneWholeItem.HexToBytes()));
+
+            CborException exception = await Assert.ThrowsAsync<CborException>(
+                async () => await Cbor.ReadNextItemAsync<RefusedByItsCreator>(pipeReader));
+
+            Assert.StartsWith("this creator refuses 12", exception.Message);
+
+            // Rethrown rather than wrapped, so the path the converters enriched on the way out survives
+            // too - the same "$" Cbor.Deserialize reports for these bytes.
+            Assert.Equal("$", exception.Path);
+        }
+
+        /// <summary>
+        /// The older half of the same conflation: a converter's <c>Read</c> refusing outright. This one
+        /// never involved a <c>TargetInvocationException</c>, and was swallowed here long before #217.
+        /// </summary>
+        [Fact]
+        public async Task AConverterRefusalReachesTheCallerOnACompletedPipeAsync()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ConverterRegistry.RegisterConverter(typeof(RefusedByItsConverter), new RefusingConverter());
+
+            PipeReader pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(OneWholeItem.HexToBytes()));
+
+            CborException exception = await Assert.ThrowsAsync<CborException>(
+                async () => await Cbor.ReadNextItemAsync<RefusedByItsConverter>(pipeReader, options));
+
+            Assert.Equal("this converter refuses what it read", exception.Message);
+        }
+
+        /// <summary>
+        /// A stream that really is truncated still fails, and now says so in the reader's own words
+        /// rather than in a message invented one frame up. The distinction the fix restores is between
+        /// two failures that were both reported as this one.
+        /// </summary>
+        [Fact]
+        public async Task ATruncatedItemReportsTheReadThatRanOutOfBytesAsync()
+        {
+            // {"Id": ... - a map of one pair whose value never arrives.
+            PipeReader pipeReader = PipeReader.Create(new ReadOnlySequence<byte>("A1624964".HexToBytes()));
+
+            CborException exception = await Assert.ThrowsAsync<CborException>(
+                async () => await Cbor.ReadNextItemAsync<Plain>(pipeReader));
+
+            Assert.Contains("Unexpected end of buffer", exception.Message);
+        }
+
+        /// <summary>
+        /// While the pipe is open the behaviour is unchanged: a refusal is still read as "not enough
+        /// bytes yet" and the read keeps waiting, because on an open pipe the two are genuinely
+        /// indistinguishable. The refusal surfaces at the moment the writer completes - not before.
+        /// </summary>
+        [Fact]
+        public async Task AnOpenPipeStillWaitsAndOnlyReportsTheRefusalOnceItCompletesAsync()
+        {
+            Pipe pipe = new Pipe();
+            await pipe.Writer.WriteAsync(OneWholeItem.HexToBytes());
+
+            Task<RefusedByItsCreator> reading = Cbor.ReadNextItemAsync<RefusedByItsCreator>(pipe.Reader).AsTask();
+
+            // The whole item is in the pipe and the creator has already refused it once. The read is
+            // waiting for bytes that would change its mind rather than reporting anything.
+            Assert.NotSame(reading, await Task.WhenAny(reading, Task.Delay(TimeSpan.FromMilliseconds(250))));
+
+            await pipe.Writer.CompleteAsync();
+
+            // The read was started here a few lines up, which is what VSTHRD003 is asking about; it is
+            // held rather than awaited only so that its not-completing can be asserted first.
+#pragma warning disable VSTHRD003
+            CborException exception = await Assert.ThrowsAsync<CborException>(() => reading);
+#pragma warning restore VSTHRD003
+            Assert.StartsWith("this creator refuses 12", exception.Message);
+        }
+
+        public class Plain
+        {
+            public int Id { get; set; }
+        }
+
+        public class RefusedByItsCreator
+        {
+            public int Id { get; set; }
+
+            [CborConstructor]
+            public RefusedByItsCreator(int id)
+            {
+                throw new CborException($"this creator refuses {id}");
+            }
+        }
+
+        public class RefusedByItsConverter
+        {
+        }
+
+        public class RefusingConverter : CborConverterBase<RefusedByItsConverter>
+        {
+            public override RefusedByItsConverter Read(ref CborReader reader)
+            {
+                throw new CborException("this converter refuses what it read");
+            }
+
+            public override void Write(ref CborWriter writer, RefusedByItsConverter value)
+                => throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0219.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0219.cs
@@ -45,8 +45,8 @@ namespace Dahomey.Cbor.Tests.Issues
 
             Assert.StartsWith("this creator refuses 12", exception.Message);
 
-            // Rethrown rather than wrapped, so the path the converters enriched on the way out survives
-            // too - the same "$" Cbor.Deserialize reports for these bytes.
+            // Rethrown rather than wrapped, so the path collected on the way out survives too - the
+            // same "$" Cbor.Deserialize reports for these bytes.
             Assert.Equal("$", exception.Path);
         }
 
@@ -65,7 +65,34 @@ namespace Dahomey.Cbor.Tests.Issues
             CborException exception = await Assert.ThrowsAsync<CborException>(
                 async () => await Cbor.ReadNextItemAsync<RefusedByItsConverter>(pipeReader, options));
 
-            Assert.Equal("this converter refuses what it read", exception.Message);
+            Assert.StartsWith("this converter refuses what it read", exception.Message);
+            Assert.Equal("$", exception.Path);
+        }
+
+        /// <summary>
+        /// The path is the root reader's doing, not the object converter's: a failure on the root value
+        /// itself - a document that contradicts the requested type outright, with no member or index to
+        /// name - is placed at <c>$</c> here exactly as <c>Cbor.Deserialize</c> places it.
+        /// </summary>
+        /// <remarks>
+        /// Worth its own case because the two tests above pass either way: their types are objects, and
+        /// <c>ObjectConverter</c> marks the path itself on the way out. A primitive at the root passes
+        /// through no such converter, so it is the one that pins <c>RootReader</c> being on this path.
+        /// </remarks>
+        [Fact]
+        public async Task AFailureOnTheRootValueIsPlacedAtTheRootAsync()
+        {
+            byte[] bytes = OneWholeItem.HexToBytes();   // a map, where an int was asked for
+
+            CborException direct = Assert.Throws<CborException>(() => Cbor.Deserialize<int>(bytes));
+
+            PipeReader pipeReader = PipeReader.Create(new ReadOnlySequence<byte>(bytes));
+            CborException piped = await Assert.ThrowsAsync<CborException>(
+                async () => await Cbor.ReadNextItemAsync<int>(pipeReader));
+
+            Assert.Equal("$", piped.Path);
+            Assert.Equal(direct.Path, piped.Path);
+            Assert.Equal(direct.Message, piped.Message);
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0219.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0219.cs
@@ -131,6 +131,47 @@ namespace Dahomey.Cbor.Tests.Issues
         }
 
         /// <summary>
+        /// The same for a converter that throws something other than a <see cref="CborException"/>,
+        /// which #216 made a supported thing to do. That one is not caught anywhere on the way out, so
+        /// it leaves the read pending by a different route than the one above.
+        /// </summary>
+        [Fact]
+        public async Task TheReaderIsLeftUsableAfterAFailureOfAnotherTypeAsync()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ConverterRegistry.RegisterConverter(typeof(RefusedByItsConverter), new ThrowingConverter());
+
+            Pipe pipe = new Pipe();
+            await pipe.Writer.WriteAsync(OneWholeItem.HexToBytes());
+            await pipe.Writer.CompleteAsync();
+
+            InvalidOperationException first = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await Cbor.ReadNextItemAsync<RefusedByItsConverter>(pipe.Reader, options));
+            InvalidOperationException second = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await Cbor.ReadNextItemAsync<RefusedByItsConverter>(pipe.Reader, options));
+
+            Assert.Equal("not a CborException", first.Message);
+            Assert.Equal(first.Message, second.Message);
+        }
+
+        /// <summary>
+        /// And the ordinary way out: the end of the sequence. It is the most common exit of all, and it
+        /// left the read pending too - a consumer polling a drained pipe got one <c>null</c> and then
+        /// "Reading is already in progress".
+        /// </summary>
+        [Fact]
+        public async Task TheReaderIsLeftUsableAtTheEndOfTheSequenceAsync()
+        {
+            Pipe pipe = new Pipe();
+            await pipe.Writer.WriteAsync("0C".HexToBytes());   // one item, then nothing
+            await pipe.Writer.CompleteAsync();
+
+            Assert.Equal(12, await Cbor.ReadNextItemAsync<int?>(pipe.Reader));
+            Assert.Null(await Cbor.ReadNextItemAsync<int?>(pipe.Reader));
+            Assert.Null(await Cbor.ReadNextItemAsync<int?>(pipe.Reader));
+        }
+
+        /// <summary>
         /// A stream that really is truncated still fails, and now says so in the reader's own words
         /// rather than in a message invented one frame up. The distinction the fix restores is between
         /// two failures that were both reported as this one.
@@ -192,6 +233,15 @@ namespace Dahomey.Cbor.Tests.Issues
 
         public class RefusedByItsConverter
         {
+        }
+
+        public class ThrowingConverter : CborConverterBase<RefusedByItsConverter>
+        {
+            public override RefusedByItsConverter Read(ref CborReader reader)
+                => throw new InvalidOperationException("not a CborException");
+
+            public override void Write(ref CborWriter writer, RefusedByItsConverter value)
+                => throw new NotSupportedException();
         }
 
         public class RefusingConverter : CborConverterBase<RefusedByItsConverter>

--- a/src/Dahomey.Cbor/Cbor.cs
+++ b/src/Dahomey.Cbor/Cbor.cs
@@ -617,21 +617,16 @@ namespace Dahomey.Cbor
                         // this one would never be returned until the writer wrote more or completed.
                         SequencePosition end = buffer.GetPosition(offset: consumed);
                         reader.AdvanceTo(end, examined: end);
-                        result = default;
                         return item;
                     }
-                    else
-                    {
-                        if (result.IsCompleted)
-                        {
-                            // Nothing more is coming, so the failure that stopped the read is the
-                            // answer. Rethrown rather than replaced, to keep its message and its path;
-                            // captured here rather than where it was caught, since every speculative
-                            // attempt catches one and only this branch has any use for it.
-                            ExceptionDispatchInfo.Capture(failure).Throw();
-                        }
 
-                        result = default;
+                    if (result.IsCompleted)
+                    {
+                        // Nothing more is coming, so the failure that stopped the read is the answer.
+                        // Rethrown rather than replaced, to keep its message and its path; captured
+                        // here rather than where it was caught, since every speculative attempt
+                        // catches one and only this branch has any use for it.
+                        ExceptionDispatchInfo.Capture(failure).Throw();
                     }
                 }
                 catch (Exception) when (!result.IsCompleted)
@@ -642,8 +637,6 @@ namespace Dahomey.Cbor
                     // wrong (IOException)
                     // 
                     // Anyways, if the pipe is complete, the exception will not be catched (see filter)
-
-                    result = default;
                 }
                 finally
                 {

--- a/src/Dahomey.Cbor/Cbor.cs
+++ b/src/Dahomey.Cbor/Cbor.cs
@@ -634,7 +634,7 @@ namespace Dahomey.Cbor
 
                 try
                 {
-                    item = converter.Read(ref reader);
+                    item = RootReader.Read(ref reader, converter);
                     consumed = reader.GetBookmark().currentPos;
                     failure = null;
                     return true;

--- a/src/Dahomey.Cbor/Cbor.cs
+++ b/src/Dahomey.Cbor/Cbor.cs
@@ -597,6 +597,12 @@ namespace Dahomey.Cbor
                     }
                     else
                     {
+                        // Consumes nothing either way: the item that stopped the read is left where it
+                        // is. On the throwing branch this is what ends the pending read - a PipeReader
+                        // left mid-read answers every later call with "Reading is already in progress"
+                        // rather than with the failure below.
+                        reader.AdvanceTo(buffer.Start, examined: buffer.End);
+
                         if (result.IsCompleted)
                         {
                             // Nothing more is coming, so the failure that stopped the read is the
@@ -604,7 +610,6 @@ namespace Dahomey.Cbor
                             failure.Throw();
                         }
 
-                        reader.AdvanceTo(buffer.Start, examined: buffer.End);
                         result = default;
                     }
                 }

--- a/src/Dahomey.Cbor/Cbor.cs
+++ b/src/Dahomey.Cbor/Cbor.cs
@@ -584,25 +584,27 @@ namespace Dahomey.Cbor
                 ReadOnlySequence<byte> buffer = result.Buffer;
                 if (buffer.IsEmpty)
                 {
+                    reader.AdvanceTo(buffer.Start, examined: buffer.End);
                     return default;
                 }
+
+                // Every route out of the read below ends it, including the ones that throw. A
+                // PipeReader left between a ReadAsync and its AdvanceTo answers every later call with
+                // "Reading is already in progress" rather than with what actually happened, so a
+                // failure reported once would be masked from then on.
+                bool advanced = false;
 
                 try
                 {
                     if (TryReadItem(buffer, options ?? CborOptions.Default, out TItem? item, out var consumed, out ExceptionDispatchInfo? failure))
                     {
+                        advanced = true;
                         reader.AdvanceTo(buffer.GetPosition(offset: consumed), examined: buffer.End);
                         result = default;
                         return item;
                     }
                     else
                     {
-                        // Consumes nothing either way: the item that stopped the read is left where it
-                        // is. On the throwing branch this is what ends the pending read - a PipeReader
-                        // left mid-read answers every later call with "Reading is already in progress"
-                        // rather than with the failure below.
-                        reader.AdvanceTo(buffer.Start, examined: buffer.End);
-
                         if (result.IsCompleted)
                         {
                             // Nothing more is coming, so the failure that stopped the read is the
@@ -622,8 +624,15 @@ namespace Dahomey.Cbor
                     // 
                     // Anyways, if the pipe is complete, the exception will not be catched (see filter)
 
-                    reader.AdvanceTo(buffer.Start, examined: buffer.End);
                     result = default;
+                }
+                finally
+                {
+                    if (!advanced)
+                    {
+                        // Consumes nothing: whatever stopped the read is left exactly where it is.
+                        reader.AdvanceTo(buffer.Start, examined: buffer.End);
+                    }
                 }
             }
 

--- a/src/Dahomey.Cbor/Cbor.cs
+++ b/src/Dahomey.Cbor/Cbor.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -564,6 +565,12 @@ namespace Dahomey.Cbor
         /// <param name="cancellationToken">The cancellation token</param>
         /// <returns>The next item in the sequence. default(TItem) is returned when no more items are available</returns>
         /// <exception cref="CborException">Thrown if the reader does not contain a valid cbor sequence</exception>
+        /// <remarks>
+        /// Reading is speculative: while the pipe is open, a failure is indistinguishable from an item
+        /// whose remaining bytes have not arrived yet, so it is discarded and the read is retried on
+        /// more data. Once the pipe is complete, the failure that stopped the last attempt reaches the
+        /// caller as itself - the reader running out of bytes, or a converter refusing what it read.
+        /// </remarks>
         public static async ValueTask<TItem?> ReadNextItemAsync<TItem>(PipeReader reader, CborOptions? options = null, CancellationToken cancellationToken = default)
         {
             while (true)
@@ -582,7 +589,7 @@ namespace Dahomey.Cbor
 
                 try
                 {
-                    if (TryReadItem(buffer, options ?? CborOptions.Default, out TItem? item, out var consumed))
+                    if (TryReadItem(buffer, options ?? CborOptions.Default, out TItem? item, out var consumed, out ExceptionDispatchInfo? failure))
                     {
                         reader.AdvanceTo(buffer.GetPosition(offset: consumed), examined: buffer.End);
                         result = default;
@@ -592,7 +599,9 @@ namespace Dahomey.Cbor
                     {
                         if (result.IsCompleted)
                         {
-                            throw new CborException("Reader has completed with some buffer bytes but no item was read");
+                            // Nothing more is coming, so the failure that stopped the read is the
+                            // answer. Rethrown rather than replaced, to keep its message and its path.
+                            failure.Throw();
                         }
 
                         reader.AdvanceTo(buffer.Start, examined: buffer.End);
@@ -617,7 +626,8 @@ namespace Dahomey.Cbor
                 in ReadOnlySequence<byte> sequence,
                 CborOptions options,
                 out TItem? item,
-                out int consumed)
+                out int consumed,
+                [NotNullWhen(false)] out ExceptionDispatchInfo? failure)
             {
                 CborReader reader = new CborReader(sequence, options.MaxDepth);
                 ICborConverter<TItem> converter = options.Registry.ConverterRegistry.Lookup<TItem>();
@@ -626,12 +636,14 @@ namespace Dahomey.Cbor
                 {
                     item = converter.Read(ref reader);
                     consumed = reader.GetBookmark().currentPos;
+                    failure = null;
                     return true;
                 }
-                catch (CborException)
+                catch (CborException exception)
                 {
                     item = default;
                     consumed = 0;
+                    failure = ExceptionDispatchInfo.Capture(exception);
                     return false;
                 }
             }

--- a/src/Dahomey.Cbor/Cbor.cs
+++ b/src/Dahomey.Cbor/Cbor.cs
@@ -570,6 +570,11 @@ namespace Dahomey.Cbor
         /// whose remaining bytes have not arrived yet, so it is discarded and the read is retried on
         /// more data. Once the pipe is complete, the failure that stopped the last attempt reaches the
         /// caller as itself - the reader running out of bytes, or a converter refusing what it read.
+        /// <para>
+        /// A failure consumes nothing, so it is not a position the sequence moves past: calling again
+        /// re-reads the same bytes and raises the same failure. There is no skip-and-continue here, and
+        /// a consumer that catches and loops will spin. Treat a throw as the end of the sequence.
+        /// </para>
         /// </remarks>
         public static async ValueTask<TItem?> ReadNextItemAsync<TItem>(PipeReader reader, CborOptions? options = null, CancellationToken cancellationToken = default)
         {
@@ -578,7 +583,13 @@ namespace Dahomey.Cbor
                 ReadResult result = await reader.ReadAsync(cancellationToken: cancellationToken);
                 if (result.IsCanceled)
                 {
-                    await Task.FromCanceled(cancellationToken);
+                    // Ends this read before reporting, as every route below does. A cancelled result
+                    // is not always a cancelled token: PipeReader.CancelPendingRead cancels the read
+                    // alone, and handing that token to Task.FromCanceled raised an
+                    // ArgumentOutOfRangeException about a parameter the caller never passed.
+                    reader.AdvanceTo(result.Buffer.Start, examined: result.Buffer.Start);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    throw new OperationCanceledException("The read was canceled through CancelPendingRead.");
                 }
 
                 ReadOnlySequence<byte> buffer = result.Buffer;
@@ -596,10 +607,16 @@ namespace Dahomey.Cbor
 
                 try
                 {
-                    if (TryReadItem(buffer, options ?? CborOptions.Default, out TItem? item, out var consumed, out ExceptionDispatchInfo? failure))
+                    if (TryReadItem(buffer, options ?? CborOptions.Default, out TItem? item, out var consumed, out CborException? failure))
                     {
                         advanced = true;
-                        reader.AdvanceTo(buffer.GetPosition(offset: consumed), examined: buffer.End);
+
+                        // Examined stops where consumed stops, not at buffer.End. Reporting the rest
+                        // of the buffer as examined tells the pipe this read has already seen it, so
+                        // the next one waits for bytes beyond it - and items already flushed behind
+                        // this one would never be returned until the writer wrote more or completed.
+                        SequencePosition end = buffer.GetPosition(offset: consumed);
+                        reader.AdvanceTo(end, examined: end);
                         result = default;
                         return item;
                     }
@@ -608,8 +625,10 @@ namespace Dahomey.Cbor
                         if (result.IsCompleted)
                         {
                             // Nothing more is coming, so the failure that stopped the read is the
-                            // answer. Rethrown rather than replaced, to keep its message and its path.
-                            failure.Throw();
+                            // answer. Rethrown rather than replaced, to keep its message and its path;
+                            // captured here rather than where it was caught, since every speculative
+                            // attempt catches one and only this branch has any use for it.
+                            ExceptionDispatchInfo.Capture(failure).Throw();
                         }
 
                         result = default;
@@ -641,7 +660,7 @@ namespace Dahomey.Cbor
                 CborOptions options,
                 out TItem? item,
                 out int consumed,
-                [NotNullWhen(false)] out ExceptionDispatchInfo? failure)
+                [NotNullWhen(false)] out CborException? failure)
             {
                 CborReader reader = new CborReader(sequence, options.MaxDepth);
                 ICborConverter<TItem> converter = options.Registry.ConverterRegistry.Lookup<TItem>();
@@ -657,7 +676,7 @@ namespace Dahomey.Cbor
                 {
                     item = default;
                     consumed = 0;
-                    failure = ExceptionDispatchInfo.Capture(exception);
+                    failure = exception;
                     return false;
                 }
             }

--- a/src/Dahomey.Cbor/Serialization/RootReader.cs
+++ b/src/Dahomey.Cbor/Serialization/RootReader.cs
@@ -13,9 +13,10 @@ namespace Dahomey.Cbor.Serialization
     /// starts a read goes through here, which is what lets <see cref="CborException.Path"/> promise
     /// that a null value means the exception did not come from a read at all.
     /// <para>
-    /// The speculative read behind the <c>PipeReader</c> overloads is deliberately not routed through
-    /// this: it throws as a matter of course while waiting for more of a stream, and discards what it
-    /// catches.
+    /// The speculative read behind the <c>PipeReader</c> overloads goes through this too. It throws as
+    /// a matter of course while waiting for more of a stream, and marking a path on a failure it is
+    /// about to discard costs nothing; the one it does not discard - the failure that stopped the last
+    /// attempt on a completed pipe - reaches the caller placed exactly as the same bytes read whole.
     /// </para>
     /// </remarks>
     internal static class RootReader


### PR DESCRIPTION
Closes #219.

## What was wrong

`Cbor.ReadNextItemAsync(PipeReader)` reads speculatively: an item that stops halfway through the bytes available so far cannot be told apart from one whose remaining bytes have not arrived yet, so its local `TryReadItem` catches `CborException` and answers "not yet". On an open pipe that is the only honest answer.

On a completed pipe there is nothing left to wait for — and the method was discarding what it had caught and throwing a message of its own:

```
CborException: Reader has completed with some buffer bytes but no item was read
```

So a converter that refuses what it read was reported as a truncated stream. `Cbor.Deserialize` on the same bytes has always reported it correctly; only the sequence API lost it.

Worth being precise about what #217 did and did not cause. Conflating "incomplete data" with "a genuine refusal" predates it: a `CborException` thrown from a converter's `Read` already disappeared here. #217 unwrapped `TargetInvocationException` at the reflective construction sites, which moved `[CborConstructor]` refusals out of an envelope this catch did not match and into one it did — a widening of an existing conflation rather than a new mechanism.

## The fix for #219

The caught exception is rethrown through `ExceptionDispatchInfo` when `result.IsCompleted`, rather than replaced. A refusal keeps its message, its `CborException.Path` and the frame it was thrown from; a genuinely truncated document now reports the reader's own `[N] Unexpected end of buffer` instead of a message invented one frame up. The open-pipe path is untouched — `TryReadItem` still returns `false` and the loop still waits.

The speculative read also now goes through `RootReader`, so a failure on the root value itself is placed at `$` exactly as `Cbor.Deserialize` places it. Without it this branch handed back `Path == null`, which contradicts what `CborException.Path` documents.

## What review turned up on the way

Restoring the exception exposed the state the method left the `PipeReader` in, which had not mattered while every failure here was terminal. Four rounds of review, each finding reproduced before being acted on:

* **The read was never ended on the failing routes.** A `PipeReader` left between a `ReadAsync` and its `AdvanceTo` answers every later call with `InvalidOperationException: Reading is already in progress` — so the exception this PR restores was readable exactly once and masked from then on. This reached the caller by three separate doors: the `CborException` route, a converter throwing something else (supported since #216), and the end of the sequence, which is the method's most common exit. A `finally` guarded by a flag now covers every route; the success path advances past what it consumed, everything else advances past nothing.
* **`examined` ran to `buffer.End` on the success path** while only one item was consumed, telling the pipe this read had already seen the rest. On an open `Pipe` carrying two items in one flush, the second read never returned. `examined` now stops where `consumed` stops.
* **The `IsCanceled` route** skipped the read-ending path entirely and misreported: a cancelled result is not always a cancelled token — `PipeReader.CancelPendingRead` cancels the read alone — and handing that token to `Task.FromCanceled` raised `ArgumentOutOfRangeException` about a parameter the caller never passed. It now throws `OperationCanceledException`, and the reader survives it.
* **`ExceptionDispatchInfo.Capture` ran on every speculative attempt**, including the thousands discarded while a fragmented item arrives, though only the completed branch has any use for one. The capture moved to that branch.

The method's remarks now state what a caller has to know rather than leaving it in a test: a failure consumes nothing, so calling again re-reads the same bytes and raises the same failure. There is no skip-and-continue here — a throw is the end of the sequence. Skipping would mean deciding how many bytes a failed read is deemed to have eaten, which is a question for an API that offers to continue.

Every exit of the method now passes through exactly one `AdvanceTo`: cancellation, empty buffer, success, refusal on a completed pipe, refusal on an open one, a non-`CborException` either way, and a mapping the registry refuses to build.

## Tests

`Issues/Issue0219.cs`, ten cases. The four for #219 itself fail against 2587151; the rest fail against the commit each was written for.

* a `[CborConstructor]` refusal over a completed pipe — message, path (`$`) and origin frame all survive
* a converter's `Read` refusing — the older half of the same conflation, which never involved a `TargetInvocationException`
* a failure on the root value itself, asserted equal to `Cbor.Deserialize`'s own answer rather than to a literal, so the two cannot drift apart
* a genuinely truncated item — still a `CborException`, now in the reader's own words
* an open pipe — the read holds rather than reporting anything, and the refusal surfaces when the writer completes, not before
* the reader still usable after a `CborException`, after an exception of another type, and at the end of the sequence
* two items flushed together on an open pipe, both readable
* a read cancelled through `CancelPendingRead`

1953 library tests green on net10.0 and net8.0, 35 generator tests, four TFMs building.