### PR TITLE
Generate the collection interfaces instead of refusing them

### DIFF
--- a/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
@@ -393,6 +393,31 @@ public partial class Context : CborSerializerContext { }
         }
 
         /// <summary>
+        /// The collection interfaces the reflection path resolves through
+        /// <c>InterfaceCollectionConverter</c>, and <c>IDictionary&lt;K,V&gt;</c> through
+        /// <c>InterfaceDictionaryConverter</c>. Declaring one is ordinary — a model that says
+        /// <c>IList&lt;T&gt;</c> rather than <c>List&lt;T&gt;</c> is expressing a contract, not being
+        /// awkward — so refusing it made the generated path unusable for that model.
+        /// </summary>
+        [Theory]
+        [InlineData("System.Collections.Generic.IList<int>")]
+        [InlineData("System.Collections.Generic.ICollection<int>")]
+        [InlineData("System.Collections.Generic.IEnumerable<int>")]
+        [InlineData("System.Collections.Generic.IReadOnlyList<int>")]
+        [InlineData("System.Collections.Generic.IReadOnlyCollection<int>")]
+        [InlineData("System.Collections.Generic.ISet<int>")]
+        [InlineData("System.Collections.Generic.IDictionary<string, int>")]
+        public void ACollectionInterfaceMemberIsNotReported(string memberType)
+        {
+            AssertClean($@"
+public class Holder {{ public {memberType} Value {{ get; set; }} }}
+
+[CborSerializable(typeof(Holder))]
+public partial class Context : CborSerializerContext {{ }}
+");
+        }
+
+        /// <summary>
         /// An abstract base is never instantiated — its subtypes are — so it must not be reported.
         /// </summary>
         [Fact]

--- a/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
+++ b/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
@@ -119,6 +119,9 @@ namespace Dahomey.Cbor.Generator
 
                     goto case TypeKind.Collection;
 
+                // A collection interface describes the same document as the concrete collection behind
+                // it: the backing type decides what the reader hands back, not what goes on the wire.
+                case TypeKind.InterfaceCollection:
                 case TypeKind.Collection:
                 {
                     string? element = Render(
@@ -127,6 +130,7 @@ namespace Dahomey.Cbor.Generator
                     break;
                 }
 
+                case TypeKind.InterfaceDictionary:
                 case TypeKind.Dictionary:
                 {
                     string? dictionaryKey = Render(

--- a/src/Dahomey.Cbor.Generator/Emitter.cs
+++ b/src/Dahomey.Cbor.Generator/Emitter.cs
@@ -263,6 +263,21 @@ namespace Dahomey.Cbor.Generator
                             $"new DictionaryConverter<{FullName(model.Symbol)}, {FullName(model.ElementType!)}, {FullName(model.ValueType!)}>(options)");
                         break;
 
+                    // An interface cannot be instantiated, so the read fills the backing collection and
+                    // hands it back as the interface. Naming that backing type here is what the
+                    // reflection path reaches MakeGenericType for, and the reason these were CBOR1002:
+                    // nothing in the source mentions List<T> merely because a member said IList<T>.
+                    case TypeKind.InterfaceCollection:
+                        EmitSimpleRegistration(builder, indent, model.Symbol,
+                            $"new InterfaceCollectionConverter<{model.BackingType}<{FullName(model.ElementType!)}>, "
+                            + $"{FullName(model.Symbol)}, {FullName(model.ElementType!)}>(options)");
+                        break;
+
+                    case TypeKind.InterfaceDictionary:
+                        EmitSimpleRegistration(builder, indent, model.Symbol,
+                            $"new InterfaceDictionaryConverter<{FullName(model.ElementType!)}, {FullName(model.ValueType!)}>(options)");
+                        break;
+
                     // One converter per arity, named with the tuple's own type arguments -- so the
                     // instantiation is written out here rather than made at run time, which is the whole
                     // point: the reflection provider reaches MakeGenericType, and a tuple was therefore

--- a/src/Dahomey.Cbor.Generator/TypeCollector.cs
+++ b/src/Dahomey.Cbor.Generator/TypeCollector.cs
@@ -34,13 +34,14 @@ namespace Dahomey.Cbor.Generator
                 return;
             }
 
-            TypeKind kind = Classify(type, out ITypeSymbol? element, out ITypeSymbol? value, out ITypeSymbol? underlying);
+            TypeKind kind = Classify(type, out ITypeSymbol? element, out ITypeSymbol? value, out ITypeSymbol? underlying, out string? backing);
 
             TypeModel model = new TypeModel(type, kind)
             {
                 ElementType = element,
                 ValueType = value,
                 UnderlyingType = underlying,
+                BackingType = backing,
                 IsTypedArray = kind == TypeKind.Array && IsTypedArrayElementType(element!),
             };
 
@@ -75,11 +76,13 @@ namespace Dahomey.Cbor.Generator
 
                 case TypeKind.Array:
                 case TypeKind.Collection:
+                case TypeKind.InterfaceCollection:
                     Collect(element!);
                     model.Dependencies.Add(element!);
                     break;
 
                 case TypeKind.Dictionary:
+                case TypeKind.InterfaceDictionary:
                     Collect(element!);
                     Collect(value!);
                     model.Dependencies.Add(element!);
@@ -130,6 +133,68 @@ namespace Dahomey.Cbor.Generator
             return type.MetadataName.StartsWith("ValueTuple`", System.StringComparison.Ordinal)
                 && type.ContainingNamespace is { Name: "System" }
                 && type.ContainingNamespace.ContainingNamespace is { IsGlobalNamespace: true };
+        }
+
+        /// <summary>
+        /// Which converter a collection interface resolves to, and the concrete type it is built into
+        /// while being read, mirroring <c>CollectionConverterProvider</c>'s choices exactly.
+        /// </summary>
+        /// <remarks>
+        /// The backing type is what makes these constructible at all: an interface cannot be
+        /// instantiated, so the read fills a concrete collection and hands it back as the interface.
+        /// <c>List&lt;T&gt;</c> for the ordered interfaces and <c>HashSet&lt;T&gt;</c> for
+        /// <c>ISet&lt;T&gt;</c> — the same pair the reflection path picks, because a document written
+        /// through one path has to read back through the other.
+        /// <para>
+        /// <c>IReadOnlyList&lt;T&gt;</c> and <c>IReadOnlyCollection&lt;T&gt;</c> are included even
+        /// though a caller cannot add to what they hand back: the converter builds a <c>List&lt;T&gt;</c>
+        /// and returns it as the read-only interface, which is what the reflection path does.
+        /// </para>
+        /// </remarks>
+        private static TypeKind ClassifyCollectionInterface(
+            INamedTypeSymbol named,
+            out ITypeSymbol? element,
+            out ITypeSymbol? value,
+            out string? backing)
+        {
+            element = null;
+            value = null;
+            backing = null;
+
+            string constructed = named.ConstructedFrom.ToDisplayString();
+
+            if (constructed == "System.Collections.Generic.IDictionary<TKey, TValue>"
+                && named.TypeArguments.Length == 2)
+            {
+                element = named.TypeArguments[0];
+                value = named.TypeArguments[1];
+                return TypeKind.InterfaceDictionary;
+            }
+
+            if (named.TypeArguments.Length != 1)
+            {
+                return TypeKind.Unsupported;
+            }
+
+            switch (constructed)
+            {
+                case "System.Collections.Generic.ISet<T>":
+                    element = named.TypeArguments[0];
+                    backing = "global::System.Collections.Generic.HashSet";
+                    return TypeKind.InterfaceCollection;
+
+                case "System.Collections.Generic.IList<T>":
+                case "System.Collections.Generic.ICollection<T>":
+                case "System.Collections.Generic.IEnumerable<T>":
+                case "System.Collections.Generic.IReadOnlyList<T>":
+                case "System.Collections.Generic.IReadOnlyCollection<T>":
+                    element = named.TypeArguments[0];
+                    backing = "global::System.Collections.Generic.List";
+                    return TypeKind.InterfaceCollection;
+
+                default:
+                    return TypeKind.Unsupported;
+            }
         }
 
         /// <summary>
@@ -628,11 +693,13 @@ namespace Dahomey.Cbor.Generator
             ITypeSymbol type,
             out ITypeSymbol? element,
             out ITypeSymbol? value,
-            out ITypeSymbol? underlying)
+            out ITypeSymbol? underlying,
+            out string? backing)
         {
             element = null;
             value = null;
             underlying = null;
+            backing = null;
 
             if (type.TypeKind == Microsoft.CodeAnalysis.TypeKind.Enum)
             {
@@ -684,6 +751,19 @@ namespace Dahomey.Cbor.Generator
                 if (IsValueTuple(named))
                 {
                     return TypeKind.Tuple;
+                }
+
+                // The collection interfaces, before the tests below: IList<T> implements ICollection<T>,
+                // so it would otherwise be taken for a concrete collection and then refused for having
+                // no parameterless constructor -- which is exactly the CBOR1002 this replaces.
+                if (named.TypeKind == Microsoft.CodeAnalysis.TypeKind.Interface)
+                {
+                    TypeKind interfaceKind = ClassifyCollectionInterface(named, out element, out value, out backing);
+
+                    if (interfaceKind != TypeKind.Unsupported)
+                    {
+                        return interfaceKind;
+                    }
                 }
 
                 // Dictionary<K,V> and anything implementing IDictionary<K,V>.

--- a/src/Dahomey.Cbor.Generator/TypeModel.cs
+++ b/src/Dahomey.Cbor.Generator/TypeModel.cs
@@ -21,6 +21,22 @@ namespace Dahomey.Cbor.Generator
 
         Collection,
         Dictionary,
+
+        /// <summary>
+        /// A collection *interface* — <c>IList&lt;T&gt;</c>, <c>ICollection&lt;T&gt;</c>,
+        /// <c>IEnumerable&lt;T&gt;</c>, <c>IReadOnlyList&lt;T&gt;</c>,
+        /// <c>IReadOnlyCollection&lt;T&gt;</c>, <c>ISet&lt;T&gt;</c> — which cannot be instantiated, so
+        /// reading one builds a concrete backing collection and hands it back as the interface. That
+        /// backing type is <see cref="BackingType"/>, chosen the way
+        /// <c>CollectionConverterProvider</c> chooses it.
+        /// </summary>
+        InterfaceCollection,
+
+        /// <summary>
+        /// <c>IDictionary&lt;K,V&gt;</c> itself, whose backing type is always
+        /// <c>Dictionary&lt;K,V&gt;</c> and so needs no <see cref="BackingType"/>.
+        /// </summary>
+        InterfaceDictionary,
         Object,
 
         /// <summary>
@@ -131,6 +147,19 @@ namespace Dahomey.Cbor.Generator
 
         /// <summary>Element type for arrays and collections; key type for dictionaries.</summary>
         public ITypeSymbol? ElementType { get; set; }
+
+        /// <summary>
+        /// The concrete collection a <see cref="TypeKind.InterfaceCollection"/> is built into while it
+        /// is read, before being handed back as the interface — <c>List&lt;T&gt;</c> for the ordered
+        /// interfaces, <c>HashSet&lt;T&gt;</c> for <c>ISet&lt;T&gt;</c>.
+        /// </summary>
+        /// <remarks>
+        /// Carried as a string rather than an <c>ITypeSymbol</c> because it is a type the source does
+        /// not mention: nothing in the compilation refers to <c>List&lt;T&gt;</c> just because a member
+        /// said <c>IList&lt;T&gt;</c>, so there is no symbol to reach for and the emitter only ever
+        /// needs its name.
+        /// </remarks>
+        public string? BackingType { get; set; }
 
         /// <summary>
         /// True when <see cref="Kind"/> is <see cref="TypeKind.Array"/> and the element type is one of

--- a/src/Dahomey.Cbor.Tests/GeneratedCollectionInterfaceTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCollectionInterfaceTests.cs
@@ -1,0 +1,130 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// A model that declares interfaces rather than concrete collections, which is an ordinary thing to
+    /// do and was <c>CBOR1002</c> for a generated context until the interface converters were emitted.
+    /// </summary>
+    public class GeneratedInterfaceHolder
+    {
+        public IList<int> List { get; set; }
+
+        public ICollection<string> Collection { get; set; }
+
+        public IEnumerable<int> Enumerable { get; set; }
+
+        public IReadOnlyList<int> ReadOnlyList { get; set; }
+
+        public IReadOnlyCollection<int> ReadOnlyCollection { get; set; }
+
+        public ISet<int> Set { get; set; }
+
+        public IDictionary<string, int> Dictionary { get; set; }
+    }
+
+    [CborSerializable(typeof(GeneratedInterfaceHolder))]
+    [CborCddlSchema]
+    public partial class InterfaceCollectionContext : CborSerializerContext
+    {
+    }
+
+    /// <summary>
+    /// The interface converters resolve to the same concrete backing collections the reflection path
+    /// picks, so the two paths agree on the wire and each reads what the other wrote.
+    /// </summary>
+    /// <remarks>
+    /// <c>GeneratedCorpusTests</c> covers this type too, by assembly scan, which is where byte identity
+    /// against the reflection path is actually asserted. What is here is the part a byte comparison
+    /// cannot show: that the concrete type handed back is the one the interface promised, since a
+    /// converter returning a <c>List&lt;int&gt;</c> where a <c>HashSet&lt;int&gt;</c> was asked for
+    /// would still write identical bytes.
+    /// </remarks>
+    public class GeneratedCollectionInterfaceTests
+    {
+        [Fact]
+        public void EveryCollectionInterfaceRoundTripsThroughAGeneratedContext()
+        {
+            InterfaceCollectionContext context = new InterfaceCollectionContext();
+            GeneratedInterfaceHolder value = Sample();
+
+            string generated = Helper.Write(value, context.Options);
+
+            Assert.Equal(Helper.Write(value), generated, ignoreCase: true);
+
+            GeneratedInterfaceHolder read =
+                Cbor.Deserialize<GeneratedInterfaceHolder>(generated.HexToBytes(), context.Options);
+
+            Assert.Equal(new[] { 1, 2 }, read.List);
+            Assert.Equal(new[] { "a" }, read.Collection);
+            Assert.Equal(new[] { 3 }, read.Enumerable);
+            Assert.Equal(new[] { 4, 5 }, read.ReadOnlyList);
+            Assert.Equal(new[] { 6 }, read.ReadOnlyCollection);
+            Assert.Equal(new[] { 7 }, read.Set);
+            Assert.Equal(8, read.Dictionary["k"]);
+        }
+
+        /// <summary>
+        /// The backing type is chosen per interface, not one for all of them: <c>ISet&lt;T&gt;</c> must
+        /// come back as something that is actually a set, and a <c>List&lt;T&gt;</c> satisfies the
+        /// compiler nowhere and the bytes everywhere. This is what the corpus comparison cannot see.
+        /// </summary>
+        [Fact]
+        public void TheBackingCollectionMatchesWhatTheInterfacePromised()
+        {
+            InterfaceCollectionContext context = new InterfaceCollectionContext();
+            string generated = Helper.Write(Sample(), context.Options);
+
+            GeneratedInterfaceHolder read =
+                Cbor.Deserialize<GeneratedInterfaceHolder>(generated.HexToBytes(), context.Options);
+
+            Assert.IsType<List<int>>(read.List);
+            Assert.IsType<HashSet<int>>(read.Set);
+            Assert.IsType<Dictionary<string, int>>(read.Dictionary);
+        }
+
+        /// <summary>
+        /// A collection interface describes the same document as the concrete collection behind it, so
+        /// the schema says <c>[* int]</c> and <c>{* tstr =&gt; int}</c> — the backing type decides what
+        /// the reader hands back, not what goes on the wire.
+        /// </summary>
+        /// <remarks>
+        /// <c>CddlSchemaParsesTests</c> already runs this context's schema through the reference tool by
+        /// assembly scan, which says it is well-formed. This says it is *right*: a rendering that lost
+        /// the element type, or emitted the backing type's name as a rule, would parse just as happily.
+        /// </remarks>
+        [Fact]
+        public void TheSchemaDescribesTheDocumentRatherThanTheBackingType()
+        {
+            string schema = InterfaceCollectionContext.CddlSchema.Replace("\r\n", "\n");
+
+            // `int` renders as its explicit range, and a member declared nullable-oblivious admits nil.
+            const string Int = "-2147483648..2147483647";
+
+            Assert.Contains($"\"List\": [* {Int}]", schema);
+            Assert.Contains($"\"Set\": [* {Int}]", schema);
+            Assert.Contains($"\"ReadOnlyList\": [* {Int}]", schema);
+            Assert.Contains($"\"Dictionary\": {{* tstr => {Int}}}", schema);
+            Assert.DoesNotContain("HashSet", schema);
+            Assert.DoesNotContain("List<", schema);
+        }
+
+        internal static GeneratedInterfaceHolder Sample()
+        {
+            return new GeneratedInterfaceHolder
+            {
+                List = new List<int> { 1, 2 },
+                Collection = new List<string> { "a" },
+                Enumerable = new List<int> { 3 },
+                ReadOnlyList = new List<int> { 4, 5 },
+                ReadOnlyCollection = new List<int> { 6 },
+                Set = new HashSet<int> { 7 },
+                Dictionary = new Dictionary<string, int> { ["k"] = 8 },
+            };
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -217,6 +217,11 @@ namespace Dahomey.Cbor.Tests
                 return GeneratedTupleTests.Sample();
             }
 
+            if (type == typeof(GeneratedInterfaceHolder))
+            {
+                return GeneratedCollectionInterfaceTests.Sample();
+            }
+
             if (type == typeof(GeneratedOverrideHolder))
             {
                 return new GeneratedOverrideHolder { Id = 7, Name = "seven" };


### PR DESCRIPTION
A generated context refused a model that declares `IList<T>` rather than `List<T>`:

```
CBOR1002: 'System.Collections.Generic.IList<int>' cannot be handled by CBOR source generation
(collection interfaces and abstract collection types are not generated yet; use a concrete type
such as List<T>). It would fall back to runtime reflection, which fails under Native AOT
```

Declaring the interface is expressing a contract, not being awkward, and the remedy the message offers is to change the model. This closes it for the six interfaces the reflection path already resolves.

## Why they were refused

Nothing exotic: `IList<T>` **implements** `ICollection<T>`, so it reached the concrete-collection branch in `TypeCollector.Classify`, and was then turned away by the parameterless-constructor test. The interfaces are now classified before those tests.

## What they resolve to

Exactly what `CollectionConverterProvider` resolves them to, because a document written through one path has to read back through the other:

| Declared | Converter |
|---|---|
| `IList<T>`, `ICollection<T>`, `IEnumerable<T>`, `IReadOnlyList<T>`, `IReadOnlyCollection<T>` | `InterfaceCollectionConverter<List<T>, I, T>` |
| `ISet<T>` | `InterfaceCollectionConverter<HashSet<T>, ISet<T>, T>` |
| `IDictionary<K,V>` | `InterfaceDictionaryConverter<K,V>` |

**The backing type is the whole reason these could not be generated before.** An interface cannot be instantiated, so the read fills a concrete collection and hands it back as the interface — and that concrete type is what the reflection path reaches `MakeGenericType` for. Nothing in the source mentions `List<T>` merely because a member said `IList<T>`, so `TypeModel` carries it as a string: there is no symbol to reach for, and the emitter only ever needs the name.

`IReadOnlyList<T>` and `IReadOnlyCollection<T>` are included even though a caller cannot add to what they get back — the converter builds a `List<T>` and returns it as the read-only interface, which is what the reflection path does.

## CDDL

Rendered as the document rather than as the backing type — `[* X]` and `{* K => V}`, the same as the concrete forms. Which concrete type the reader hands back is not something the wire records.

## Tests

- **Seven generator cases**, one per interface, asserting no diagnostic. All seven report `CBOR1002` without the change.
- **A corpus entry.** `GeneratedInterfaceHolder` is enrolled in `GeneratedCorpusTests`, which is where byte identity against the reflection path is actually asserted, along with the round trip.
- **One thing the corpus cannot see**: that `ISet<T>` comes back a `HashSet<T>` and not a `List<T>`. Both write identical bytes, so a byte comparison is blind to it — and getting it wrong would hand the caller something that does not satisfy the interface they declared.
- **The emitted schema**, pinned. `EveryEmittedSchemaParses` already runs it through the reference `cddl` tool by assembly scan, which says it is well-formed; this says it is right, since a rendering that lost the element type would parse just as happily.

## Native AOT

Proven on a stripped ELF binary with no CoreCLR anywhere — `PublishAot` inside the csproj, gcc as the linker, a context over a type with all four interface kinds:

```
written : A4644C6973748201026353657481636F6E65634D6170A161610163536571820304
types   : List`1 HashSet`1 Dictionary`2 List`1
values  : [1,2] [one] a=1 [3,4]
ROUND TRIP OK
```

## Verification

**2029 library tests and 49 generator tests green on net10.0** with `CDDL_REQUIRED=1`, 0 skipped; four TFMs build. Rebased onto `25d05a8`, and it adds **no build warnings** — checked deliberately, since that commit had just brought the solution to zero.

---
_Generated by [Claude Code](https://claude.ai/code)_
