### PR TITLE
Resolve an Array member by its position, closes #222

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,28 @@ If the aim is compactness rather than interoperability with a producer you do no
 keys altogether. Both compress a document of repeated keys harder than string references do, in plain
 RFC 8949.
 
+The two read `[CborProperty(n)]` differently, and the difference is worth being explicit about.
+`IntKeyMap` writes `n` into the document as the member's key, so it addresses the member: gaps are
+free, and a member keeps its meaning wherever it moves in the type. `Array` writes no keys at all, so
+`n` only *orders* the members — they are written in ascending index order and read back by position.
+Gaps and negative indexes are allowed and change nothing on the wire, so these two types produce
+identical bytes:
+
+```csharp
+[CborObjectFormat(CborObjectFormat.Array)]
+public class Row { [CborProperty(0)] public int Id { get; set; } [CborProperty(1)] public string Name { get; set; } }
+
+[CborObjectFormat(CborObjectFormat.Array)]
+public class SameRow { [CborProperty(5)] public int Id { get; set; } [CborProperty(9)] public string Name { get; set; } }
+
+// both write 82 02 63 726F77  --  [2, "row"]
+```
+
+What that costs is that an `Array` type's wire format depends on its member *set*, not only on the
+indexes: inserting a member with an index that sorts between two existing ones shifts everything after
+it by one position, where `IntKeyMap` would not move. Use `IntKeyMap` where indexes need to be stable
+addresses across versions.
+
 ### Bignums (RFC 8949 §3.4.3)
 
 A member typed `System.Numerics.BigInteger` reads and writes integers of any width. Values that fit in 64

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -615,20 +615,21 @@ namespace Dahomey.Cbor.Tests
         /// with a reason attached and not something a shape can drift into.
         /// </summary>
         /// <remarks>
-        /// Both entries were reproduced against a plain <c>new CborOptions()</c> with no generated
-        /// context in play, so they are pre-existing library defects rather than anything source
-        /// generation does differently. All of them stay in
-        /// <see cref="GeneratedBytesMatchReflectionBytes"/>, which they pass: the two writers agree
+        /// The entry was reproduced against a plain <c>new CborOptions()</c> with no generated
+        /// context in play, so it is a pre-existing library defect rather than anything source
+        /// generation does differently. It stays in
+        /// <see cref="GeneratedBytesMatchReflectionBytes"/>, which it passes: the two writers agree
         /// byte for byte and it is the shared reader that cannot consume the result.
         /// <list type="bullet">
         /// <item><description>A member declared as an abstract class or an interface. The
         /// discriminator is written -- <c>"_t": "circle"</c> is in the bytes -- but reading such a
         /// member asks for a <c>CreatorMapping</c> instead of resolving it.</description></item>
-        /// <item><description><c>Array</c> object format on a type carrying no discriminator. The
-        /// writer packs the first member into slot 0 while the reader treats slot 0 as the
-        /// discriminator's, so <c>CddlRow { Id = 2, Name = "row" }</c> writes <c>[2, "row"]</c> and
-        /// reads <c>"row"</c> back as <c>Id</c>.</description></item>
         /// </list>
