### PR TITLE
Assert a refusal reaches the caller through every read entry point

### DIFF
--- a/src/Dahomey.Cbor.Tests/RefusalReachesEveryEntryPointTests.cs
+++ b/src/Dahomey.Cbor.Tests/RefusalReachesEveryEntryPointTests.cs
@@ -26,7 +26,10 @@ namespace Dahomey.Cbor.Tests
     /// <para>
     /// Arranged as a theory over the entry points rather than as a test each, so the failure names the
     /// door rather than the mechanism, and so adding an entry point without a row here is a visible
-    /// omission rather than a silent one.
+    /// omission rather than a silent one. The rows are the reading half of <see cref="Cbor"/>: the four
+    /// single-item doors, the four multiple-item ones, and <c>ReadNextItemAsync</c>. The non-generic
+    /// <c>Type</c> overloads are the same methods with the type passed rather than inferred, and reach
+    /// the converter by the same route, so they are not repeated here.
     /// </para>
     /// </remarks>
     public class RefusalReachesEveryEntryPointTests
@@ -40,29 +43,12 @@ namespace Dahomey.Cbor.Tests
 
         public static IEnumerable<object[]> EntryPoints()
         {
-            yield return Row("Deserialize(ReadOnlySpan)",
-                (bytes, options) => Cbor.Deserialize<RefusedByItsConverter>(bytes.Span, options));
+            return EntryPointsFor<RefusedByItsConverter>();
+        }
 
-            yield return Row("Deserialize(ReadOnlySequence)",
-                (bytes, options) => Cbor.Deserialize<RefusedByItsConverter>(new ReadOnlySequence<byte>(bytes), options));
-
-            yield return Row("DeserializeMultiple(ReadOnlySpan)",
-                (bytes, options) => Cbor.DeserializeMultiple<RefusedByItsConverter>(bytes.Span, options));
-
-            yield return Row("DeserializeMultiple(ReadOnlySequence)",
-                (bytes, options) => Cbor.DeserializeMultiple<RefusedByItsConverter>(new ReadOnlySequence<byte>(bytes), options));
-
-            yield return Row("DeserializeAsync(Stream)",
-                (bytes, options) => Cbor.DeserializeAsync<RefusedByItsConverter>(
-                    new MemoryStream(bytes.ToArray()), options).AsTask().GetAwaiter().GetResult());
-
-            yield return Row("DeserializeAsync(PipeReader)",
-                (bytes, options) => Cbor.DeserializeAsync<RefusedByItsConverter>(
-                    PipeReader.Create(new ReadOnlySequence<byte>(bytes)), options).AsTask().GetAwaiter().GetResult());
-
-            yield return Row("ReadNextItemAsync(PipeReader)",
-                (bytes, options) => Cbor.ReadNextItemAsync<RefusedByItsConverter>(
-                    PipeReader.Create(new ReadOnlySequence<byte>(bytes)), options).AsTask().GetAwaiter().GetResult());
+        public static IEnumerable<object[]> CreatorEntryPoints()
+        {
+            return EntryPointsFor<RefusedByItsCreator>();
         }
 
         /// <summary>
@@ -71,16 +57,17 @@ namespace Dahomey.Cbor.Tests
         /// </summary>
         [Theory]
         [MemberData(nameof(EntryPoints))]
