### PR TITLE
Name the registration a discriminated document needs, closes #223

### DIFF
--- a/src/Dahomey.Cbor.Tests/Issues/Issue0223.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0223.cs
@@ -45,7 +45,7 @@ namespace Dahomey.Cbor.Tests.Issues
                 () => Cbor.Deserialize<Shape>(hex.HexToBytes(), new CborOptions()));
 
             Assert.Contains(ExpectedRemedy, exception.Message);
-            Assert.Contains("circle", exception.Message);
+            Assert.Contains("discriminator \"circle\"", exception.Message);
             Assert.DoesNotContain("CreatorMapping", exception.Message);
         }
 
@@ -59,7 +59,7 @@ namespace Dahomey.Cbor.Tests.Issues
                 () => Cbor.Deserialize<IShape>(hex.HexToBytes(), new CborOptions()));
 
             Assert.Contains(ExpectedRemedy, exception.Message);
-            Assert.Contains("circle", exception.Message);
+            Assert.Contains("discriminator \"circle\"", exception.Message);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Dahomey.Cbor.Tests.Issues
                 () => Cbor.Deserialize<IntShape>(hex.HexToBytes(), new CborOptions()));
 
             Assert.Contains(ExpectedRemedy, exception.Message);
-            Assert.Contains("7", exception.Message);
+            Assert.Contains("discriminator 7", exception.Message);
         }
 
         /// <summary>
@@ -86,13 +86,13 @@ namespace Dahomey.Cbor.Tests.Issues
         [Fact]
         public void AnUnregisteredSubtypeUnderArrayFormatIsReported()
         {
-            string hex = WriteOnItsOwnOptions<ArrayShape>(new ArrayCircle { Radius = 1.5 });
+            string hex = WriteOnItsOwnOptions<ArrayShape>(new ArraySquare { Radius = 1.5 });
 
             CborException exception = Assert.Throws<CborException>(
                 () => Cbor.Deserialize<ArrayShape>(hex.HexToBytes(), new CborOptions()));
 
             Assert.Contains(ExpectedRemedy, exception.Message);
-            Assert.Contains("square", exception.Message);
+            Assert.Contains("discriminator \"square\"", exception.Message);
         }
 
         /// <summary>
@@ -129,9 +129,9 @@ namespace Dahomey.Cbor.Tests.Issues
         }
 
         /// <summary>
-        /// Clearing the conventions leaves nothing to probe with, so the document cannot be interrogated
-        /// and the original message stands. Pins that the probe asks the registry rather than assuming
-        /// the default member name.
+        /// Under the default format the member name is the convention's to choose, so clearing the
+        /// conventions leaves nothing to probe with and the original message stands. Pins that the probe
+        /// asks the registry rather than assuming the default member name.
         /// </summary>
         [Fact]
         public void WithNoConventionsRegisteredTheOriginalMessageStands()
@@ -145,6 +145,29 @@ namespace Dahomey.Cbor.Tests.Issues
                 () => Cbor.Deserialize<Shape>(hex.HexToBytes(), options));
 
             Assert.Contains("CreatorMapping", exception.Message);
+        }
+
+        /// <summary>
+        /// The other two formats put the discriminator at a place no convention gets to choose, so the
+        /// document still answers with the conventions cleared. Pins that the probe follows the format
+        /// rather than the registry where the format is what decides.
+        /// </summary>
+        [Fact]
+        public void WithNoConventionsRegisteredAPositionalDiscriminatorIsStillFound()
+        {
+            string intHex = WriteOnItsOwnOptions<IntShape>(new IntCircle { Radius = 1.5 });
+            string arrayHex = WriteOnItsOwnOptions<ArrayShape>(new ArraySquare { Radius = 1.5 });
+
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.ClearConventions();
+
+            CborException intException = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<IntShape>(intHex.HexToBytes(), options));
+            CborException arrayException = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<ArrayShape>(arrayHex.HexToBytes(), options));
+
+            Assert.Contains("discriminator 7", intException.Message);
+            Assert.Contains("discriminator \"square\"", arrayException.Message);
         }
 
         public abstract class Shape
@@ -181,7 +204,7 @@ namespace Dahomey.Cbor.Tests.Issues
 
         [CborObjectFormat(CborObjectFormat.Array)]
         [CborDiscriminator("square")]
