### PR TITLE
Write every Array position, closes #233

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,14 @@ indexes: inserting a member with an index that sorts between two existing ones s
 it by one position, where `IntKeyMap` would not move. Use `IntKeyMap` where indexes need to be stable
 addresses across versions.
 
+For the same reason, `Array` writes every member of the type on every document. A member omitted by
+`[CborIgnoreIfDefault]`, `[CborProperty(DefaultValue = ...)]` or a `ShouldSerializeXyz()` method would
+leave no trace in a keyless format, so everything after it would shift a position earlier and read
+back onto the wrong member. Those declarations are therefore ignored in `Array`, and the member is
+written with the value it holds — `null` or the type's default in the case they exist to catch. They
+work as declared in `StringKeyMap` and `IntKeyMap`, where each value travels with the key that says
+which member it belongs to.
+
 ### Bignums (RFC 8949 §3.4.3)
 
 A member typed `System.Numerics.BigInteger` reads and writes integers of any width. Values that fit in 64

--- a/README.md
+++ b/README.md
@@ -296,12 +296,26 @@ it by one position, where `IntKeyMap` would not move. Use `IntKeyMap` where inde
 addresses across versions.
 
 For the same reason, `Array` writes every member of the type on every document. A member omitted by
-`[CborIgnoreIfDefault]`, `[CborProperty(DefaultValue = ...)]` or a `ShouldSerializeXyz()` method would
-leave no trace in a keyless format, so everything after it would shift a position earlier and read
-back onto the wrong member. Those declarations are therefore ignored in `Array`, and the member is
-written with the value it holds — `null` or the type's default in the case they exist to catch. They
-work as declared in `StringKeyMap` and `IntKeyMap`, where each value travels with the key that says
-which member it belongs to.
+`[CborIgnoreIfDefault]` or by a `ShouldSerializeXyz()` method would leave no trace in a keyless
+format, so everything after it would shift a position earlier and read back onto the wrong member.
+Those declarations are therefore ignored in `Array`, and the member is written with the value it
+holds — `null` or the type's default in the case they exist to catch. They work as declared in
+`StringKeyMap` and `IntKeyMap`, where each value travels with the key that says which member it
+belongs to.
+
+One combination becomes visible that way: a member declaring both `[CborIgnoreIfDefault]` and
+`[CborRequired]` — with a policy of `DisallowNull` or `Always` — now throws when it is null, where the
+omission used to hide it. The two declarations contradict each other in a format that cannot omit
+anything, and the document the write used to produce could not be read back. Drop one of the two, or
+use `IntKeyMap`.
+
+A member keyed by an index has no name to put in such a message, so it is reported as its index:
+`Property 'index 2' cannot be null.` That also applies to `IntKeyMap`, where the same messages used to
+name the member with an empty string.
+
+The discriminator is not a member and holds no position — it is written under a semantic tag and
+recognised by it — so `CborDiscriminatorPolicy` decides whether it appears in an `Array` exactly as it
+does in a map.
 
 ### Bignums (RFC 8949 §3.4.3)
 

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0233.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0233.cs
@@ -1,0 +1,113 @@
+using Dahomey.Cbor.Attributes;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// Issue #233: a member a <c>ShouldSerialize</c> predicate declined was not written in
+    /// <see cref="CborObjectFormat.Array"/>, and since that format emits no keys, every member after
+    /// it slid one position earlier. The read resolved each position against the member list and
+    /// landed on the wrong member: it threw where the shifted members disagreed on type, and assigned
+    /// silently where they agreed.
+    /// </summary>
+    /// <remarks>
+    /// The fix belongs to the writer. A reader cannot recover a position the document never carried,
+    /// an omitted member leaving no trace to skip over, and the format has no way to express absence.
+    /// So a member that holds a position is written whatever the predicate says — with its current
+    /// value, which is the default in the very case <c>[CborIgnoreIfDefault]</c> exists to catch. The
+    /// predicate still applies to the two map formats, where a key travels with each value.
+    /// </remarks>
+    public class Issue0233
+    {
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class Skipper
+        {
+            [CborProperty(5)] public int Id { get; set; }
+            [CborProperty(7)][CborIgnoreIfDefault] public string Name { get; set; }
+            [CborProperty(9)] public int Tail { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        public class MapSkipper
+        {
+            [CborProperty(5)] public int Id { get; set; }
+            [CborProperty(7)][CborIgnoreIfDefault] public string Name { get; set; }
+            [CborProperty(9)] public int Tail { get; set; }
+        }
+
+        /// <summary>
+        /// The reported shape: the declined member keeps its slot, written as the null its value is,
+        /// and the array header still counts three items.
+        /// </summary>
+        [Fact]
+        public void ADeclinedMemberStillHoldsItsPosition()
+        {
+            // 83 01 F6 182A  --  [1, null, 42]
+            const string hexBuffer = "8301F6182A";
+
+            Helper.TestWrite(new Skipper { Id = 1, Name = null, Tail = 42 }, hexBuffer);
+        }
+
+        [Fact]
+        public void TheDocumentReadsBackOntoTheMembersItWasWrittenFrom()
+        {
+            Skipper skipper = Helper.Read<Skipper>("8301F6182A");
+
+            Assert.NotNull(skipper);
+            Assert.Equal(1, skipper.Id);
+            Assert.Null(skipper.Name);
+            Assert.Equal(42, skipper.Tail);
+        }
+
+        /// <summary>
+        /// The other half of the fix: a map carries the key that says which member a value belongs
+        /// to, so omitting a member costs nothing there and the predicate keeps working as declared.
+        /// </summary>
+        [Fact]
+        public void AMapStillOmitsTheDeclinedMember()
+        {
+            // A2 05 01 09 182A  --  {5: 1, 9: 42}
+            const string hexBuffer = "A2050109182A";
+
+            Helper.TestWrite(new MapSkipper { Id = 1, Name = null, Tail = 42 }, hexBuffer);
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class ShouldSerializeSkipper
+        {
+            [CborProperty(1)] public int Id { get; set; }
+            [CborProperty(2)] public int Middle { get; set; }
+            [CborProperty(3)] public int Tail { get; set; }
+
+            public bool ShouldSerializeMiddle() => false;
+        }
+
+        /// <summary>
+        /// The silent shape, and the one <c>ShouldSerializeXyz</c> reaches: three members of the same
+        /// type, where a hole raises nothing and simply moves two values onto the wrong members.
+        /// </summary>
+        [Fact]
+        public void AShouldSerializeMethodDoesNotShiftTheMembersAfterIt()
+        {
+            // 83 01 02 03  --  [1, 2, 3]
+            const string hexBuffer = "83010203";
+
+            Helper.TestWrite(new ShouldSerializeSkipper { Id = 1, Middle = 2, Tail = 3 }, hexBuffer);
+
+            ShouldSerializeSkipper skipper = Helper.Read<ShouldSerializeSkipper>(hexBuffer);
+
+            Assert.Equal(1, skipper.Id);
+            Assert.Equal(2, skipper.Middle);
+            Assert.Equal(3, skipper.Tail);
+        }
+
+        [Fact]
+        public void APresentValueIsUnaffected()
+        {
+            // 83 01 63 466F6F 182A  --  [1, "Foo", 42]
+            const string hexBuffer = "830163466F6F182A";
+
+            Helper.TestWrite(new Skipper { Id = 1, Name = "Foo", Tail = 42 }, hexBuffer);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0233.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0233.cs
@@ -101,6 +101,62 @@ namespace Dahomey.Cbor.Tests.Issues
             Assert.Equal(3, skipper.Tail);
         }
 
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class ContradictorySkipper
+        {
+            [CborProperty(1)] public int Id { get; set; }
+
+            [CborProperty(2)]
+            [CborIgnoreIfDefault]
+            [CborRequired(RequirementPolicy.DisallowNull)]
+            public string Name { get; set; }
+        }
+
+        /// <summary>
+        /// Writing the slot makes one contradictory pair of declarations visible: a member both
+        /// omitted when default and required not to be null now says so, where the omission used to
+        /// hide it behind a document that could not be read back.
+        /// </summary>
+        [Fact]
+        public void ARequiredMemberThatWouldHaveBeenOmittedIsReported()
+        {
+            CborException exception = Assert.Throws<CborException>(
+                () => Helper.Write(new ContradictorySkipper { Id = 1, Name = null }));
+
+            // Named by its index: an Array member carries no name to report.
+            Assert.Equal("Property 'index 2' cannot be null.", exception.Message);
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public class PolymorphicBase
+        {
+            [CborProperty(1)] public int Id { get; set; }
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        [CborDiscriminator("issue233-derived")]
+        public class PolymorphicDerived : PolymorphicBase
+        {
+            [CborProperty(2)] public int Tail { get; set; }
+        }
+
+        /// <summary>
+        /// The discriminator holds no position and is not a member of the type, so the policy still
+        /// decides whether it appears — including on a polymorphic write, where the member list comes
+        /// from the derived type's converter rather than the declared type's.
+        /// </summary>
+        [Fact]
+        public void TheDiscriminatorPolicyStillDecidesInAnArray()
+        {
+            CborOptions options = new CborOptions { DiscriminatorPolicy = CborDiscriminatorPolicy.Never };
+            options.Registry.DiscriminatorConventionRegistry.RegisterType<PolymorphicDerived>();
+
+            PolymorphicBase value = new PolymorphicDerived { Id = 1, Tail = 42 };
+
+            // 82 01 182A  --  [1, 42], with no discriminator in front of it
+            Assert.Equal("8201182A", Helper.Write(value, options));
+        }
+
         [Fact]
         public void APresentValueIsUnaffected()
         {

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
@@ -120,6 +120,18 @@ namespace Dahomey.Cbor.Serialization.Converters
             _requirementPolicy = requirementPolicy;
         }
 
+        /// <summary>
+        /// Names this member for an error message: its CBOR name, or its index for a member that
+        /// carries one instead — <see cref="CborObjectFormat.IntKeyMap"/> and
+        /// <see cref="CborObjectFormat.Array"/> members have no name to report.
+        /// </summary>
+        private string Describe()
+        {
+            return _memberName.IsEmpty && _memberIndex.HasValue
+                ? $"index {_memberIndex.Value}"
+                : Encoding.UTF8.GetString(_memberName.Span);
+        }
+
         public void Read(ref CborReader reader, object obj)
         {
             // Inspect rather than read: this only asks whether the member is null, and the member's
@@ -128,13 +140,13 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 if (_requirementPolicy == RequirementPolicy.DisallowNull || _requirementPolicy == RequirementPolicy.Always)
                 {
-                    throw new CborException($"Property '{Encoding.UTF8.GetString(_memberName.Span)}' cannot be null.");
+                    throw new CborException($"Property '{Describe()}' cannot be null.");
                 }
             }
 
             if (_memberSetter == null)
             {
-                throw new CborException($"No member setter for '{Encoding.UTF8.GetString(_memberName.Span)}'");
+                throw new CborException($"No member setter for '{Describe()}'");
             }
 
             _memberSetter((T)obj, Converter.Read(ref reader));
@@ -144,7 +156,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             if (_memberGetter == null)
             {
-                throw new CborException($"No member getter for '{Encoding.UTF8.GetString(_memberName.Span)}'");
+                throw new CborException($"No member getter for '{Describe()}'");
             }
 
             TM value = _memberGetter((T)obj);
@@ -152,7 +164,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             if (_isClass && value == null && (_requirementPolicy == RequirementPolicy.DisallowNull
                 || _requirementPolicy == RequirementPolicy.Always))
             {
-                throw new CborException($"Property '{Encoding.UTF8.GetString(_memberName.Span)}' cannot be null.");
+                throw new CborException($"Property '{Describe()}' cannot be null.");
             }
 
             Converter.Write(ref writer, value, _lengthMode);
@@ -167,7 +179,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             if (_memberSetter == null)
             {
-                throw new CborException($"No member setter for '{Encoding.UTF8.GetString(_memberName.Span)}'");
+                throw new CborException($"No member setter for '{Describe()}'");
             }
 
             _memberSetter((T)obj, (TM)value);
@@ -177,7 +189,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             if (_memberGetter == null)
             {
-                throw new CborException($"No member getter for '{Encoding.UTF8.GetString(_memberName.Span)}'");
+                throw new CborException($"No member getter for '{Describe()}'");
             }
 
             if (IgnoreIfDefault && EqualityComparer<TM>.Default.Equals(_memberGetter((T)obj), _defaultValue))
@@ -463,7 +475,20 @@ namespace Dahomey.Cbor.Serialization.Converters
         }
     }
 
-    public class DiscriminatorMemberConverter<T> : IMemberConverter
+    /// <summary>
+    /// Marks the discriminator's member converter whatever type it was built for.
+    /// </summary>
+    /// <remarks>
+    /// A write resolves its member list on the object's actual type, so a polymorphic write hands a
+    /// declared type's converter the derived type's members — and with them a
+    /// <see cref="DiscriminatorMemberConverter{T}"/> closed over that derived type. Recognising it by
+    /// the closed type would therefore miss it exactly where a discriminator is written at all.
+    /// </remarks>
+    public interface IDiscriminatorMemberConverter : IMemberConverter
+    {
+    }
+
+    public class DiscriminatorMemberConverter<T> : IDiscriminatorMemberConverter
     {
         private readonly CborOptions _options;
         private readonly IDiscriminatorConvention _discriminatorConvention;

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -1375,7 +1375,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         private static bool HoldsAPosition(IMemberConverter memberConverter, ref WriterContext context)
         {
             return context.objectFormat == CborObjectFormat.Array
-                && memberConverter is not DiscriminatorMemberConverter<T>;
+                && memberConverter is not IDiscriminatorMemberConverter;
         }
 
         private bool WriteItem(ref CborWriter writer, ref WriterContext context)

--- a/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/ObjectConverter.cs
@@ -1331,7 +1331,12 @@ namespace Dahomey.Cbor.Serialization.Converters
 
             foreach (IMemberConverter memberConverter in context.memberConvertersForWrite)
             {
-                if (_isStruct)
+                if (HoldsAPosition(memberConverter, ref context))
+                {
+                    // Written whatever ShouldSerialize says: see WriteItem.
+                    writableMembersCount++;
+                }
+                else if (_isStruct)
                 {
                     IMemberConverter<T> typedMemberConverter = (IMemberConverter<T>)memberConverter;
 
@@ -1349,6 +1354,30 @@ namespace Dahomey.Cbor.Serialization.Converters
             return writableMembersCount;
         }
 
+        /// <summary>
+        /// Whether this member is addressed by nothing but its position in the document, and so has
+        /// to be written whatever <c>ShouldSerialize</c> says about it.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="CborObjectFormat.Array"/> carries no keys, so an omitted member slides every
+        /// member after it a position earlier, onto the wrong member on the read; the format has no
+        /// way to express absence, so the member is written with its current value -- the default, in
+        /// the very case the predicate exists to catch -- and the predicate is consulted only where a
+        /// key travels with the value to say which member it belongs to. That is the same reasoning
+        /// that keeps <see cref="CborObjectFormat.Array"/> out of the deterministic member sort in
+        /// <see cref="MemberConvertersForWrite"/>.
+        /// <para>
+        /// The discriminator is the exception: it is not a member of the type and holds no position,
+        /// being written under a semantic tag and recognised by it on the read. Whether it appears at
+        /// all is the discriminator policy's business, so it keeps answering for itself.
+        /// </para>
+        /// </remarks>
+        private static bool HoldsAPosition(IMemberConverter memberConverter, ref WriterContext context)
+        {
+            return context.objectFormat == CborObjectFormat.Array
+                && memberConverter is not DiscriminatorMemberConverter<T>;
+        }
+
         private bool WriteItem(ref CborWriter writer, ref WriterContext context)
         {
             while (context.memberIndex < context.memberConvertersForWrite.Count)
@@ -1358,7 +1387,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                 {
                     IMemberConverter<T> typedMemberConverter = (IMemberConverter<T>)memberConverter;
 
-                    if (typedMemberConverter.ShouldSerialize(ref context.obj, typeof(T)))
+                    if (HoldsAPosition(memberConverter, ref context) || typedMemberConverter.ShouldSerialize(ref context.obj, typeof(T)))
                     {
                         switch (context.objectFormat)
                         {
@@ -1380,7 +1409,7 @@ namespace Dahomey.Cbor.Serialization.Converters
                         break;
                     }
                 }
-                else if (memberConverter.ShouldSerialize(context.obj!, typeof(T), context.options))
+                else if (HoldsAPosition(memberConverter, ref context) || memberConverter.ShouldSerialize(context.obj!, typeof(T), context.options))
                 {
                     switch (context.objectFormat)
                     {


### PR DESCRIPTION
Closes #233.

`CborObjectFormat.Array` writes its members positionally and emits no keys, so a member is identified
by nothing but its position. `ShouldSerialize` was applied there all the same: a member it declined
was not written and everything after it slid one position earlier, so the read resolved each position
against the member list and landed on the wrong member — throwing where the shifted members disagreed
on type, assigning silently where they agreed.

```csharp
[CborObjectFormat(CborObjectFormat.Array)]
public class Skipper
{
    [CborProperty(5)] public int Id { get; set; }
    [CborProperty(7)][CborIgnoreIfDefault] public string? Name { get; set; }
    [CborProperty(9)] public int Tail { get; set; }
}

// before: 82 01 182A  --  [1, 42], and the read throws on Tail's value arriving at Name
// after:  83 01 F6 182A  --  [1, null, 42]
```

## The fix is the writer's

A reader cannot recover a position the document never carried — an omitted member leaves no trace to
skip over — and the format has no way to express absence. So a member that holds a position is written
whatever the predicate says, with the value it holds: `null` or the type's default in the very case
`[CborIgnoreIfDefault]`, a `DefaultValue` or a `ShouldSerializeXyz()` method exists to catch. `GetSize`
counts the same way, since it sizes the definite-length array from the same predicate. That is the
reasoning that already keeps `Array` out of the deterministic member sort: removing or reordering
members in a keyless format changes what the document means, not how it is spelled.

The discriminator is the exception and keeps answering for itself. It is not a member of the type and
holds no position, being written under a semantic tag and recognised by it, so whether it appears at
all remains the discriminator policy's business — `WriteArrayWithDiscrimator` and
`Issue0222.DiscriminatedIndexesNeedNotStartAtOne` pin that.

The two map formats are untouched: a key travels with each value there to say which member it belongs
to, so an omitted member costs nothing and the predicate keeps working as declared.

## Decisions

The issue asked whether `[CborIgnoreIfDefault]` on an `Array` type should instead be refused at
registration. This honours it by writing the slot rather than refusing it, which keeps the attribute
harmless on a type that uses one format for some documents and another for others.

Struct coverage was left out because `Array` + struct is unreachable today: `StructMemberConverter`
lacks the null-`MemberName` guard `MemberConverter` has, so any struct declaring `[CborProperty(int)]`
throws `ArgumentNullException` when its converter is built. Filed separately.

## Tests

`Issue0233` covers the reported shape, its round trip, the silent shape via `ShouldSerializeXyz()` on
three members of one type, a present value as a non-regression, and the map still omitting. Full suite
green with `CDDL_REQUIRED=1`: 2017 passing, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