+        /// <para>
+        /// The <c>Array</c> object format entries -- <c>CddlRow</c>, <c>CddlArrayBase</c> and
+        /// <c>CddlArrayDerived</c>, whose declared indexes start at 1 rather than 0 -- were removed
+        /// once #222 was fixed, and now round-trip here rather than being excluded from the theory.
+        /// </para>
         /// </remarks>
         private static readonly HashSet<Type> NotReadBackByEitherPath = new HashSet<Type>
         {
@@ -636,9 +637,6 @@ namespace Dahomey.Cbor.Tests
             typeof(Cddl.CddlEventLog),
             typeof(Cddl.CddlOutbox),
             typeof(Cddl.CddlEscapedHolder),
-            typeof(Cddl.CddlRow),
-            typeof(Cddl.CddlArrayBase),
-            typeof(Cddl.CddlArrayDerived),
         };
 
         public static IEnumerable<object[]> RoundTrippableTypes()

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0222.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0222.cs
@@ -1,0 +1,231 @@
+using Dahomey.Cbor.Attributes;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #222: a <see cref="CborObjectFormat.Array"/> type whose declared indexes did not start at
+    /// zero and run consecutively could not read its own output. The write emits members packed from
+    /// the first position; the read counted positions and used the count as the declared index, so the
+    /// two agreed only where the indexes happened to equal the positions.
+    /// </summary>
+    /// <remarks>
+    /// An array carries no keys, so the index in <c>[CborProperty(n)]</c> orders the members and does
+    /// not address them — <c>ObjectMapping</c> sorts by it and allows gaps and negatives alike, and
+    /// <see cref="DeterministicEncodingTests"/> already pins a type declaring <c>-1</c>, which no
+    /// position could ever be. The read now resolves a position against the member list and keys
+    /// everything downstream on the index it finds there.
+    /// <para>
+    /// The silent shape is the one worth keeping covered: indexes far enough from the positions that
+    /// nothing matched at all left every member defaulted and raised nothing, because an unmapped
+    /// index is <see cref="UnhandledNameMode"/>'s business and it ignores by default.
+    /// </para>
+    /// </remarks>
+    public class Issue0222
+    {
+        // 82 02 63 726F77  --  [2, "row"]
+        private const string Row = "820263726F77";
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class ZeroBased
+        {
+            [CborProperty(0)] public int Id { get; set; }
+            [CborProperty(1)] public string Name { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class OneBased
+        {
+            [CborProperty(1)] public int Id { get; set; }
+            [CborProperty(2)] public string Name { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class Sparse
+        {
+            [CborProperty(5)] public int Id { get; set; }
+            [CborProperty(9)] public string Name { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class Negative
+        {
+            [CborProperty(-1)] public int Id { get; set; }
+            [CborProperty(4)] public string Name { get; set; }
+        }
+
+        /// <summary>
+        /// The index set does not reach the wire: all four write the same two items, in ascending
+        /// index order. Pinned first because it is what makes the read the only side that can be
+        /// wrong, and what keeps this fix free of a format change.
+        /// </summary>
+        [Fact]
+        public void EveryIndexSetWritesTheSameBytes()
+        {
+            Assert.Equal(Row, Helper.Write(new ZeroBased { Id = 2, Name = "row" }, new CborOptions()));
+            Assert.Equal(Row, Helper.Write(new OneBased { Id = 2, Name = "row" }, new CborOptions()));
+            Assert.Equal(Row, Helper.Write(new Sparse { Id = 2, Name = "row" }, new CborOptions()));
+            Assert.Equal(Row, Helper.Write(new Negative { Id = 2, Name = "row" }, new CborOptions()));
+        }
+
+        [Fact]
+        public void ZeroBasedIndexesRoundTrip()
+        {
+            ZeroBased row = Helper.Read<ZeroBased>(Row, new CborOptions());
+
+            Assert.Equal(2, row.Id);
+            Assert.Equal("row", row.Name);
+        }
+
+        /// <summary>
+        /// Threw <c>Invalid major type TextString</c> at <c>$.Id</c>: position 0 was read as index 0,
+        /// which no member holds, and position 1 as index 1, which is <c>Id</c> — so the text landed
+        /// on the int.
+        /// </summary>
+        [Fact]
+        public void OneBasedIndexesRoundTrip()
+        {
+            OneBased row = Helper.Read<OneBased>(Row, new CborOptions());
+
+            Assert.Equal(2, row.Id);
+            Assert.Equal("row", row.Name);
+        }
+
+        /// <summary>
+        /// Returned an object with every member defaulted and raised nothing.
+        /// </summary>
+        [Fact]
+        public void SparseIndexesRoundTrip()
+        {
+            Sparse row = Helper.Read<Sparse>(Row, new CborOptions());
+
+            Assert.Equal(2, row.Id);
+            Assert.Equal("row", row.Name);
+        }
+
+        /// <summary>
+        /// A negative index is the case that settles what the index means: it cannot be a position,
+        /// so ordering is all it can be.
+        /// </summary>
+        [Fact]
+        public void NegativeIndexesRoundTrip()
+        {
+            Negative row = Helper.Read<Negative>(Row, new CborOptions());
+
+            Assert.Equal(2, row.Id);
+            Assert.Equal("row", row.Name);
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        [CborDiscriminator("issue222-two-three")]
+        public class DiscriminatedTwoBased
+        {
+            [CborProperty(2)] public int Id { get; set; }
+            [CborProperty(3)] public string Name { get; set; }
+        }
+
+        /// <summary>
+        /// The defect was never confined to undiscriminated types. A discriminated one whose members
+        /// start at 2 rather than 1 failed identically, because the read reserved exactly one slot for
+        /// the discriminator and then assumed the members carried on from there.
+        /// </summary>
+        [Fact]
+        public void DiscriminatedIndexesNeedNotStartAtOne()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<DiscriminatedTwoBased>();
+
+            Assert.Equal(Row, Helper.Write(new DiscriminatedTwoBased { Id = 2, Name = "row" }, options));
+
+            DiscriminatedTwoBased row = Helper.Read<DiscriminatedTwoBased>(Row, options);
+
+            Assert.Equal(2, row.Id);
+            Assert.Equal("row", row.Name);
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class RegistryBase
+        {
+            [CborProperty(1)] public int Id { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        [CborDiscriminator("issue222-registry-derived")]
+        public class RegistryDerived : RegistryBase
+        {
+            [CborProperty(2)] public string Name { get; set; }
+        }
+
+        /// <summary>
+        /// The read skipped a slot whenever a discriminator convention resolved for the type, which
+        /// <see cref="Serialization.Conventions.DiscriminatorConventionRegistry"/> answers for every
+        /// base of a registered hierarchy. So registering a derived type elsewhere in the program
+        /// changed how the base alone read its own bytes, while the write was unaffected — the same
+        /// document, the same type, two different results.
+        /// </summary>
+        [Fact]
+        public void ReadingDoesNotDependOnAnotherTypeBeingRegistered()
+        {
+            const string justId = "810C"; // [12]
+
+            CborOptions plain = new CborOptions();
+            Assert.Equal(justId, Helper.Write(new RegistryBase { Id = 12 }, plain));
+            Assert.Equal(12, Helper.Read<RegistryBase>(justId, plain).Id);
+
+            CborOptions registered = new CborOptions();
+            registered.Registry.DiscriminatorConventionRegistry.RegisterType<RegistryDerived>();
+            Assert.Equal(justId, Helper.Write(new RegistryBase { Id = 12 }, registered));
+            Assert.Equal(12, Helper.Read<RegistryBase>(justId, registered).Id);
+        }
+
+        /// <summary>
+        /// A member the type can write but not read still holds its position: the writer emits it, so
+        /// everything after it sits one place further along. It resolves to an index no read lookup
+        /// holds, which skips the item without disturbing the count.
+        /// </summary>
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class WithAGetOnlyMember
+        {
+            [CborProperty(3)] public int Id { get; set; }
+            [CborProperty(6)] public string Computed => "computed";
+            [CborProperty(8)] public string Name { get; set; }
+        }
+
+        [Fact]
+        public void AMemberThatCannotBeReadStillHoldsItsPosition()
+        {
+            WithAGetOnlyMember value = new WithAGetOnlyMember { Id = 2, Name = "row" };
+
+            // 83 02 68 636F6D7075746564 63 726F77  --  [2, "computed", "row"]
+            const string hex = "830268636F6D7075746564" + "63726F77";
+            Assert.Equal(hex, Helper.Write(value, new CborOptions()));
+
+            WithAGetOnlyMember back = Helper.Read<WithAGetOnlyMember>(hex, new CborOptions());
+
+            Assert.Equal(2, back.Id);
+            Assert.Equal("row", back.Name);
+        }
+
+        /// <summary>
+        /// More items than the type has members. There is no declared index to name, so the position
+        /// is what gets reported.
+        /// </summary>
+        [Fact]
+        public void AnArrayLongerThanTheTypeReportsThePosition()
+        {
+            // 83 02 63 726F77 0D  --  [2, "row", 13]
+            const string threeItems = "830263726F770D";
+
+            CborOptions options = new CborOptions { UnhandledNameMode = UnhandledNameMode.ThrowException };
+            CborException exception = Assert.Throws<CborException>(
+                () => Helper.Read<OneBased>(threeItems, options));
+
+            Assert.Contains("Unhandled index [2]", exception.Message);
+
+            // Ignored by default, leaving the members that did map alone.
+            OneBased row = Helper.Read<OneBased>(threeItems, new CborOptions());
+            Assert.Equal(2, row.Id);
+            Assert.Equal("row", row.Name);
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/ObjectMapping.cs
@@ -339,7 +339,14 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
         /// <summary>
         /// The class/struct will be serialized as a CBOR array instead of a CBOR map
         /// </summary>
-        /// CborPropertyAttribute.Index will be used as the index of each property/field of the class in the CBOR array
+        /// <remarks>
+        /// In <see cref="CborObjectFormat.Array"/> the document carries no keys, so
+        /// <c>CborPropertyAttribute.Index</c> orders the members rather than addressing them: they are
+        /// written in ascending index order and read back by position. Gaps and negative indexes are
+        /// allowed and do not reach the wire, so two types differing only in their index values encode
+        /// identically. <see cref="CborObjectFormat.IntKeyMap"/> is the format whose index is written
+        /// into the document and so survives as an address.
+        /// </remarks>
         public void SetObjectFormat(CborObjectFormat objectFormat)
         {
             ObjectFormat = objectFormat;

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -23,6 +23,20 @@ namespace Dahomey.Cbor.Serialization.Converters
         IReadOnlyList<IMemberConverter> MemberConvertersForWrite { get; }
         ByteBufferDictionary<MemberReadEntry> MemberConvertersForRead { get; }
         Dictionary<int, MemberReadEntry> MemberConvertersForReadByIndex { get; }
+
+        /// <summary>
+        /// The declared member index occupying each position of a
+        /// <see cref="CborObjectFormat.Array"/> document, in the order the members are written. Empty
+        /// for every other object format, which name their members in the document itself.
+        /// </summary>
+        /// <remarks>
+        /// An array carries no keys, so the only thing a position can be resolved against is the
+        /// member list, and this is that list reduced to what the read needs from it. Exposed on the
+        /// interface for the same reason as <see cref="MemberConvertersForReadByIndex"/>: on a
+        /// polymorphic read the positions belong to the resolved type, which the declared type's
+        /// converter reaches only through here.
+        /// </remarks>
+        IReadOnlyList<int> MemberIndexesByPosition { get; }
         IReadOnlyList<IMemberConverter> RequiredMemberConvertersForRead { get; }
         IObjectMapping ObjectMapping { get; }
     }
@@ -49,7 +63,19 @@ namespace Dahomey.Cbor.Serialization.Converters
             public Dictionary<int, object>? creatorValuesByIndex;
             public Dictionary<int, object>? regularValuesByIndex;
             public MemberReadState readState;
-            public int memberIndex;
+
+            /// <summary>
+            /// How many members of a <see cref="CborObjectFormat.Array"/> document this read has
+            /// already consumed, and so which position the next item holds. Unused by the map
+            /// formats, which read their key from the document.
+            /// </summary>
+            /// <remarks>
+            /// A position, not a member index: the two coincide only for a type whose declared
+            /// indexes start at zero and run consecutively, and treating this as an index is what
+            /// lost the members of every type that did not. <see cref="MemberIndexesByPosition"/>
+            /// turns it into one.
+            /// </remarks>
+            public int memberPosition;
         }
 
         public struct WriterContext
@@ -102,6 +128,15 @@ namespace Dahomey.Cbor.Serialization.Converters
         private int _nextReadOrdinal = 1;
         public List<IMemberConverter> _requiredMemberConvertersForRead = new List<IMemberConverter>();
         private readonly List<IMemberConverter> _memberConvertersForWrite;
+
+        /// <inheritdoc cref="IObjectConverter.MemberIndexesByPosition"/>
+        /// <remarks>
+        /// Built alongside <see cref="_memberConvertersForWrite"/> and from the same mappings in the
+        /// same pass, because the positions this describes are the ones that list produces: the write
+        /// emits those members in order and nothing else, so any list assembled separately could only
+        /// drift from what is actually on the wire.
+        /// </remarks>
+        private readonly int[] _memberIndexesByPosition;
         private List<IMemberConverter>? _deterministicMemberConvertersForWrite;
         private readonly CborOptions _options;
         private readonly SerializationRegistry _registry;
@@ -210,6 +245,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         public ByteBufferDictionary<MemberReadEntry> MemberConvertersForRead => _memberConvertersForRead;
         public Dictionary<int, MemberReadEntry> MemberConvertersForReadByIndex => _memberConvertersForReadByIndex;
         public IReadOnlyList<IMemberConverter> RequiredMemberConvertersForRead => _requiredMemberConvertersForRead;
+        public IReadOnlyList<int> MemberIndexesByPosition => _memberIndexesByPosition;
         public IObjectMapping ObjectMapping => _objectMapping;
 
         public ObjectConverter(CborOptions options)
@@ -236,6 +272,11 @@ namespace Dahomey.Cbor.Serialization.Converters
             _objectMapping = _registry.ObjectMappingRegistry.Lookup<T>();
 
             _memberConvertersForWrite = new List<IMemberConverter>();
+
+            // Positions exist only in the Array format; every other format keys its members in the
+            // document, so there is nothing for a position to resolve against and nothing to collect.
+            List<int>? memberIndexesByPosition =
+                _objectMapping.ObjectFormat == CborObjectFormat.Array ? new List<int>() : null;
 
             foreach (IMemberMapping memberMapping in _objectMapping.GetMemberMappingsForConverter(this))
             {
@@ -329,8 +370,27 @@ namespace Dahomey.Cbor.Serialization.Converters
                 if (memberMapping.CanBeSerialized)
                 {
                     _memberConvertersForWrite.Add(memberConverter);
+
+                    // The discriminator holds a position of its own when it is written, but it is not
+                    // a member and is resolved by its semantic tag rather than by counting -- see the
+                    // Array arm of ReadItem, which consumes that item before any position is counted.
+                    // Leaving it out is also what makes the count independent of whether the policy
+                    // wrote one for this particular document.
+                    //
+                    // A member that can be written but not read still takes a position: the writer
+                    // emits it, so every member after it sits one place further along, and dropping it
+                    // here would shift them all. It resolves to an index no read lookup holds, which
+                    // skips the item and leaves the positions intact.
+                    if (memberIndexesByPosition != null
+                        && memberMapping is not IDiscriminatorMapping
+                        && memberConverter.MemberIndex.HasValue)
+                    {
+                        memberIndexesByPosition.Add(memberConverter.MemberIndex.Value);
+                    }
                 }
             }
+
+            _memberIndexesByPosition = memberIndexesByPosition?.ToArray() ?? Array.Empty<int>();
 
             _isInterfaceOrAbstract = typeof(T).IsInterface || typeof(T).IsAbstract;
             _isStruct = typeof(T).IsStruct();
@@ -804,8 +864,14 @@ namespace Dahomey.Cbor.Serialization.Converters
                                         context.converter = this;
                                     }
 
-                                    // increment to skip discriminator index even when the semantic tag is not present
-                                    context.memberIndex++;
+                                    // No position is counted here, in either branch. The discriminator
+                                    // is not one of the members positions are counted over, so when it
+                                    // was present this call consumed its item and the next call is
+                                    // still at position 0; when it was absent, the item this call is
+                                    // looking at IS position 0. Counting one here instead made the
+                                    // read start at the second member of a type whose declared indexes
+                                    // did not happen to begin at 1, and made that offset depend on
+                                    // whether some other type in the hierarchy had been registered.
                                 }
                                 break;
                         }
@@ -949,38 +1015,60 @@ namespace Dahomey.Cbor.Serialization.Converters
                     }
                     break;
                 case CborObjectFormat.Array:
-                    try
                     {
-                        if (context.creatorValuesByIndex == null)
-                        {
-                            if (_isStruct)
-                            {
-                                ReadValueForStruct(ref reader, ref context.obj, context.memberIndex, ref context.readState);
-                            }
-                            else
-                            {
-                                context.converter.ReadValue(ref reader, context.obj!, context.memberIndex, ref context.readState);
-                            }
-                        }
-                        else if (context.converter.ReadValue(ref reader, context.memberIndex, ref context.readState, out object? value))
-                        {
-                            if (context.converter.ObjectMapping.IsCreatorMember(context.memberIndex))
-                            {
-                                AddMemberValue(ref reader, context.readState.Mode, context.creatorValuesByIndex, context.memberIndex, value);
-                            }
-                            else
-                            {
-                                AddMemberValue(ref reader, context.readState.Mode, context.regularValuesByIndex!, context.memberIndex, value);
-                            }
-                        }
-                    }
-                    catch (CborException exception)
-                    {
-                        PushMemberSegment(exception, context.converter, context.memberIndex);
-                        throw;
-                    }
+                        // An array names nothing, so what the document supplies is a position, and the
+                        // member holding that position is the one the type declares there. The declared
+                        // index is then what everything downstream is keyed on -- the read lookups, the
+                        // creator's member list, the failure path -- exactly as in the map formats,
+                        // because that index is what those were built from. Reading the position itself
+                        // as the index is what made a type whose indexes did not start at 0 and run
+                        // consecutively lose its members, since only then are the two the same number.
+                        IReadOnlyList<int> memberIndexesByPosition = context.converter.MemberIndexesByPosition;
+                        int position = context.memberPosition++;
 
-                    context.memberIndex++;
+                        if (position >= memberIndexesByPosition.Count)
+                        {
+                            // More items than the type has members to put in them. There is no declared
+                            // index to name, so the position is reported instead - the only thing about
+                            // this item the type has anything to say about.
+                            HandleUnknownIndex(ref reader, typeof(T), position);
+                            reader.SkipDataItem();
+                            break;
+                        }
+
+                        int memberIndex = memberIndexesByPosition[position];
+
+                        try
+                        {
+                            if (context.creatorValuesByIndex == null)
+                            {
+                                if (_isStruct)
+                                {
+                                    ReadValueForStruct(ref reader, ref context.obj, memberIndex, ref context.readState);
+                                }
+                                else
+                                {
+                                    context.converter.ReadValue(ref reader, context.obj!, memberIndex, ref context.readState);
+                                }
+                            }
+                            else if (context.converter.ReadValue(ref reader, memberIndex, ref context.readState, out object? value))
+                            {
+                                if (context.converter.ObjectMapping.IsCreatorMember(memberIndex))
+                                {
+                                    AddMemberValue(ref reader, context.readState.Mode, context.creatorValuesByIndex, memberIndex, value);
+                                }
+                                else
+                                {
+                                    AddMemberValue(ref reader, context.readState.Mode, context.regularValuesByIndex!, memberIndex, value);
+                                }
+                            }
+                        }
+                        catch (CborException exception)
+                        {
+                            PushMemberSegment(exception, context.converter, memberIndex);
+                            throw;
+                        }
+                    }
                     break;
             }
         }


### PR DESCRIPTION
Fixes #222.

`CborObjectFormat.Array` writes its members packed in ascending index order and emits no keys, so a position is all the document supplies. The read counted positions and used the count as the declared member index — the same number only for a type whose indexes start at zero and run consecutively. Every other type lost its members: indexes `1`, `2` threw `Invalid major type TextString` reading the name into the id, and indexes far enough out returned a fully defaulted object with no error at all.

## The index orders, it does not address

`ObjectMapping` sorts by the index and allows gaps and negatives alike, and a negative index is already pinned by `DeterministicEncodingTests.ArrayFormatWithNegativeIndex` — so an index cannot be a position. The read now resolves a position against the member list and keys everything downstream (read lookups, `IsCreatorMember`, the `creatorValuesByIndex`/`regularValuesByIndex` dictionaries, `PushMemberSegment`) on the *declared* index it finds there — the same key those structures were built from, which is why the creator and struct paths need no change of their own.

## Two consequences beyond the reported shapes

- **The discriminated case was affected too**, whenever the members did not start at 1: the read reserved exactly one slot and assumed they carried on from there.
- **That slot was reserved on registry state.** The `context.memberIndex++` ran whenever a discriminator convention merely *resolved* for the type, which the registry answers for every base of a registered hierarchy — so registering a derived type elsewhere in the program changed how the base read its own bytes while leaving the write alone. Positions are now counted over members only, and the discriminator is recognised by its semantic tag as it already was.

## Compatibility and docs

No writer change and no format change: the affected shapes could not be read back by this library at all, so no round-trippable document existed in that form. `CddlRow`, `CddlArrayBase` and `CddlArrayDerived` come off `GeneratedCorpusTests`' `NotReadBackByEitherPath` exclusion list and round-trip there now.

Contiguity is deliberately not validated — under an ordering reading a gap is not a mistake, and a rule would have to reject the legitimate negative-index declaration. Documented instead in the README and on `SetObjectFormat`: in `Array` the index orders members and gaps never reach the wire, so two types differing only in index values encode identically; `IntKeyMap` is the format whose index survives as an address.

## Verification

`net8.0`, `net9.0` and `net10.0`: 1967 passed, 0 failed, plus 42 generator tests. The 45 CDDL tests skip here because the external `cddl` tool is not installed on this machine — they need a run where it is present.