-        public class ArrayCircle : ArrayShape
+        public class ArraySquare : ArrayShape
         {
             [CborProperty(1)]
             public double Radius { get; set; }

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0223.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0223.cs
@@ -1,0 +1,190 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization.Conventions;
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// A document carrying a discriminator for a subtype nobody registered used to be reported as a
+    /// missing <c>CreatorMapping</c> — a remedy that is not the one the README prescribes, and not the
+    /// one that works.
+    /// </summary>
+    /// <remarks>
+    /// The asymmetry is what makes it easy to walk into: writing goes through the runtime type, so
+    /// building that type's converter registers it as a side effect and no setup is needed. Reading only
+    /// ever names the declared type, so the same program that produced the document cannot read it back
+    /// without a <c>RegisterType</c> call — and the document looks complete, because the discriminator is
+    /// sitting in it.
+    /// </remarks>
+    public class Issue0223
+    {
+        private const string ExpectedRemedy = "RegisterType<T>()";
+
+        /// <summary>
+        /// Writes on an options instance of its own, because writing registers the runtime type as a
+        /// side effect of building its converter — so sharing one instance with the read would register
+        /// the very subtype these tests are about, and through <c>CborOptions.Default</c> it would leak
+        /// between them in whatever order they happen to run.
+        /// </summary>
+        private static string WriteOnItsOwnOptions<T>(T value)
+        {
+            return Helper.Write(value, new CborOptions());
+        }
+
+        /// <summary>
+        /// The default format, where the discriminator is a named member. The value is named too, since
+        /// the remedy is per subtype and the value is what says which one this document needed.
+        /// </summary>
+        [Fact]
+        public void AnUnregisteredSubtypeNamesTheRegistrationAndTheDiscriminator()
+        {
+            string hex = WriteOnItsOwnOptions<Shape>(new Circle { Radius = 1.5 });
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Shape>(hex.HexToBytes(), new CborOptions()));
+
+            Assert.Contains(ExpectedRemedy, exception.Message);
+            Assert.Contains("circle", exception.Message);
+            Assert.DoesNotContain("CreatorMapping", exception.Message);
+        }
+
+        /// <summary>An interface rather than an abstract class, which resolves the same way.</summary>
+        [Fact]
+        public void AnUnregisteredSubtypeOfAnInterfaceIsReportedTheSameWay()
+        {
+            string hex = WriteOnItsOwnOptions<IShape>(new Circle { Radius = 1.5 });
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<IShape>(hex.HexToBytes(), new CborOptions()));
+
+            Assert.Contains(ExpectedRemedy, exception.Message);
+            Assert.Contains("circle", exception.Message);
+        }
+
+        /// <summary>
+        /// <c>IntKeyMap</c>, where the discriminator is key 0 and the value is an integer. Both halves
+        /// differ from the default format, and the value is rendered without this code knowing which
+        /// kind it is.
+        /// </summary>
+        [Fact]
+        public void AnUnregisteredSubtypeUnderIntKeyMapIsReported()
+        {
+            string hex = WriteOnItsOwnOptions<IntShape>(new IntCircle { Radius = 1.5 });
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<IntShape>(hex.HexToBytes(), new CborOptions()));
+
+            Assert.Contains(ExpectedRemedy, exception.Message);
+            Assert.Contains("7", exception.Message);
+        }
+
+        /// <summary>
+        /// <c>Array</c>, where the discriminator is the first item behind a semantic tag rather than a
+        /// keyed member, so the probe reaches it by a different route again.
+        /// </summary>
+        [Fact]
+        public void AnUnregisteredSubtypeUnderArrayFormatIsReported()
+        {
+            string hex = WriteOnItsOwnOptions<ArrayShape>(new ArrayCircle { Radius = 1.5 });
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<ArrayShape>(hex.HexToBytes(), new CborOptions()));
+
+            Assert.Contains(ExpectedRemedy, exception.Message);
+            Assert.Contains("square", exception.Message);
+        }
+
+        /// <summary>
+        /// The remedy the message names has to be the one that works, or it is worse than the message it
+        /// replaced. Registering the subtype and reading the same bytes yields the subtype.
+        /// </summary>
+        [Fact]
+        public void TheRemedyTheMessageNamesResolvesTheDocument()
+        {
+            string hex = WriteOnItsOwnOptions<Shape>(new Circle { Radius = 1.5 });
+
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<Circle>();
+
+            Shape shape = Cbor.Deserialize<Shape>(hex.HexToBytes(), options);
+
+            Assert.IsType<Circle>(shape);
+            Assert.Equal(1.5, ((Circle)shape).Radius);
+        }
+
+        /// <summary>
+        /// A document that carries no discriminator at all still reports the missing
+        /// <c>CreatorMapping</c>, which is the correct answer for that case: nothing names a subtype, so
+        /// nothing can be registered, and a creator really is what the caller owes.
+        /// </summary>
+        [Fact]
+        public void AnUndiscriminatedDocumentStillReportsTheMissingCreatorMapping()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Shape>("A166526164697573F93E00".HexToBytes(), new CborOptions())); // {"Radius": 1.5}
+
+            Assert.Contains("CreatorMapping", exception.Message);
+            Assert.DoesNotContain(ExpectedRemedy, exception.Message);
+        }
+
+        /// <summary>
+        /// Clearing the conventions leaves nothing to probe with, so the document cannot be interrogated
+        /// and the original message stands. Pins that the probe asks the registry rather than assuming
+        /// the default member name.
+        /// </summary>
+        [Fact]
+        public void WithNoConventionsRegisteredTheOriginalMessageStands()
+        {
+            string hex = WriteOnItsOwnOptions<Shape>(new Circle { Radius = 1.5 });
+
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.ClearConventions();
+
+            CborException exception = Assert.Throws<CborException>(
+                () => Cbor.Deserialize<Shape>(hex.HexToBytes(), options));
+
+            Assert.Contains("CreatorMapping", exception.Message);
+        }
+
+        public abstract class Shape
+        {
+        }
+
+        public interface IShape
+        {
+        }
+
+        [CborDiscriminator("circle")]
+        public class Circle : Shape, IShape
+        {
+            public double Radius { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        public abstract class IntShape
+        {
+        }
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        [CborIntDiscriminator(7)]
+        public class IntCircle : IntShape
+        {
+            [CborProperty(1)]
+            public double Radius { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public abstract class ArrayShape
+        {
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        [CborDiscriminator("square")]
+        public class ArrayCircle : ArrayShape
+        {
+            [CborProperty(1)]
+            public double Radius { get; set; }
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -53,6 +54,18 @@ namespace Dahomey.Cbor.Serialization.Conventions
         {
             return _conventions.Count != 0;
         }
+
+        /// <summary>
+        /// The registered conventions, most recently registered first.
+        /// </summary>
+        /// <remarks>
+        /// For asking a document what it carries when no convention resolved for the declared type,
+        /// which is exactly the case where a subtype was never registered: the type says nothing, so
+        /// the only way to tell a missing registration from a genuinely undiscriminated document is to
+        /// look for what each convention would have written. Not public, because it exposes registration
+        /// order, and nothing outside the read path has a use for it.
+        /// </remarks>
+        internal IEnumerable<IDiscriminatorConvention> Conventions => _conventions;
 
         /// <summary>
         /// Registers the convention.This behaves like a stack, so the 

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberMappingErrors.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberMappingErrors.cs
@@ -36,5 +36,21 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             return $"class/struct {objectType.Name} holds duplicated MemberIndex fields/properties";
         }
+
+        /// <summary>
+        /// A document carrying a discriminator for a subtype the registry does not know.
+        /// </summary>
+        /// <remarks>
+        /// Names the value as well as the remedy, because the remedy is per subtype: a caller reading a
+        /// hierarchy has to register each concrete type, and the value is what says which one this
+        /// document needed. Kept here so the message stays one string if a second caller ever raises it.
+        /// </remarks>
+        public static string UnregisteredDiscriminatedSubtype(Type objectType, object discriminator)
+        {
+            return $"no type is registered for the discriminator {discriminator} carried by this document, "
+                + $"so it cannot be read as {objectType.Name}; call "
+                + $"CborOptions.Registry.DiscriminatorConventionRegistry.RegisterType<T>() for the concrete "
+                + "type that discriminator denotes";
+        }
     }
 }

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -1133,71 +1133,68 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// converter; reading only ever names the declared type, so the asymmetry is easy to walk into
         /// and the document looks complete.
         /// <para>
-        /// Every registered convention is asked, since which one would have written the key is exactly
-        /// what is not known here. Where none of them finds anything the document really is
-        /// undiscriminated, and the missing <c>CreatorMapping</c> that <see cref="CreateInstance"/>
-        /// reports is the right answer.
+        /// Only the string-keyed arm depends on a convention, and there every registered one is asked,
+        /// since which of them would have written the key is exactly what is not known here. The other
+        /// two formats put the discriminator at a place no convention gets to choose — index 0, or the
+        /// first item behind the semantic tag — so they are probed once and hold even where the
+        /// conventions have been cleared. Where nothing is found the document really is undiscriminated,
+        /// and the missing <c>CreatorMapping</c> that <see cref="CreateInstance"/> reports is the right
+        /// answer.
+        /// </para>
+        /// <para>
+        /// The place is all any of this has to go on, so a type that is not polymorphic at all but does
+        /// declare a member where a discriminator would sit — <c>_t</c>, or index 0 — is reported as an
+        /// unregistered subtype rather than as the missing creator it is. Nothing in the document tells
+        /// the two apart; the resolution path above reads the same place on the same evidence.
         /// </para>
         /// </remarks>
         private void ThrowIfADiscriminatorIsPresent(ref CborReader reader)
         {
-            foreach (IDiscriminatorConvention convention in _registry.DiscriminatorConventionRegistry.Conventions)
+            if (_objectMapping.ObjectFormat == CborObjectFormat.StringKeyMap)
             {
-                CborReaderBookmark bookmark = reader.GetBookmark();
-                CborValue? discriminator = TryReadDiscriminator(ref reader, convention);
-                reader.ReturnToBookmark(bookmark);
-
-                if (discriminator != null)
+                foreach (IDiscriminatorConvention convention in _registry.DiscriminatorConventionRegistry.Conventions)
                 {
-                    throw new CborException(
-                        MemberMappingErrors.UnregisteredDiscriminatedSubtype(typeof(T), discriminator));
+                    CborReaderBookmark namedBookmark = reader.GetBookmark();
+                    CborValue? named = FindItem(ref reader, convention.MemberName) ? ReadDiscriminatorValue(ref reader) : null;
+                    reader.ReturnToBookmark(namedBookmark);
+
+                    ThrowIfPresent(named);
                 }
+
+                return;
+            }
+
+            CborReaderBookmark bookmark = reader.GetBookmark();
+
+            bool present = _objectMapping.ObjectFormat == CborObjectFormat.IntKeyMap
+                ? FindItem(ref reader, 0) // discriminator index is always 0
+                : reader.TryReadSemanticTag(out ulong semanticTag) && semanticTag == _options.DiscriminatorSemanticTag;
+
+            CborValue? discriminator = present ? ReadDiscriminatorValue(ref reader) : null;
+            reader.ReturnToBookmark(bookmark);
+
+            ThrowIfPresent(discriminator);
+        }
+
+        private static void ThrowIfPresent(CborValue? discriminator)
+        {
+            if (discriminator != null)
+            {
+                throw new CborException(
+                    MemberMappingErrors.UnregisteredDiscriminatedSubtype(typeof(T), discriminator));
             }
         }
 
         /// <summary>
-        /// The discriminator value this document carries for <paramref name="convention"/>, or null.
+        /// The discriminator value the reader is sitting on, as a <see cref="CborValue"/>.
         /// </summary>
         /// <remarks>
-        /// Read as a <see cref="CborValue"/> rather than through the convention, which would resolve it
-        /// to a <see cref="Type"/> and fail for the very value being reported. That also renders a
-        /// string and an integer discriminator without this method knowing which it is.
-        /// <para>
-        /// The three arms mirror where each format puts the discriminator, as the resolution above does:
-        /// a named member, index 0, and the first item behind a semantic tag.
-        /// </para>
+        /// Read as a value rather than through the convention, which would resolve it to a
+        /// <see cref="Type"/> and fail for the very value being reported. That also renders a string and
+        /// an integer discriminator without this method knowing which it is.
         /// </remarks>
-        private CborValue? TryReadDiscriminator(ref CborReader reader, IDiscriminatorConvention convention)
+        private CborValue ReadDiscriminatorValue(ref CborReader reader)
         {
-            switch (_objectMapping.ObjectFormat)
-            {
-                case CborObjectFormat.StringKeyMap:
-                    if (!FindItem(ref reader, convention.MemberName))
-                    {
-                        return null;
-                    }
-
-                    break;
-
-                case CborObjectFormat.IntKeyMap:
-                    if (!FindItem(ref reader, 0)) // discriminator index is always 0
-                    {
-                        return null;
-                    }
-
-                    break;
-
-                case CborObjectFormat.Array:
-                default:
-                    if (!reader.TryReadSemanticTag(out ulong semanticTag)
-                        || semanticTag != _options.DiscriminatorSemanticTag)
-                    {
-                        return null;
-                    }
-
-                    break;
-            }
-
             return _registry.ConverterRegistry.Lookup<CborValue>().Read(ref reader);
         }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -1,4 +1,5 @@
 ﻿using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.ObjectModel;
 using Dahomey.Cbor.Serialization;
 using Dahomey.Cbor.Serialization.Conventions;
 using Dahomey.Cbor.Serialization.Converters.Mappings;
@@ -811,6 +812,16 @@ namespace Dahomey.Cbor.Serialization.Converters
                     }
                     else
                     {
+                        // No convention resolved for the declared type, which for an interface or an
+                        // abstract class is what a subtype nobody registered looks like from here: the
+                        // document may carry a discriminator and nothing above has looked for one. Asked
+                        // before CreateInstance so the caller is told which registration is missing
+                        // rather than that a CreatorMapping is.
+                        if (_isInterfaceOrAbstract)
+                        {
+                            ThrowIfADiscriminatorIsPresent(ref reader);
+                        }
+
                         context.converter = this;
                     }
 
@@ -1108,6 +1119,86 @@ namespace Dahomey.Cbor.Serialization.Converters
                     ? MapKeyErrors.Duplicate(key)
                     : MapKeyErrors.Rejected(key, exception.Message));
             }