-        public void AConverterRefusalKeepsItsMessage(string name, Func<ReadOnlyMemory<byte>, CborOptions, object> read)
+        public async Task AConverterRefusalKeepsItsMessageAsync(string name, Func<ReadOnlyMemory<byte>, CborOptions, Task<object>> readAsync)
         {
             CborOptions options = new CborOptions();
             options.Registry.ConverterRegistry.RegisterConverter(
                 typeof(RefusedByItsConverter), new RefusingConverter());
 
-            CborException exception = Assert.Throws<CborException>(
-                () => read(WholeItem.HexToBytes(), options));
+            CborException exception = await Assert.ThrowsAsync<CborException>(
+                async () => await readAsync(WholeItem.HexToBytes(), options));
 
-            Assert.StartsWith(ConverterMessage, exception.Message);
+            Assert.True(exception.Message.StartsWith(ConverterMessage, StringComparison.Ordinal),
+                $"{name} reported \"{exception.Message}\" rather than the converter's refusal.");
             Assert.Equal("$", exception.Path);
 
             // The message the entry point would invent if it discarded the refusal. Named rather than
@@ -97,39 +84,66 @@ namespace Dahomey.Cbor.Tests
         /// </summary>
         [Theory]
         [MemberData(nameof(CreatorEntryPoints))]
-        public void ACreatorRefusalKeepsItsMessage(string name, Func<ReadOnlyMemory<byte>, CborOptions, object> read)
+        public async Task ACreatorRefusalKeepsItsMessageAsync(string name, Func<ReadOnlyMemory<byte>, CborOptions, Task<object>> readAsync)
         {
-            CborException exception = Assert.Throws<CborException>(
-                () => read(WholeItem.HexToBytes(), new CborOptions()));
+            CborException exception = await Assert.ThrowsAsync<CborException>(
+                async () => await readAsync(WholeItem.HexToBytes(), new CborOptions()));
 
-            Assert.StartsWith(CreatorMessage, exception.Message);
+            Assert.True(exception.Message.StartsWith(CreatorMessage, StringComparison.Ordinal),
+                $"{name} reported \"{exception.Message}\" rather than the creator's refusal.");
             Assert.Equal("$", exception.Path);
         }
 
-        public static IEnumerable<object[]> CreatorEntryPoints()
+        /// <summary>
+        /// The same rows for either refusing type: what differs between the two theories is where the
+        /// refusal comes from, not which doors have to carry it.
+        /// </summary>
+        /// <remarks>
+        /// The synchronous doors are wrapped rather than awaited — a lambda holding a
+        /// <see cref="ReadOnlySpan{T}"/> cannot be <c>async</c>, and the exception each one throws while
+        /// the delegate is being invoked is caught by <c>Assert.ThrowsAsync</c> all the same.
+        /// </remarks>
+        private static IEnumerable<object[]> EntryPointsFor<T>()
         {
             yield return Row("Deserialize(ReadOnlySpan)",
-                (bytes, options) => Cbor.Deserialize<RefusedByItsCreator>(bytes.Span, options));
+                (bytes, options) => CompletedAsync(Cbor.Deserialize<T>(bytes.Span, options)));
 
             yield return Row("Deserialize(ReadOnlySequence)",
-                (bytes, options) => Cbor.Deserialize<RefusedByItsCreator>(new ReadOnlySequence<byte>(bytes), options));
+                (bytes, options) => CompletedAsync(Cbor.Deserialize<T>(new ReadOnlySequence<byte>(bytes), options)));
 
             yield return Row("DeserializeAsync(Stream)",
-                (bytes, options) => Cbor.DeserializeAsync<RefusedByItsCreator>(
-                    new MemoryStream(bytes.ToArray()), options).AsTask().GetAwaiter().GetResult());
+                async (bytes, options) => await Cbor.DeserializeAsync<T>(new MemoryStream(bytes.ToArray()), options));
 
             yield return Row("DeserializeAsync(PipeReader)",
-                (bytes, options) => Cbor.DeserializeAsync<RefusedByItsCreator>(
-                    PipeReader.Create(new ReadOnlySequence<byte>(bytes)), options).AsTask().GetAwaiter().GetResult());
+                async (bytes, options) => await Cbor.DeserializeAsync<T>(
+                    PipeReader.Create(new ReadOnlySequence<byte>(bytes)), options));
+
+            yield return Row("DeserializeMultiple(ReadOnlySpan)",
+                (bytes, options) => CompletedAsync(Cbor.DeserializeMultiple<T>(bytes.Span, options)));
+
+            yield return Row("DeserializeMultiple(ReadOnlySequence)",
+                (bytes, options) => CompletedAsync(Cbor.DeserializeMultiple<T>(new ReadOnlySequence<byte>(bytes), options)));
+
+            yield return Row("DeserializeMultipleAsync(Stream)",
+                async (bytes, options) => await Cbor.DeserializeMultipleAsync<T>(new MemoryStream(bytes.ToArray()), options));
+
+            yield return Row("DeserializeMultipleAsync(PipeReader)",
+                async (bytes, options) => await Cbor.DeserializeMultipleAsync<T>(
+                    PipeReader.Create(new ReadOnlySequence<byte>(bytes)), options));
 
             yield return Row("ReadNextItemAsync(PipeReader)",
-                (bytes, options) => Cbor.ReadNextItemAsync<RefusedByItsCreator>(
-                    PipeReader.Create(new ReadOnlySequence<byte>(bytes)), options).AsTask().GetAwaiter().GetResult());
+                async (bytes, options) => await Cbor.ReadNextItemAsync<T>(
+                    PipeReader.Create(new ReadOnlySequence<byte>(bytes)), options));
         }
 
-        private static object[] Row(string name, Func<ReadOnlyMemory<byte>, CborOptions, object> read)
+        private static Task<object> CompletedAsync(object result)
         {
-            return new object[] { name, read };
+            return Task.FromResult(result);
+        }
+
+        private static object[] Row(string name, Func<ReadOnlyMemory<byte>, CborOptions, Task<object>> readAsync)
+        {
+            return new object[] { name, readAsync };
         }
 
         public class RefusedByItsConverter

