### PR TITLE
Rest the duplicate-member comment on a reason that holds

### DIFF
--- a/src/Dahomey.Cbor.Generator/TypeCollector.cs
+++ b/src/Dahomey.Cbor.Generator/TypeCollector.cs
@@ -249,14 +249,11 @@ namespace Dahomey.Cbor.Generator
                 // formats -- the same split ObjectConverter's read lookup makes. Two members under one
                 // key cannot both be in a document, so the second is reported.
                 //
-                // Reported and still registered, deliberately. Dropping it would be invisible if the
-                // diagnostic were suppressed -- `dotnet_diagnostic.CBOR1013.severity = none` makes an
-                // error a no-op, and the build would then succeed with a member silently missing from
-                // the generated context and present in every document the reflection path writes.
-                // Registering both leaves the run-time check to give the same answer the reflection path
-                // gives for the same source: ObjectMapping.ValidateMemberNamesAndindexes throws while
-                // the context is being built. Loud in both configurations, rather than loud in one and
-                // silently wrong in the other.
+                // Reported and still registered, so that nothing here assumes the build stops. If
+                // emission ever proceeds past the diagnostic, both members reach
+                // ObjectMapping.ValidateMemberNamesAndindexes, which refuses the mapping exactly as it
+                // does for the same source on the reflection path. Registering one member fewer than the
+                // source declares would be silent instead.
                 if (model.ObjectFormat == "StringKeyMap")
                 {
                     if (membersByCborName.TryGetValue(cborName, out string? firstUnderName))


### PR DESCRIPTION
Follow-up to #211, comment only — nothing about what the generator emits changes.

#211 made a duplicate member **reported and still registered** rather than dropped. That is the right behaviour, and it stayed. What it does not have is the reason the comment gives for it:

> Dropping it would be invisible if the diagnostic were suppressed -- `dotnet_diagnostic.CBOR1013.severity = none` makes an error a no-op

That route does not exist. Roslyn does not run diagnostics reported from a source generator through the analyzer severity table, so nothing an `.editorconfig` says about CBOR1013 ever reaches `SourceProductionContext.ReportDiagnostic`. Measured on the merge commit, with CS8632 suppressed in the same file as a control:

```ini
[*.cs]
dotnet_diagnostic.CBOR1013.severity = none
dotnet_diagnostic.CS8632.severity   = none
```

```
CS8632   : 0 occurrences   ← the .editorconfig is being applied
CBOR1013 : error, still reported
```

And with `defaultSeverity: Error` there is no other way in either: `NoWarn` does not apply to errors, and a `DiagnosticSuppressor` only ever suppresses warnings.

I am the one who put that idea in front of the contributor, in a review note I flagged as minor and did not check, so this is my correction rather than a defect found in the PR.

## What the comment says instead

The reason that does hold is the weaker, more durable one: don't assume the build stops. Whenever emission proceeds past the diagnostic, dropping the member would leave the generated context short a member the reflection path writes into every document — silent, and exactly the divergence CBOR1013 exists to remove. Registered, the two members reach `ObjectMapping.ValidateMemberNamesAndindexes`, which gives the same answer the reflection path gives for the same source. At the default severity nothing is lost by that: the build fails on CBOR1013 first and the run-time check is never reached.

## Verification

**1952 library tests and 42 generator tests green on net10.0** with `CDDL_REQUIRED=1`, 0 skipped, all four TFMs building — unchanged from the merge commit, as a comment-only diff should be.

Separately confirmed while reviewing #211, and the reason the behaviour is worth keeping: registering the duplicate still emits compilable C# for a duplicate name and a duplicate index alike. The emitter produces `MapMember(o => o.First, …)` calls rather than `case` labels, so there is no CS0152 hiding behind the diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdSo15DYDHWp2znMgwMDjm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdSo15DYDHWp2znMgwMDjm)_