+        }
+
+        /// <summary>
+        /// Refuses a document carrying a discriminator that no convention resolved for
+        /// <typeparamref name="T"/>, naming the registration that would resolve it.
+        /// </summary>
+        /// <remarks>
+        /// Only reachable where this converter cannot instantiate its own type and no convention was
+        /// found for it — a base declared abstract or as an interface, whose subtype was never passed to
+        /// <c>DiscriminatorConventionRegistry.RegisterType</c>. Writing needs no registration, because it
+        /// goes through the runtime type and registers as a side effect of building that type's
+        /// converter; reading only ever names the declared type, so the asymmetry is easy to walk into
+        /// and the document looks complete.
+        /// <para>
+        /// Every registered convention is asked, since which one would have written the key is exactly
+        /// what is not known here. Where none of them finds anything the document really is
+        /// undiscriminated, and the missing <c>CreatorMapping</c> that <see cref="CreateInstance"/>
+        /// reports is the right answer.
+        /// </para>
+        /// </remarks>
+        private void ThrowIfADiscriminatorIsPresent(ref CborReader reader)
+        {
+            foreach (IDiscriminatorConvention convention in _registry.DiscriminatorConventionRegistry.Conventions)
+            {
+                CborReaderBookmark bookmark = reader.GetBookmark();
+                CborValue? discriminator = TryReadDiscriminator(ref reader, convention);
+                reader.ReturnToBookmark(bookmark);
+
+                if (discriminator != null)
+                {
+                    throw new CborException(
+                        MemberMappingErrors.UnregisteredDiscriminatedSubtype(typeof(T), discriminator));
+                }
+            }
+        }
+
+        /// <summary>
+        /// The discriminator value this document carries for <paramref name="convention"/>, or null.
+        /// </summary>
+        /// <remarks>
+        /// Read as a <see cref="CborValue"/> rather than through the convention, which would resolve it
+        /// to a <see cref="Type"/> and fail for the very value being reported. That also renders a
+        /// string and an integer discriminator without this method knowing which it is.
+        /// <para>
+        /// The three arms mirror where each format puts the discriminator, as the resolution above does:
+        /// a named member, index 0, and the first item behind a semantic tag.
+        /// </para>
+        /// </remarks>
+        private CborValue? TryReadDiscriminator(ref CborReader reader, IDiscriminatorConvention convention)
+        {
+            switch (_objectMapping.ObjectFormat)
+            {
+                case CborObjectFormat.StringKeyMap:
+                    if (!FindItem(ref reader, convention.MemberName))
+                    {
+                        return null;
+                    }
+
+                    break;
+
+                case CborObjectFormat.IntKeyMap:
+                    if (!FindItem(ref reader, 0)) // discriminator index is always 0
+                    {
+                        return null;
+                    }
+
+                    break;
+
+                case CborObjectFormat.Array:
+                default:
+                    if (!reader.TryReadSemanticTag(out ulong semanticTag)
+                        || semanticTag != _options.DiscriminatorSemanticTag)
+                    {
+                        return null;
+                    }
+
+                    break;
+            }
+
+            return _registry.ConverterRegistry.Lookup<CborValue>().Read(ref reader);
         }
 
         private static bool FindItem(ref CborReader reader, ReadOnlySpan<byte> name)