--- a/src/Dahomey.Cbor.Tests/RefusalReachesEveryEntryPointTests.cs
+++ b/src/Dahomey.Cbor.Tests/RefusalReachesEveryEntryPointTests.cs
@@ -1,0 +1,161 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Serialization.Converters;
+using Dahomey.Cbor.Tests.Extensions;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipelines;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// A refusal is reported as a refusal whichever door the caller came in through. One refusing
+    /// converter, one document, every public read entry point, and the same assertion on each: the
+    /// message the converter wrote reaches the caller.
+    /// </summary>
+    /// <remarks>
+    /// This exists because the contract held everywhere except one place, and the tests were arranged by
+    /// mechanism rather than by entry point, so nothing compared them. <c>ReadNextItemAsync</c> reads
+    /// speculatively and treated a refusal as "not enough bytes yet", reporting a truncated stream
+    /// instead — for as long as it had existed, and invisibly, because every other door reported it
+    /// correctly and each was tested on its own.
+    /// <para>
+    /// Arranged as a theory over the entry points rather than as a test each, so the failure names the
+    /// door rather than the mechanism, and so adding an entry point without a row here is a visible
+    /// omission rather than a silent one.
+    /// </para>
+    /// </remarks>
+    public class RefusalReachesEveryEntryPointTests
+    {
+        /// <summary>{"Id": 12} — a whole, well-formed item. Nothing here is truncated or malformed.</summary>
+        private const string WholeItem = "A16249640C";
+
+        private const string ConverterMessage = "this converter refuses what it read";
+
+        private const string CreatorMessage = "this creator refuses 12";
+
+        public static IEnumerable<object[]> EntryPoints()
+        {
+            yield return Row("Deserialize(ReadOnlySpan)",
+                (bytes, options) => Cbor.Deserialize<RefusedByItsConverter>(bytes.Span, options));
+
+            yield return Row("Deserialize(ReadOnlySequence)",
+                (bytes, options) => Cbor.Deserialize<RefusedByItsConverter>(new ReadOnlySequence<byte>(bytes), options));
+
+            yield return Row("DeserializeMultiple(ReadOnlySpan)",
+                (bytes, options) => Cbor.DeserializeMultiple<RefusedByItsConverter>(bytes.Span, options));
+
+            yield return Row("DeserializeMultiple(ReadOnlySequence)",
+                (bytes, options) => Cbor.DeserializeMultiple<RefusedByItsConverter>(new ReadOnlySequence<byte>(bytes), options));
+
+            yield return Row("DeserializeAsync(Stream)",
+                (bytes, options) => Cbor.DeserializeAsync<RefusedByItsConverter>(
+                    new MemoryStream(bytes.ToArray()), options).AsTask().GetAwaiter().GetResult());
+
+            yield return Row("DeserializeAsync(PipeReader)",
+                (bytes, options) => Cbor.DeserializeAsync<RefusedByItsConverter>(
+                    PipeReader.Create(new ReadOnlySequence<byte>(bytes)), options).AsTask().GetAwaiter().GetResult());
+
+            yield return Row("ReadNextItemAsync(PipeReader)",
+                (bytes, options) => Cbor.ReadNextItemAsync<RefusedByItsConverter>(
+                    PipeReader.Create(new ReadOnlySequence<byte>(bytes)), options).AsTask().GetAwaiter().GetResult());
+        }
+
+        /// <summary>
+        /// A converter that refuses what it read. The converter is the shortest route to the contract —
+        /// it is the caller's code, and every entry point reaches it the same way.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(EntryPoints))]
+        public void AConverterRefusalKeepsItsMessage(string name, Func<ReadOnlyMemory<byte>, CborOptions, object> read)
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ConverterRegistry.RegisterConverter(
+                typeof(RefusedByItsConverter), new RefusingConverter());
+
+            CborException exception = Assert.Throws<CborException>(
+                () => read(WholeItem.HexToBytes(), options));
+
+            Assert.StartsWith(ConverterMessage, exception.Message);
+            Assert.Equal("$", exception.Path);
+
+            // The message the entry point would invent if it discarded the refusal. Named rather than
+            // implied, because that substitution is the failure this test exists to catch and it is
+            // otherwise indistinguishable from a genuinely truncated document.
+            Assert.DoesNotContain("no item was read", exception.Message);
+            Assert.DoesNotContain("Unexpected end of buffer", exception.Message);
+        }
+
+        /// <summary>
+        /// The same through a <c>[CborConstructor]</c>, which is the caller's own type refusing the
+        /// values a document carried rather than a converter they wrote. It reaches the entry points
+        /// through <c>CreatorMapping</c>, one layer further in.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(CreatorEntryPoints))]
+        public void ACreatorRefusalKeepsItsMessage(string name, Func<ReadOnlyMemory<byte>, CborOptions, object> read)
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => read(WholeItem.HexToBytes(), new CborOptions()));
+
+            Assert.StartsWith(CreatorMessage, exception.Message);
+            Assert.Equal("$", exception.Path);
+        }
+
+        public static IEnumerable<object[]> CreatorEntryPoints()
+        {
+            yield return Row("Deserialize(ReadOnlySpan)",
+                (bytes, options) => Cbor.Deserialize<RefusedByItsCreator>(bytes.Span, options));
+
+            yield return Row("Deserialize(ReadOnlySequence)",
+                (bytes, options) => Cbor.Deserialize<RefusedByItsCreator>(new ReadOnlySequence<byte>(bytes), options));
+
+            yield return Row("DeserializeAsync(Stream)",
+                (bytes, options) => Cbor.DeserializeAsync<RefusedByItsCreator>(
+                    new MemoryStream(bytes.ToArray()), options).AsTask().GetAwaiter().GetResult());
+
+            yield return Row("DeserializeAsync(PipeReader)",
+                (bytes, options) => Cbor.DeserializeAsync<RefusedByItsCreator>(
+                    PipeReader.Create(new ReadOnlySequence<byte>(bytes)), options).AsTask().GetAwaiter().GetResult());
+
+            yield return Row("ReadNextItemAsync(PipeReader)",
+                (bytes, options) => Cbor.ReadNextItemAsync<RefusedByItsCreator>(
+                    PipeReader.Create(new ReadOnlySequence<byte>(bytes)), options).AsTask().GetAwaiter().GetResult());
+        }
+
+        private static object[] Row(string name, Func<ReadOnlyMemory<byte>, CborOptions, object> read)
+        {
+            return new object[] { name, read };
+        }
+
+        public class RefusedByItsConverter
+        {
+        }
+
+        public class RefusingConverter : CborConverterBase<RefusedByItsConverter>
+        {
+            public override RefusedByItsConverter Read(ref CborReader reader)
+            {
+                throw new CborException(ConverterMessage);
+            }
+
+            public override void Write(ref CborWriter writer, RefusedByItsConverter value)
+                => throw new NotSupportedException();
+        }
+
+        public class RefusedByItsCreator
+        {
+            public int Id { get; set; }
+
+            [CborConstructor]
+            public RefusedByItsCreator(int id)
+            {
+                throw new CborException($"this creator refuses {id}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Test-only, and a follow-up to your #220 rather than a fix for anything still broken.

## What it is for

#219 survived as long as it did because the contract held at every public entry point **except one**, and the tests were grouped *by mechanism* rather than *by entry point* — so nothing ever compared the doors against each other. Each door had its own file, each file tested what it was about, and the odd one out was only visible from a vantage point no test occupied.

`Issues/Issue0219.cs` fixes the case. This closes the shape: one refusing converter, one whole document, the same assertion on each of

```
Deserialize(ReadOnlySpan)          DeserializeAsync(Stream)
Deserialize(ReadOnlySequence)      DeserializeAsync(PipeReader)
DeserializeMultiple(ReadOnlySpan)  ReadNextItemAsync(PipeReader)
DeserializeMultiple(ReadOnlySequence)
```

twelve cases with the `[CborConstructor]` half.

## Two details that are the point

**A theory over the entry points, not a test each.** A failure names the door rather than the mechanism, and adding an entry point without a row is a visible omission rather than a silent one.

**It asserts against the substitute messages by name**, not just the exception type:

```csharp
Assert.StartsWith(ConverterMessage, exception.Message);
Assert.Equal("$", exception.Path);
Assert.DoesNotContain("no item was read", exception.Message);
Assert.DoesNotContain("Unexpected end of buffer", exception.Message);
```

A `CborException` of the right type passes while the message has been replaced, and a replaced message is exactly how a refusal disguises itself as malformed input — which is the whole of #219.

## Verification

**1974 library tests green on net10.0** with `CDDL_REQUIRED=1`, 0 skipped, four TFMs building.

All twelve pass on `master` as of #220. Against `f429ba5^` — the commit before it — exactly two fail, and they are the two `ReadNextItemAsync` rows, both reporting `Reader has completed with some buffer bytes but no item was read`. So it isolates your fix precisely.

Offered on #220 before it merged; opening it separately now, as you'd expect.

---
_Generated by [Claude Code](https://claude.ai/code)_
