### PR TITLE
Guard the member name a struct member may not have, closes #236

### DIFF
--- a/src/Dahomey.Cbor.Tests/StructTests.cs
+++ b/src/Dahomey.Cbor.Tests/StructTests.cs
@@ -83,6 +83,72 @@ namespace Dahomey.Cbor.Tests
             Assert.Equal(12, strct.id);
         }
 
+        [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+        public struct IndexKeyedStruct
+        {
+            [CborProperty(1)]
+            public int Id { get; set; }
+
+            [CborProperty(2)]
+            public string? Name { get; set; }
+        }
+
+        [Fact]
+        public void WriteStructWithMemberIndexes()
+        {
+            IndexKeyedStruct strct = new IndexKeyedStruct
+            {
+                Id = 12,
+                Name = "row"
+            };
+
+            const string hexBuffer = "A2010C0263726F77";
+            Helper.TestWrite(strct, hexBuffer);
+        }
+
+        [Fact]
+        public void ReadStructWithMemberIndexes()
+        {
+            const string hexBuffer = "A2010C0263726F77";
+            IndexKeyedStruct strct = Helper.Read<IndexKeyedStruct>(hexBuffer);
+
+            Assert.Equal(12, strct.Id);
+            Assert.Equal("row", strct.Name);
+        }
+
+        [CborObjectFormat(CborObjectFormat.Array)]
+        public struct ArrayFormatStruct
+        {
+            [CborProperty(0)]
+            public int Id { get; set; }
+
+            [CborProperty(1)]
+            public string? Name { get; set; }
+        }
+
+        [Fact]
+        public void WriteStructWithArrayFormat()
+        {
+            ArrayFormatStruct strct = new ArrayFormatStruct
+            {
+                Id = 12,
+                Name = "row"
+            };
+
+            const string hexBuffer = "820C63726F77";
+            Helper.TestWrite(strct, hexBuffer);
+        }
+
+        [Fact]
+        public void ReadStructWithArrayFormat()
+        {
+            const string hexBuffer = "820C63726F77";
+            ArrayFormatStruct strct = Helper.Read<ArrayFormatStruct>(hexBuffer);
+
+            Assert.Equal(12, strct.Id);
+            Assert.Equal("row", strct.Name);
+        }
+
         public readonly struct MyStruct
         {
             [CborConstructor("Value")]

--- a/src/Dahomey.Cbor/Serialization/Converters/Mappings/DelegateStructMemberMapping.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Mappings/DelegateStructMemberMapping.cs
@@ -117,7 +117,7 @@ namespace Dahomey.Cbor.Serialization.Converters.Mappings
             }
 
             return new StructMemberConverter<T, TM>(
-                MemberName ?? string.Empty,
+                MemberName,
                 MemberIndex,
                 ResolveConverter,
                 _memberGetter,

--- a/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/MemberConverter.cs
@@ -292,7 +292,17 @@ namespace Dahomey.Cbor.Serialization.Converters
 
         public ReadOnlySpan<byte> MemberName => _memberName.Span;
         public int? MemberIndex { get; private set; }
-        public string MemberNameAsString { get; }
+
+        /// <summary>
+        /// Null for a member keyed by an index rather than by a name: a member carries one or the
+        /// other, never both. Use <see cref="MemberLabel"/> to name the member in a message.
+        /// </summary>
+        public string? MemberNameAsString { get; }
+
+        /// <summary>
+        /// How this member is named in an error message: its name, or its index when it has no name.
+        /// </summary>
+        private string MemberLabel => MemberNameAsString ?? $"[{MemberIndex}]";
         public bool IgnoreIfDefault => _ignoreIfDefault;
         public RequirementPolicy RequirementPolicy => _requirementPolicy;
 
@@ -305,8 +315,13 @@ namespace Dahomey.Cbor.Serialization.Converters
                 throw new CborException("MemberInfo must not be null");
             }
 
-            MemberNameAsString = memberMapping.MemberName!;
-            _memberName = Encoding.UTF8.GetBytes(MemberNameAsString);
+            MemberNameAsString = memberMapping.MemberName;
+
+            if (MemberNameAsString != null)
+            {
+                _memberName = Encoding.UTF8.GetBytes(MemberNameAsString);
+            }
+
             MemberIndex = memberMapping.MemberIndex;
             _memberGetter = GenerateGetter(memberInfo);
             _memberSetter = GenerateSetter(memberInfo);
@@ -321,7 +336,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         /// Reflection-free and AOT-safe. Used by <see cref="DelegateStructMemberMapping{T, TM}"/>.
         /// </summary>
         internal StructMemberConverter(
-            string memberName,
+            string? memberName,
             int? memberIndex,
             Func<ICborConverter<TM>> converterFactory,
             StructMemberGetterDelegate<T, TM>? memberGetter,
@@ -331,7 +346,12 @@ namespace Dahomey.Cbor.Serialization.Converters
             RequirementPolicy requirementPolicy)
         {
             MemberNameAsString = memberName;
-            _memberName = Encoding.UTF8.GetBytes(memberName);
+
+            if (memberName != null)
+            {
+                _memberName = Encoding.UTF8.GetBytes(memberName);
+            }
+
             MemberIndex = memberIndex;
             _converterFactory = converterFactory;
             _memberGetter = memberGetter;
@@ -374,13 +394,13 @@ namespace Dahomey.Cbor.Serialization.Converters
             {
                 if (_requirementPolicy == RequirementPolicy.DisallowNull || _requirementPolicy == RequirementPolicy.Always)
                 {
-                    throw new CborException($"Property '{MemberNameAsString}' cannot be null.");
+                    throw new CborException($"Property '{MemberLabel}' cannot be null.");
                 }
             }
 
             if (_memberSetter == null)
             {
-                throw new CborException($"No member setter for '{MemberNameAsString}'");
+                throw new CborException($"No member setter for '{MemberLabel}'");
             }
 
             _memberSetter(ref instance, Converter.Read(ref reader));
@@ -390,7 +410,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             if (_memberGetter == null)
             {
-                throw new CborException($"No member getter for '{MemberNameAsString}'");
+                throw new CborException($"No member getter for '{MemberLabel}'");
             }
 
             TM value = _memberGetter(ref instance);
@@ -398,7 +418,7 @@ namespace Dahomey.Cbor.Serialization.Converters
             if (_isClass && value == null && (_requirementPolicy == RequirementPolicy.DisallowNull
                 || _requirementPolicy == RequirementPolicy.Always))
             {
-                throw new CborException($"Property '{MemberNameAsString}' cannot be null.");
+                throw new CborException($"Property '{MemberLabel}' cannot be null.");
             }
 
             Converter.Write(ref writer, value);
@@ -408,7 +428,7 @@ namespace Dahomey.Cbor.Serialization.Converters
         {
             if (_memberGetter == null)
             {
-                throw new CborException($"No member getter for '{MemberNameAsString}'");
+                throw new CborException($"No member getter for '{MemberLabel}'");
             }
 
             if (IgnoreIfDefault && EqualityComparer<TM>.Default.Equals(_memberGetter(ref instance), _defaultValue))


### PR DESCRIPTION
`StructMemberConverter` read `memberMapping.MemberName` unconditionally, but a member carries
either a name or an index, never both. Any struct declaring `[CborProperty(n)]` therefore threw
`ArgumentNullException` while its converter was being built, before a single byte was read or
written -- which also made `CborObjectFormat.Array` unreachable for structs, since that format
requires every member to carry an index.

## What changed

- `StructMemberConverter` guards the name the way `MemberConverter`, the class counterpart on the
  line above in the same file, already does -- in both constructors, the reflection one and the
  delegate one.
- `MemberNameAsString` becomes `string?` to say the name may be absent (a nullable annotation only,
  no binary break), and the error messages of `Read`, `Write` and `ShouldSerialize` go through a
  private `MemberLabel` that falls back to the index. Without it they would have read
  `'' cannot be null` for an index-keyed member.
- `DelegateStructMemberMapping` stops substituting `string.Empty` for the absent name: an
  index-keyed member has no name, not an empty one.

## Tests

Four tests in `StructTests`, covering read and write of an `IntKeyMap` struct and of a
`CborObjectFormat.Array` struct. All four throw the reported `ArgumentNullException` without the
fix and pass with it.

Full suite green on net8.0, net9.0 and net10.0 (2024 tests, `CDDL_REQUIRED=1`), plus the 42
generator tests.