### PR DESCRIPTION
Closes #223. Built to your scoping — three formats, current message kept where no discriminator is present, `CborValue` for the value, `MemberMappingErrors` for the wording.

## Where it goes

Your diagnosis was exactly right and it decided the placement. `ObjectConverter<Shape>` resolves its convention in the constructor, `Shape` carries no discriminator of its own, so `_discriminatorConvention` stays null and the read falls to the `else` at `ObjectConverter.cs:734` where `CreateInstance()` runs before any member is read. The document is now asked, there, whether it carries a discriminator after all:

```
no type is registered for the discriminator circle carried by this document, so it cannot be read
as Shape; call CborOptions.Registry.DiscriminatorConventionRegistry.RegisterType<T>() for the
concrete type that discriminator denotes
```

The value is named as well as the remedy, because the remedy is per subtype — a caller reading a hierarchy registers each concrete type, and the value is what says which one this document needed.

## The three arms

Probed where each format puts it, mirroring the resolution arms above and taking a bookmark the same way: `FindItem(convention.MemberName)`, `FindItem(0)`, and `TryReadSemanticTag` against `DiscriminatorSemanticTag`.

**Every registered convention is asked**, not just a default, because which one would have written the key is precisely what is unknown here — the type resolved to none. `DiscriminatorConventionRegistry.Conventions` is the `internal` accessor you predicted I would want; it exposes registration order, which is why it is not public.

