### PR TITLE
Emit [CborRequired] and ShouldSerialize, which the mappings already supported

### DIFF
--- a/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
@@ -93,7 +93,6 @@ public partial class Context : CborSerializerContext {{ }}
         }
 
         [Theory]
-        [InlineData("[CborRequired]")]
         [InlineData("[CborIgnoreIfDefault]")]
         [InlineData("[DefaultValue(3)]")]
         [InlineData("[CborLengthMode(LengthMode = LengthMode.IndefiniteLength)]")]
@@ -141,15 +140,52 @@ public partial class Context : CborSerializerContext { }
 ");
         }
 
+        /// <summary>
+        /// Both are expressible through the delegate mappings — <c>SetRequired</c> and
+        /// <c>SetShouldSerializeMethod</c> have always been there — so refusing them was the generator
+        /// not emitting a call it could make, rather than a shape it could not reproduce.
+        /// </summary>
         [Fact]
-        public void AShouldSerializeMethodIsReported()
+        public void ARequiredMemberIsNotReported()
         {
-            AssertReports("CBOR1007", @"
+            AssertClean(@"
+public class Holder { [CborRequired] public int Value { get; set; } }
+
+[CborSerializable(typeof(Holder))]
+public partial class Context : CborSerializerContext { }
+");
+        }
+
+        [Fact]
+        public void AShouldSerializeMethodIsNotReported()
+        {
+            AssertClean(@"
 public class Holder
 {
     public int Value { get; set; }
 
     public bool ShouldSerializeValue() => true;
+}
+
+[CborSerializable(typeof(Holder))]
+public partial class Context : CborSerializerContext { }
+");
+        }
+
+        /// <summary>
+        /// A <c>ShouldSerialize</c> method the reflection path ignores — it takes a parameter, so it is
+        /// not the convention — must not be picked up here either, or the two paths disagree about
+        /// whether the member is written at all.
+        /// </summary>
+        [Fact]
+        public void AShouldSerializeMethodTheReflectionPathIgnoresIsNotUsed()
+        {
+            AssertClean(@"
+public class Holder
+{
+    public int Value { get; set; }
+
+    public bool ShouldSerializeValue(int unused) => false;
 }
 
 [CborSerializable(typeof(Holder))]

--- a/src/Dahomey.Cbor.Generator/Emitter.cs
+++ b/src/Dahomey.Cbor.Generator/Emitter.cs
@@ -473,10 +473,21 @@ namespace Dahomey.Cbor.Generator
                 ? $".SetMemberIndex({member.CborIndex})"
                 : $".SetMemberName({Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(member.CborName, quote: true)})";
 
+            // Both are calls DelegateMemberMapping has always offered; what was missing was the
+            // generator making them, which is why they were CBOR1007 rather than a shape it could not
+            // reproduce. Order follows the reflection path's: the predicate, then the requirement.
+            string shouldSerialize = member.ShouldSerializeMethod is null
+                ? string.Empty
+                : $".SetShouldSerializeMethod(o => (({ownerName})o).{member.ShouldSerializeMethod}())";
+
+            string required = member.RequirementPolicy is null
+                ? string.Empty
+                : $".SetRequired({member.RequirementPolicy})";
+
             builder.AppendLine($"{indent}                new {mappingType}(");
             builder.AppendLine($"{indent}                    converters,");
             builder.AppendLine($"{indent}                    {getter},");
-            builder.AppendLine($"{indent}                    {setter}){key},");
+            builder.AppendLine($"{indent}                    {setter}){key}{shouldSerialize}{required},");
         }
 
         private static string FullName(ITypeSymbol type)

--- a/src/Dahomey.Cbor.Generator/TypeCollector.cs
+++ b/src/Dahomey.Cbor.Generator/TypeCollector.cs
@@ -289,7 +289,11 @@ namespace Dahomey.Cbor.Generator
                     }
                 }
 
-                model.Members.Add(new MemberModel(member.Name, cborName, cborIndex, memberType, canRead, canWrite));
+                model.Members.Add(new MemberModel(member.Name, cborName, cborIndex, memberType, canRead, canWrite)
+                {
+                    RequirementPolicy = ReadRequirementPolicy(member),
+                    ShouldSerializeMethod = FindShouldSerializeMethod(type, member),
+                });
 
                 Collect(memberType);
 
@@ -319,7 +323,6 @@ namespace Dahomey.Cbor.Generator
         private static readonly (string Attribute, string Description)[] UnsupportedMemberFeatures =
         {
             ("CborConverterAttribute", "[CborConverter]"),
-            ("CborRequiredAttribute", "[CborRequired]"),
             ("CborIgnoreIfDefaultAttribute", "[CborIgnoreIfDefault]"),
             ("CborLengthModeAttribute", "[CborLengthMode]"),
             ("DefaultValueAttribute", "[DefaultValue]"),
@@ -349,14 +352,6 @@ namespace Dahomey.Cbor.Generator
                     if (HasAttribute(method, "OnDeserializedAttribute"))
                     {
                         Report(method.Locations.FirstOrDefault(), type.ToDisplayString(), "[OnDeserialized]");
-                    }
-
-                    if (method.Name.StartsWith("ShouldSerialize", System.StringComparison.Ordinal)
-                        && method.Name.Length > "ShouldSerialize".Length
-                        && method.Parameters.Length == 0
-                        && method.ReturnType.SpecialType == SpecialType.System_Boolean)
-                    {
-                        Report(method.Locations.FirstOrDefault(), type.ToDisplayString(), $"a {method.Name}() method");
                     }
 
                     continue;
@@ -890,6 +885,115 @@ namespace Dahomey.Cbor.Generator
             {
                 yield return overridden;
             }
+        }
+
+        /// <summary>
+        /// The <c>[CborRequired]</c> policy for a member, as the <c>RequirementPolicy</c> member name to
+        /// emit, or null where the member is not required.
+        /// </summary>
+        /// <remarks>
+        /// The attribute's constructor defaults to <c>Always</c>, so an argumentless <c>[CborRequired]</c>
+        /// means <c>Always</c> — the same default <c>CborRequiredAttribute</c> itself applies, rather
+        /// than a second copy of the policy living here.
+        /// <para>
+        /// The value is rendered by <c>TypedConstant.ToCSharpString()</c> rather than mapped from its
+        /// underlying number, so a reordering of <c>RequirementPolicy</c> cannot silently turn one policy
+        /// into another here — the emitted text names the member the caller wrote.
+        /// </para>
+        /// </remarks>
+        private static string? ReadRequirementPolicy(ISymbol member)
+        {
+            foreach (ISymbol declaration in WithOverriddenDeclarations(member))
+            {
+                foreach (AttributeData attribute in declaration.GetAttributes())
+                {
+                    if (attribute.AttributeClass?.Name != "CborRequiredAttribute")
+                    {
+                        continue;
+                    }
+
+                    foreach (TypedConstant argument in attribute.ConstructorArguments)
+                    {
+                        return RenderEnumConstant(argument) ?? DefaultRequirementPolicy;
+                    }
+
+                    foreach (KeyValuePair<string, TypedConstant> named in attribute.NamedArguments)
+                    {
+                        if (named.Key == "Policy")
+                        {
+                            return RenderEnumConstant(named.Value) ?? DefaultRequirementPolicy;
+                        }
+                    }
+
+                    // The attribute's own constructor default.
+                    return DefaultRequirementPolicy;
+                }
+            }
+
+            return null;
+        }
+
+        private const string DefaultRequirementPolicy =
+            "global::Dahomey.Cbor.Attributes.RequirementPolicy.Always";
+
+        /// <summary>
+        /// An enum-valued attribute argument as the fully qualified member the caller wrote.
+        /// </summary>
+        /// <remarks>
+        /// Resolved from the enum's own symbol rather than mapped from the underlying number, so a
+        /// reordering of the enum cannot silently turn one member into another here.
+        /// </remarks>
+        private static string? RenderEnumConstant(TypedConstant constant)
+        {
+            if (constant.Type is not INamedTypeSymbol enumType || constant.Value is null)
+            {
+                return null;
+            }
+
+            foreach (ISymbol candidate in enumType.GetMembers())
+            {
+                if (candidate is IFieldSymbol { HasConstantValue: true } field
+                    && Equals(field.ConstantValue, constant.Value))
+                {
+                    return enumType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+                        + "." + field.Name;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// The <c>ShouldSerialize&lt;Member&gt;()</c> method the reflection path would use for this
+        /// member, or null where the type declares none that qualifies.
+        /// </summary>
+        /// <remarks>
+        /// The test is <c>DefaultObjectMappingConvention.ProcessShouldSerializeMethod</c>'s, repeated
+        /// rather than approximated: public, no parameters, returning <c>bool</c>, named for the member.
+        /// A method that misses any of those is ignored by the reflection path, so picking it up here
+        /// would make the two paths disagree about whether the member is written at all — which is a
+        /// silent divergence rather than a loud one.
+        /// </remarks>
+        private static string? FindShouldSerializeMethod(ITypeSymbol type, ISymbol member)
+        {
+            string name = "ShouldSerialize" + member.Name;
+
+            foreach (ISymbol candidate in AllMembers(type))
+            {
+                if (candidate is IMethodSymbol
+                    {
+                        Parameters.Length: 0,
+                        DeclaredAccessibility: Accessibility.Public,
+                        IsStatic: false,
+                    } method
+                    && method.Name == name
+                    && method.ReturnType.SpecialType == SpecialType.System_Boolean)
+                {
+                    return name;
+                }
+            }
+
+            return null;
         }
 
         private static bool HasInheritedAttribute(ISymbol member, string attributeName)

--- a/src/Dahomey.Cbor.Generator/TypeModel.cs
+++ b/src/Dahomey.Cbor.Generator/TypeModel.cs
@@ -56,6 +56,23 @@ namespace Dahomey.Cbor.Generator
         /// <summary>The C# member name, used to build the accessor lambdas.</summary>
         public string Name { get; }
 
+        /// <summary>
+        /// The <c>[CborRequired]</c> policy as a <c>RequirementPolicy</c> member name, or null where the
+        /// member is not required.
+        /// </summary>
+        public string? RequirementPolicy { get; set; }
+
+        /// <summary>
+        /// The name of the <c>ShouldSerialize&lt;Member&gt;()</c> method governing this member, or null
+        /// where the type declares none the reflection path would use.
+        /// </summary>
+        /// <remarks>
+        /// Carried by name rather than as a symbol because all the emitter needs is the call, and the
+        /// rules for which method counts — public, no parameters, returning <c>bool</c> — are the
+        /// reflection path's and are applied where the member is collected.
+        /// </remarks>
+        public string? ShouldSerializeMethod { get; set; }
+
         /// <summary>The wire name, after naming convention and <c>[CborProperty]</c>.</summary>
         public string CborName { get; }
 

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -217,6 +217,16 @@ namespace Dahomey.Cbor.Tests
                 return GeneratedTupleTests.Sample();
             }
 
+            if (type == typeof(GeneratedRequiredHolder))
+            {
+                return new GeneratedRequiredHolder { Id = 7, Name = "n" };
+            }
+
+            if (type == typeof(GeneratedShouldSerializeHolder))
+            {
+                return new GeneratedShouldSerializeHolder { Id = 1, Name = "n" };
+            }
+
             if (type == typeof(GeneratedOverrideHolder))
             {
                 return new GeneratedOverrideHolder { Id = 7, Name = "seven" };

--- a/src/Dahomey.Cbor.Tests/GeneratedMemberFeatureTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedMemberFeatureTests.cs
@@ -1,0 +1,112 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// A required member and a <c>ShouldSerialize</c> predicate, both of which the delegate mappings
+    /// have always been able to express and the generator simply did not emit.
+    /// </summary>
+    public class GeneratedRequiredHolder
+    {
+        [CborRequired]
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    public class GeneratedShouldSerializeHolder
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        /// <summary>Skips <see cref="Name"/> exactly when it is empty, on both paths.</summary>
+        public bool ShouldSerializeName() => !string.IsNullOrEmpty(Name);
+    }
+
+    [CborSerializable(typeof(GeneratedRequiredHolder))]
+    [CborSerializable(typeof(GeneratedShouldSerializeHolder))]
+    public partial class MemberFeatureContext : CborSerializerContext
+    {
+    }
+
+    /// <summary>
+    /// Both features change behaviour rather than bytes-for-a-given-value, so the corpus cannot see
+    /// them: it compares one sample through both paths, and a sample that satisfies the requirement and
+    /// passes the predicate encodes identically whether or not either is honoured.
+    /// </summary>
+    /// <remarks>
+    /// What is asserted here is the part that only shows up on the values the feature exists for — a
+    /// document missing the required member, and a value the predicate excludes — and in both cases
+    /// against the reflection path, since agreeing with it is the contract.
+    /// </remarks>
+    public class GeneratedMemberFeatureTests
+    {
+        /// <summary>
+        /// The requirement is a *read*-side rule, so it needs a document that omits the member. A
+        /// generated context that dropped `SetRequired` would return a default-populated object here
+        /// and say nothing.
+        /// </summary>
+        [Fact]
+        public void ARequiredMemberIsEnforcedOnTheGeneratedPath()
+        {
+            MemberFeatureContext context = new MemberFeatureContext();
+
+            // {"Name": "n"} -- Id absent
+            const string missing = "A1644E616D65616E";
+
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<GeneratedRequiredHolder>(missing.HexToBytes(), context.Options));
+
+            // The reflection path refuses the same document, which is what makes this a match rather
+            // than an opinion of the generated path's own.
+            Assert.Throws<CborException>(
+                () => Cbor.Deserialize<GeneratedRequiredHolder>(missing.HexToBytes()));
+        }
+
+        /// <summary>A document that carries it reads back through the generated context.</summary>
+        [Fact]
+        public void ARequiredMemberThatIsPresentReadsBack()
+        {
+            MemberFeatureContext context = new MemberFeatureContext();
+            GeneratedRequiredHolder value = new GeneratedRequiredHolder { Id = 7, Name = "n" };
+
+            string generated = Helper.Write(value, context.Options);
+
+            Assert.Equal(Helper.Write(value), generated, ignoreCase: true);
+            Assert.Equal(7, Cbor.Deserialize<GeneratedRequiredHolder>(generated.HexToBytes(), context.Options).Id);
+        }
+
+        /// <summary>
+        /// The predicate is a *write*-side rule, so it needs the value it excludes — which is exactly
+        /// the value the corpus does not use.
+        /// </summary>
+        [Fact]
+        public void AShouldSerializeMethodIsHonouredOnTheGeneratedPath()
+        {
+            MemberFeatureContext context = new MemberFeatureContext();
+            GeneratedShouldSerializeHolder skipped = new GeneratedShouldSerializeHolder { Id = 1, Name = "" };
+
+            string generated = Helper.Write(skipped, context.Options);
+
+            // A map of one: Name is excluded by the predicate, so only Id is written.
+            Assert.StartsWith("A1", generated, System.StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(Helper.Write(skipped), generated, ignoreCase: true);
+        }
+
+        [Fact]
+        public void AShouldSerializeMethodThatPassesWritesTheMember()
+        {
+            MemberFeatureContext context = new MemberFeatureContext();
+            GeneratedShouldSerializeHolder kept = new GeneratedShouldSerializeHolder { Id = 1, Name = "n" };
+
+            string generated = Helper.Write(kept, context.Options);
+
+            Assert.StartsWith("A2", generated, System.StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(Helper.Write(kept), generated, ignoreCase: true);
+        }
+    }
+}


### PR DESCRIPTION
Two member features that were `CBOR1007` — "source generation does not reproduce this" — and are calls `DelegateMemberMapping` has always offered:

```csharp
.SetRequired(RequirementPolicy.Always)
.SetShouldSerializeMethod(o => ((Holder)o).ShouldSerializeName())
```

So the refusal was about the emitter not making a call, rather than a shape that cannot be reproduced. Both come off the `UnsupportedMemberFeatures` list.

## Two details worth the review time

**The requirement policy is resolved on the enum's own symbol, not mapped from its number.** That is not fastidiousness — `RequirementPolicy` is `Never = 0, Always = 1, AllowNull = 2, DisallowNull = 3`, which is not the order a reader assumes, and the hand-written table I wrote first got *every* value wrong. `RenderEnumConstant` walks the enum's fields for the matching constant and emits the fully qualified member, so a reordering cannot silently turn one policy into another here.

**`ShouldSerialize` repeats `DefaultObjectMappingConvention.ProcessShouldSerializeMethod`'s test rather than approximating it** — public, no parameters, returning `bool`, named for the member. A method the reflection path ignores has to be ignored here too: picking up a looser set would make the two paths disagree about whether a member is *written at all*, which is a silent divergence rather than a loud one. `AShouldSerializeMethodTheReflectionPathIgnoresIsNotUsed` pins it with a method that takes a parameter.

## Why the corpus cannot cover these

`GeneratedCorpusTests` compares one sample through both paths, and a sample that satisfies the requirement and passes the predicate encodes **identically whether or not either feature is honoured**. Both types are enrolled anyway — that is still worth having for the ordinary case — but the tests that bind use the values the features exist for:

- a document that *omits* the required member, asserted to throw on the generated path **and** on the reflection path, so it is a match rather than an opinion of its own;
- a value the predicate *excludes*, asserted to write a map of one and to equal the reflection path's bytes.

## Verification

**2032 library tests and 43 generator tests green on net10.0** with `CDDL_REQUIRED=1`, 0 skipped; four TFMs build; **no new build warnings**, checked because `25d05a8` had just brought the solution to zero.

Binding measured by reverting **only the emission** — leaving the diagnostics removed so the test project still compiles, which the usual revert would not. That fails exactly the two behavioural tests and leaves the two positive controls passing, which is the split it should have.

Stacked on nothing: this is independent of #238, and the two do not touch the same lines.

---
_Generated by [Claude Code](https://claude.ai/code)_
