### PR TITLE
Latch the discriminator member name once it resolves, closes #225

### DIFF
--- a/src/Dahomey.Cbor.Tests/Issues/Issue0225.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0225.cs
@@ -1,0 +1,122 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization.Converters.Mappings;
+using System.Linq;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// <c>DiscriminatorMapping.EnsureInitialize</c> spelled the double-checked pattern out in full and
+    /// never assigned the flag it tested, so both checks always passed: every read of
+    /// <c>MemberName</c> took the lock, went back to the registry, and decoded the name into a fresh
+    /// string.
+    /// </summary>
+    /// <remarks>
+    /// The flag latches on having resolved a convention, not on having looked for one - assigning it
+    /// unconditionally would freeze the name at <c>null</c> for a type whose subtypes are registered
+    /// after the first lookup, which is what #224 is about. Now that #224 has stopped the registry
+    /// memoising its own <c>null</c>, both halves of that contract are observable from here, and
+    /// there is a test for each.
+    /// </remarks>
+    public class Issue0225
+    {
+        public abstract class Shape
+        {
+        }
+
+        [CborDiscriminator("circle")]
+        public class Circle : Shape
+        {
+            public double Radius { get; set; }
+        }
+
+        [CborIntDiscriminator(7)]
+        public class NumberedSeven : Shape
+        {
+            public int Value { get; set; }
+        }
+
+        private static IMemberMapping DiscriminatorMappingOf<T>(CborOptions options)
+        {
+            return options.Registry.ObjectMappingRegistry
+                .Lookup<T>()
+                .MemberMappings
+                .OfType<IDiscriminatorMapping>()
+                .Single();
+        }
+
+        /// <summary>
+        /// Two reads of the same mapping hand back the same string. Before the fix each one allocated,
+        /// which is the visible trace of a lock and a registry lookup that were meant to happen once.
+        /// </summary>
+        [Fact]
+        public void TheDiscriminatorMemberNameIsResolvedOnce()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<Circle>();
+
+            IMemberMapping mapping = DiscriminatorMappingOf<Circle>(options);
+
+            string first = mapping.MemberName;
+            string second = mapping.MemberName;
+
+            Assert.Equal("_t", first);
+            Assert.Same(first, second);
+        }
+
+        /// <summary>
+        /// The name the mapping keeps is the one the convention in force actually carries, not the
+        /// default it would have had. Latching the wrong string is worse than re-deriving the right
+        /// one, so the value is pinned as well as its identity.
+        /// </summary>
+        [Fact]
+        public void TheLatchedNameIsTheOneTheConventionCarries()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.ClearConventions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterConvention(
+                new Serialization.Conventions.DefaultDiscriminatorConvention<string>(options.Registry, "$type"));
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<Circle>();
+
+            IMemberMapping mapping = DiscriminatorMappingOf<Circle>(options);
+
+            string first = mapping.MemberName;
+            string second = mapping.MemberName;
+
+            Assert.Equal("$type", first);
+            Assert.Same(first, second);
+        }
+
+        /// <summary>
+        /// The other half of the latch: a read taken while nothing resolves finds no convention, and
+        /// that non-answer must not be what the mapping keeps. Latching on the attempt rather than on
+        /// the resolution would pin <c>null</c> here for the lifetime of the options.
+        /// </summary>
+        /// <remarks>
+        /// The mapping is built here rather than fetched through <see cref="DiscriminatorMappingOf{T}"/>
+        /// because an unresolved one cannot be reached that way: <c>ObjectMapping.EnsureInitialize</c>
+        /// validates that every member mapping has a name, so reading <c>MemberMappings</c> throws
+        /// before it can hand this one back. The type is one whose discriminator is an <c>int</c> in a
+        /// registry holding only the <c>string</c> convention, which is what makes the first lookup
+        /// resolve to nothing without contriving anything.
+        /// </remarks>
+        [Fact]
+        public void ARegistrationAfterTheFirstReadStillReachesTheMapping()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.ClearConventions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterConvention(
+                new Serialization.Conventions.DefaultDiscriminatorConvention<string>(options.Registry));
+
+            IMemberMapping mapping = new DiscriminatorMapping<NumberedSeven>(
+                options, options.Registry.ObjectMappingRegistry.Lookup<NumberedSeven>());
+
+            Assert.Null(mapping.MemberName);
+
+            options.Registry.DiscriminatorConventionRegistry.RegisterConvention(
+                new Serialization.Conventions.DefaultDiscriminatorConvention<int>(options.Registry));
+
+            Assert.Equal("_t", mapping.MemberName);
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/CreatorMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/CreatorMapping.cs
@@ -11,6 +11,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
     public class CreatorMapping : ICreatorMapping
     {
         private bool _isInitialized = false;
+        private readonly object _lock = new object();
         private readonly IObjectMapping _objectMapping;
         private readonly Delegate _delegate;
         private readonly ParameterInfo[] _parameters;
@@ -131,7 +132,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         {
             if (!_isInitialized)
             {
-                lock (this)
+                lock (_lock)
                 {
                     if (!_isInitialized)
                     {

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DiscriminatorMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DiscriminatorMapping.cs
@@ -12,7 +12,15 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
 
     public class DiscriminatorMapping<T> : IDiscriminatorMapping
     {
-        private bool _isInitialized = false;
+        /// <remarks>
+        /// Volatile because <see cref="EnsureInitialize"/> reads it outside the lock and the caller
+        /// goes straight on to read <see cref="_memberName"/>. The two writes are ordered here and
+        /// have to be seen in that order by a reader that never takes the lock; without the barrier
+        /// a weak memory model may hand it the flag ahead of the name it stands for, and
+        /// <see cref="MemberName"/> answers <c>null</c> for a mapping that is in fact initialized.
+        /// </remarks>
+        private volatile bool _isInitialized = false;
+        private readonly object _lock = new object();
         private readonly CborOptions _options;
         private readonly DiscriminatorConventionRegistry _discriminatorConventionRegistry;
         private readonly IObjectMapping _objectMapping;
@@ -45,11 +53,19 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             _objectMapping = objectMapping;
         }
 
+        /// <remarks>
+        /// The flag latches on having <em>resolved a convention</em>, not on having looked for one.
+        /// The registry answers <c>null</c> for a type whose subtypes are not registered yet, and a
+        /// registration that arrives later has to reach this mapping; latching on the attempt would
+        /// freeze <see cref="MemberName"/> at <c>null</c> for the lifetime of the options. Once a
+        /// convention is in hand the answer no longer moves — the registry never displaces a
+        /// resolved convention with another one — so the name is safe to keep.
+        /// </remarks>
         public void EnsureInitialize()
         {
             if (!_isInitialized)
             {
-                lock (this)
+                lock (_lock)
                 {
                     if (!_isInitialized)
                     {
@@ -57,6 +73,8 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                         if (discriminatorConvention != null)
                         {
                             _memberName = Encoding.UTF8.GetString(discriminatorConvention.MemberName);
+
+                            _isInitialized = true;
                         }
                     }
                 }
@@ -71,8 +89,6 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             {
                 throw new CborException($"Cannot find a discriminator convention for type {_objectMapping.ObjectType}");
             }
-
-            int? memberIndex = _objectMapping.ObjectFormat == CborObjectFormat.Array ? 0 : null;
 
             IMemberConverter memberConverter = new DiscriminatorMemberConverter<T>(
                 _options, discriminatorConvention, _objectMapping.DiscriminatorPolicy, _objectMapping.ObjectFormat);

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/MemberMapping.cs
@@ -9,6 +9,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
     public class MemberMapping<T> : IMemberMapping
     {
         private bool _isInitialized = false;
+        private readonly object _lock = new object();
         private readonly IObjectMapping _objectMapping;
         private readonly CborConverterRegistry _converterRegistry;
         private string? _memberName = null;
@@ -50,7 +51,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
                 // lookup now completes.
                 if (_converter == null)
                 {
-                    lock (this)
+                    lock (_lock)
                     {
                         _converter ??= _converterRegistry.Lookup(MemberType);
                     }
@@ -146,7 +147,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         {
             if (!_isInitialized)
             {
-                lock (this)
+                lock (_lock)
                 {
                     if (!_isInitialized)
                     {

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
@@ -18,6 +18,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
     public class ObjectMapping<T> : IObjectMapping
     {
         private bool _isInitialized = false;
+        private readonly object _lock = new object();
         private readonly SerializationRegistry _registry;
         private readonly CborOptions _options;
         private List<IMemberMapping> _memberMappings = new List<IMemberMapping>();
@@ -354,7 +355,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         {
             if (!_isInitialized)
             {
-                lock (this)
+                lock (_lock)
                 {
                     if (!_isInitialized)
                     {


### PR DESCRIPTION
Closes #225. Rebased on `master`, so #226 is in the base.

`DiscriminatorMapping` spelled the double-checked pattern out in full and never assigned the flag it tested, so both checks always passed: every read of `MemberName` took the lock, went back to the convention registry, and decoded the name into a fresh string. It was the only one of the four mappings in the folder with the flag left dead.

## The decision the issue asked for

Of the two options the issue put on the table — latch on success, or drop the flag and the lock and let it re-resolve honestly — this takes the first.

```csharp
if (discriminatorConvention != null)
{
    _memberName = Encoding.UTF8.GetString(discriminatorConvention.MemberName);

    _isInitialized = true;
}
```

Latching on *having resolved a convention* rather than on *having looked for one* keeps the property the current code gets by accident: the registry answers `null` for a type whose subtypes are not registered yet, and a registration that arrives later still has to reach the mapping. Latching on the attempt would freeze the name at `null` for the lifetime of the options, which is the trap #224 is about. Latching on success keeps that door open while making the lock and the allocation happen once. The kept value is stable because the registry never displaces a convention it has already resolved, so there is nothing later to re-read.

The reasoning is now in a `<remarks>` on the method, since the conditional assignment is the kind of thing a later reader would "tidy" into an unconditional one.

## The flag is now `volatile`

Latching it is what makes this necessary, and it is the one genuinely load-bearing part of the change beyond the latch itself. While the flag was never set, every read of `MemberName` went through the monitor and therefore saw `_memberName` under a barrier. Setting it puts a lock-free fast path in front of the field, and the two writes — the name, then the flag — have to be observed in that order by a reader that never takes the lock. Without the barrier a weak memory model may hand that reader the flag ahead of the name it stands for, and `MemberName` answers `null` for a mapping that is in fact initialized. This is the same failure 4e6e690 guards against on the registry's version counter.

The three sibling mappings carry the same non-volatile flag, but theirs were already live, so that is pre-existing and out of scope here rather than something this PR introduces.

## The two neighbours

Both were flagged in the issue as optional; both are in.

**`lock (this)` on a publicly reachable instance.** All four mappings — `DiscriminatorMapping`, `ObjectMapping`, `MemberMapping` (two sites), `CreatorMapping` — now take a private `_lock` object, so external code holding a reference to a mapping can no longer contend for the same monitor. Mechanical change, no behavioural difference beyond removing the deadlock surface.

**The dead local in `GenerateMemberConverter`.** `int? memberIndex = _objectMapping.ObjectFormat == CborObjectFormat.Array ? 0 : null;` was unused, and its `null` branch contradicted the `MemberIndex` property just above it, which returns `0` unconditionally — and which `ObjectConverter.HandleUnmappedIndex` depends on for `IntKeyMap`. The shipped behaviour is the property's, not the local's, so the local is deleted rather than promoted. No behaviour change.

## Tests

`Issues/Issue0225.cs`, three facts.

Two pin the latch, and both fail before the change:

* `TheDiscriminatorMemberNameIsResolvedOnce` — two reads of the same mapping hand back the same string instance (`Assert.Same`). Before, each read allocated, which is the visible trace of the lock and lookup that were meant to happen once.
* `TheLatchedNameIsTheOneTheConventionCarries` — with a convention configured for `$type`, that is the name latched, so the fix cannot pass by freezing a plausible default.

The third pins the other half of the contract:

* `ARegistrationAfterTheFirstReadStillReachesTheMapping` — a convention registered after a read that resolved to nothing still reaches the mapping. It passes before the change, since nothing latched at all then; what it guards is the future edit that tidies the conditional assignment into an unconditional one. Verified by making that edit: the test fails.

Two things about that third test worth recording, because neither is obvious and both cost a rewrite to find:

* Registering the *subtype* is no way in. `Circle` carries its discriminator as an attribute, so `GetConvention` resolves it on the first ask without any registration at all. Getting a first lookup that resolves to nothing takes a type whose discriminator is an `int` in a registry holding only the `string` convention — `TryRegisterType` turns that one down.
* **An unresolved mapping is not reachable through `MemberMappings`.** `ObjectMapping.EnsureInitialize` runs `ValidateMemberNamesAndindexes`, which requires a name on every member mapping, so reading `MemberMappings` throws `CborException` before it can hand the unresolved discriminator mapping back. The test builds the `DiscriminatorMapping<T>` directly for that reason.

The second point qualifies the claim this PR would otherwise be making. The latch-on-success behaviour is real at the level of the mapping, but the `ObjectMapping` that holds it refuses to initialize while the name is missing, so the door the latch keeps open is one nothing currently walks through. That is a reason to keep it shut correctly rather than to weld it — freezing `null` would still be wrong the day `ObjectMapping` tolerates a late name — but it is not the same as saying #226 made the behaviour observable end to end.

## Verification

Rebased on `master` (4e6e690), no conflicts.

| Target | Result |
| --- | --- |
| `Dahomey.Cbor.Tests` net8.0 / net9.0 / net10.0 | 1929 passed, 0 failed, 45 skipped (1974) each |
| `Dahomey.Cbor.Generator.Tests` net8.0 / net9.0 / net10.0 | 42 passed each |

Every runnable target framework was run. `netstandard2.0` is the one that was not: no test project targets it, so that build of the library is compiled and never executed — here or in CI.