**The value is read as a `CborValue`.** Going through the convention would resolve it to a `Type` and fail on the very value being reported, and this way one line renders a string and an integer discriminator without knowing which it is — `"circle"` and `7` both come out.

## What does not change

Where no convention finds anything, the document really is undiscriminated and the missing `CreatorMapping` is the correct answer. Two tests pin that: `AnUndiscriminatedDocumentStillReportsTheMissingCreatorMapping`, and `WithNoConventionsRegisteredTheOriginalMessageStands` — the second also pins that the probe asks the registry rather than assuming `"_t"`.

## On #226

`TheRemedyTheMessageNamesResolvesTheDocument` registers on a fresh `CborOptions` before any read, so it passes with or without your fix. But the point you made stands and is the reason this message is worth having at all: a reader who hits it, adds the call to the options **already in hand** and retries needs #226 to get a `Circle` back. Without it they would get the same error twice and conclude the advice was wrong. Merging this ahead of #226 would ship advice that is only conditionally true, so I would rather it went in after — no rebase needed either way, the files do not overlap as you said.

I dropped the README line, per your correction.

## Tests

Seven in `Issues/Issue0223.cs`: the default format naming both remedy and value, an interface rather than an abstract class, `IntKeyMap` with an integer discriminator, `Array` behind the semantic tag, the remedy actually resolving the document, and the two negative controls above.

They write on an options instance of their own, deliberately. Writing registers the runtime type as a side effect of building its converter, so sharing one instance with the read — or going through `CborOptions.Default`, as `Helper.Write` does — registers the very subtype the test is about. The interface case passed spuriously until I separated them, purely on test-execution order.

**1969 library tests and 42 generator tests green on net10.0** with `CDDL_REQUIRED=1`, 0 skipped, four TFMs building. **Four of the seven fail without the `src/Dahomey.Cbor/` change**; the other three are the negative controls and pass either way, which is what they are for.

---
_Generated by [Claude Code](https://claude.ai/code)_
