### PR TITLE
Build a type through its constructor, so records round-trip under AOT

### DIFF
--- a/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
@@ -233,7 +233,30 @@ public partial class Context : CborSerializerContext { }
         [Fact]
         public void ATypeWithNoAccessibleParameterlessConstructorIsReported()
         {
+            // Only a private constructor, so there is nothing to build the type with and nothing to
+            // build it *through* either. A single accessible parameterised constructor is a different
+            // case now -- it becomes the creator -- and has its own test.
             AssertReports("CBOR1010", @"
+public class Holder
+{
+    private Holder() { }
+
+    public int Value { get; set; }
+}
+
+[CborSerializable(typeof(Holder))]
+public partial class Context : CborSerializerContext { }
+");
+        }
+
+        /// <summary>
+        /// The case that changed: one accessible constructor, no parameterless one. It used to be
+        /// CBOR1010 and is now the creator the type is read through.
+        /// </summary>
+        [Fact]
+        public void ASingleParameterisedConstructorIsNotReported()
+        {
+            AssertClean(@"
 public class Holder
 {
     public Holder(int value) { Value = value; }
@@ -388,6 +411,90 @@ public class Holder<T> { public virtual T Value { get; set; } }
 public class IntHolder : Holder<int> { public override int Value { get; set; } }
 
 [CborSerializable(typeof(IntHolder))]
+public partial class Context : CborSerializerContext { }
+");
+        }
+
+        /// <summary>
+        /// A positional record has no parameterless constructor and `init`-only properties, so it failed
+        /// twice over: nothing could build it, and nothing could set its members. Both stop mattering
+        /// once the values arrive through the constructor.
+        /// </summary>
+        [Fact]
+        public void APositionalRecordIsNotReported()
+        {
+            AssertClean(@"
+public record R(int Id, string Name);
+
+[CborSerializable(typeof(R))]
+public partial class Context : CborSerializerContext { }
+");
+        }
+
+        /// <summary>
+        /// An `init`-only property the creator does not supply still has no way back, so it keeps its
+        /// CBOR1006 — the suppression is per member, not per type.
+        /// </summary>
+        [Fact]
+        public void AnInitOnlyMemberTheCreatorDoesNotSupplyIsStillReported()
+        {
+            AssertReports("CBOR1006", @"
+public class Holder
+{
+    [CborConstructor]
+    public Holder(int id) { Id = id; }
+
+    public int Id { get; init; }
+    public string Extra { get; init; }
+}
+
+[CborSerializable(typeof(Holder))]
+public partial class Context : CborSerializerContext { }
+");
+        }
+
+        /// <summary>
+        /// Several constructors, none marked and none parameterless: the reflection path takes
+        /// <c>constructorInfos[0]</c>, and nothing guarantees Roslyn orders them the same way. Picking
+        /// one here could build the type through a different constructor than the reflection path uses,
+        /// so this keeps CBOR1010 — whose remedy resolves the ambiguity for both paths at once.
+        /// </summary>
+        [Fact]
+        public void SeveralUnmarkedConstructorsAreStillReported()
+        {
+            AssertReports("CBOR1010", @"
+public class Holder
+{
+    public Holder(int id) { Id = id; }
+    public Holder(int id, string name) { Id = id; Name = name; }
+
+    public int Id { get; set; }
+    public string Name { get; set; }
+}
+
+[CborSerializable(typeof(Holder))]
+public partial class Context : CborSerializerContext { }
+");
+        }
+
+        /// <summary>
+        /// A parameter naming no serialized member cannot be filled from a document. The reflection path
+        /// leaves it at its default; emitting a creator that silently drops it would make the two paths
+        /// agree on the bytes and disagree on what the object comes back holding, which is worse.
+        /// </summary>
+        [Fact]
+        public void ACreatorParameterMatchingNoMemberIsReported()
+        {
+            AssertReports("CBOR1007", @"
+public class Holder
+{
+    [CborConstructor]
+    public Holder(int id, string absent) { Id = id; }
+
+    public int Id { get; set; }
+}
+
+[CborSerializable(typeof(Holder))]
 public partial class Context : CborSerializerContext { }
 ");
         }

--- a/src/Dahomey.Cbor.Generator/Emitter.cs
+++ b/src/Dahomey.Cbor.Generator/Emitter.cs
@@ -426,6 +426,27 @@ namespace Dahomey.Cbor.Generator
                 builder.AppendLine($"{indent}            }});");
             }
 
+            // A creator for a type `new T()` cannot build: a [CborConstructor], or the single
+            // constructor of a type with no parameterless one, which is what a positional record is.
+            // The member names are given explicitly rather than left to the lambda's parameter names,
+            // because a CBOR name need not be a legal C# identifier and a parameter must be.
+            if (model.CreatorParameters.Count > 0)
+            {
+                string parameters = string.Join(
+                    ", ", model.CreatorParameters.Select((p, i) => $"a{i}"));
+                string signature = string.Join(
+                    ", ", model.CreatorParameters.Select(p => p.Type).Concat(new[] { fullName }));
+                string names = string.Join(
+                    ", ",
+                    model.CreatorParameters.Select(
+                        p => Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(p.CborName, quote: true)));
+
+                builder.AppendLine(
+                    $"{indent}            objectMapping.MapCreator("
+                    + $"new System.Func<{signature}>(({parameters}) => new {fullName}({parameters})))");
+                builder.AppendLine($"{indent}                .SetMemberNames({names});");
+            }
+
             // SetDiscriminator inserts the discriminator entry at index 0 of the member list, so it
             // must run after SetMemberMappings, which replaces that list wholesale.
             if (model.Discriminator is not null)

--- a/src/Dahomey.Cbor.Generator/TypeCollector.cs
+++ b/src/Dahomey.Cbor.Generator/TypeCollector.cs
@@ -167,7 +167,8 @@ namespace Dahomey.Cbor.Generator
             // without a constructor is a problem. The reflection path can reach a non-public
             // constructor or a [CborConstructor] creator mapping; a generated factory is `new T()`.
             if (!model.CanInstantiate
-                && type is { IsAbstract: false, TypeKind: Microsoft.CodeAnalysis.TypeKind.Class })
+                && type is { IsAbstract: false, TypeKind: Microsoft.CodeAnalysis.TypeKind.Class }
+                && FindCreatorConstructor(type) is null)
             {
                 _diagnostics.Add(DiagnosticInfo.Create(
                     Diagnostics.NoParameterlessConstructor,
@@ -177,6 +178,7 @@ namespace Dahomey.Cbor.Generator
 
             ReadTypeLevelAttributes(type, model);
             ReportUnsupportedFeatures(type);
+            IMethodSymbol? creator = FindCreatorConstructor(type);
 
             Dictionary<string, string> membersByCborName = new Dictionary<string, string>(StringComparer.Ordinal);
             Dictionary<int, string> membersByCborIndex = new Dictionary<int, string>();
@@ -236,7 +238,14 @@ namespace Dahomey.Cbor.Generator
                     continue;
                 }
 
-                if (!canWrite)
+                // A member the creator supplies is read back through the constructor, so it needs no
+                // setter -- which is what makes an `init`-only or get-only member work at all. Matched
+                // on the parameter name the way CreatorMapping matches it, case-insensitively.
+                bool suppliedByCreator = creator is not null
+                    && creator.Parameters.Any(
+                        p => string.Equals(p.Name, member.Name, StringComparison.OrdinalIgnoreCase));
+
+                if (!canWrite && !suppliedByCreator)
                 {
                     _diagnostics.Add(DiagnosticInfo.Create(
                         Diagnostics.MemberNotDeserializable,
@@ -291,6 +300,11 @@ namespace Dahomey.Cbor.Generator
 
                 model.Members.Add(new MemberModel(member.Name, cborName, cborIndex, memberType, canRead, canWrite));
 
+                if (suppliedByCreator)
+                {
+                    model.CreatorMembers[member.Name] = cborName;
+                }
+
                 Collect(memberType);
 
                 // A member's converter must exist before this object's converter is constructed —
@@ -300,6 +314,42 @@ namespace Dahomey.Cbor.Generator
                     model.Dependencies.Add(memberType);
                 }
             }
+
+            // Resolved after the member walk, because a parameter is named for the member it fills and
+            // that member's CBOR name is only settled once its attributes and the naming convention
+            // have been read.
+            if (creator is not null)
+            {
+                foreach (IParameterSymbol parameter in creator.Parameters)
+                {
+                    string? cborName = model.CreatorMembers
+                        .FirstOrDefault(entry => string.Equals(
+                            entry.Key, parameter.Name, StringComparison.OrdinalIgnoreCase))
+                        .Value;
+
+                    if (cborName is null)
+                    {
+                        // A parameter naming no member cannot be filled from a document, and the
+                        // reflection path leaves it at its default. Refusing here rather than emitting a
+                        // creator that silently drops it: the two paths would not disagree about the
+                        // bytes, only about what the object comes back holding, which is worse.
+                        _diagnostics.Add(DiagnosticInfo.Create(
+                            Diagnostics.UnsupportedFeature,
+                            creator.Locations.FirstOrDefault(),
+                            type.ToDisplayString(),
+                            $"a constructor parameter '{parameter.Name}' that matches no serialized member"));
+                        model.CreatorParameters.Clear();
+                        return;
+                    }
+
+                    model.CreatorParameters.Add((FullNameOf(parameter.Type), cborName));
+                }
+            }
+        }
+
+        private static string FullNameOf(ITypeSymbol type)
+        {
+            return type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         }
 
         /// <summary>
@@ -890,6 +940,55 @@ namespace Dahomey.Cbor.Generator
             {
                 yield return overridden;
             }
+        }
+
+        /// <summary>
+        /// The constructor a read builds this type through, or null where <c>new T()</c> will do.
+        /// </summary>
+        /// <remarks>
+        /// Mirrors <c>DefaultObjectMappingConvention</c>: a <c>[CborConstructor]</c> wins, and otherwise
+        /// a type with no parameterless constructor is built through the one it has — which is what a
+        /// positional record is, and why records could not round-trip through a generated context.
+        /// <para>
+        /// Deliberately narrower than the reflection path in one case. Where several constructors are
+        /// declared, none marked and none parameterless, that path takes <c>constructorInfos[0]</c>;
+        /// nothing guarantees Roslyn orders them as reflection does, so picking one here could silently
+        /// build a type through a different constructor than the reflection path uses. That case keeps
+        /// CBOR1010, whose remedy — add a parameterless constructor, or mark one with
+        /// <c>[CborConstructor]</c> — resolves the ambiguity for both paths at once.
+        /// </para>
+        /// </remarks>
+        private static IMethodSymbol? FindCreatorConstructor(ITypeSymbol type)
+        {
+            if (type is not INamedTypeSymbol named || named.IsAbstract)
+            {
+                return null;
+            }
+
+            // Implicitly declared ones are excluded, which is what keeps a record workable: its copy
+            // constructor is compiler-generated and protected, while the primary constructor is neither,
+            // so a positional record has exactly one candidate rather than two. Measured, not assumed --
+            // Roslyn reports the primary as IsImplicitlyDeclared: false.
+            List<IMethodSymbol> constructors = named.InstanceConstructors
+                .Where(c => !c.IsStatic
+                    && !c.IsImplicitlyDeclared
+                    && c.DeclaredAccessibility != Accessibility.Private)
+                .ToList();
+
+            IMethodSymbol? marked = constructors.FirstOrDefault(
+                c => HasAttribute(c, "CborConstructorAttribute"));
+
+            if (marked is not null)
+            {
+                return marked;
+            }
+
+            if (constructors.Any(c => c.Parameters.Length == 0))
+            {
+                return null;
+            }
+
+            return constructors.Count == 1 ? constructors[0] : null;
         }
 
         private static bool HasInheritedAttribute(ISymbol member, string attributeName)

--- a/src/Dahomey.Cbor.Generator/TypeModel.cs
+++ b/src/Dahomey.Cbor.Generator/TypeModel.cs
@@ -133,6 +133,25 @@ namespace Dahomey.Cbor.Generator
         public ITypeSymbol? ElementType { get; set; }
 
         /// <summary>
+        /// The constructor a read builds this type through, when it cannot be built with
+        /// <c>new T()</c> — a <c>[CborConstructor]</c>, or the single constructor of a type that has no
+        /// parameterless one, which is what a positional record is.
+        /// </summary>
+        /// <remarks>
+        /// Each entry is the parameter's type and the CBOR name of the member it takes its value from,
+        /// in constructor order. The names are passed to <c>SetMemberNames</c> explicitly rather than
+        /// left to the parameter names of the emitted lambda: a CBOR name set by
+        /// <c>[CborProperty("my-name")]</c> or by a naming convention need not be a legal C#
+        /// identifier, and a lambda's parameters have to be.
+        /// </remarks>
+        public List<(string Type, string CborName)> CreatorParameters { get; } =
+            new List<(string Type, string CborName)>();
+
+        /// <summary>C# member name to CBOR name, for the members a creator supplies.</summary>
+        public Dictionary<string, string> CreatorMembers { get; } =
+            new Dictionary<string, string>();
+
+        /// <summary>
         /// True when <see cref="Kind"/> is <see cref="TypeKind.Array"/> and the element type is one of
         /// the RFC 8746 typed array element types, so the emitter registers
         /// <c>TypedArrayConverter&lt;T&gt;</c> instead of <c>ArrayConverter&lt;T&gt;</c>. The reflection

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -217,6 +217,16 @@ namespace Dahomey.Cbor.Tests
                 return GeneratedTupleTests.Sample();
             }
 
+            if (type == typeof(GeneratedRecord))
+            {
+                return GeneratedCreatorTests.SampleRecord();
+            }
+
+            if (type == typeof(GeneratedCreatorHolder))
+            {
+                return GeneratedCreatorTests.SampleHolder();
+            }
+
             if (type == typeof(GeneratedOverrideHolder))
             {
                 return new GeneratedOverrideHolder { Id = 7, Name = "seven" };

--- a/src/Dahomey.Cbor.Tests/GeneratedCreatorTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCreatorTests.cs
@@ -1,0 +1,96 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// A positional record: one constructor, no parameterless one, and `init`-only properties. Every
+    /// part of that was a reason a generated context could not read it back.
+    /// </summary>
+    public record GeneratedRecord(int Id, string Name);
+
+    /// <summary>A constructor named explicitly, which wins over any other.</summary>
+    public class GeneratedCreatorHolder
+    {
+        [CborConstructor]
+        public GeneratedCreatorHolder(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public GeneratedCreatorHolder()
+        {
+            Name = "unused";
+        }
+
+        public int Id { get; init; }
+
+        public string Name { get; init; }
+    }
+
+    [CborSerializable(typeof(GeneratedRecord))]
+    [CborSerializable(typeof(GeneratedCreatorHolder))]
+    public partial class CreatorContext : CborSerializerContext
+    {
+    }
+
+    /// <summary>
+    /// A type built through a constructor rather than through <c>new T()</c> and a set of setters.
+    /// </summary>
+    /// <remarks>
+    /// This is the gap that blocked records: a positional record has no parameterless constructor, so
+    /// the generated factory could not build it, and its properties are <c>init</c>-only, so
+    /// <c>(o, v) =&gt; o.X = v</c> does not compile for them either. Both stop mattering once the
+    /// values arrive through the constructor.
+    /// </remarks>
+    public class GeneratedCreatorTests
+    {
+        [Fact]
+        public void APositionalRecordRoundTripsThroughAGeneratedContext()
+        {
+            CreatorContext context = new CreatorContext();
+            GeneratedRecord value = new GeneratedRecord(7, "seven");
+
+            string generated = Helper.Write(value, context.Options);
+
+            Assert.Equal(Helper.Write(value), generated, ignoreCase: true);
+
+            GeneratedRecord read =
+                Cbor.Deserialize<GeneratedRecord>(generated.HexToBytes(), context.Options);
+
+            Assert.Equal(value, read);
+        }
+
+        /// <summary>
+        /// <c>[CborConstructor]</c> wins over the parameterless constructor that is also declared, so
+        /// the generated path picks the same one the reflection path does — which a round trip alone
+        /// would not show, since both constructors can produce a correct object.
+        /// </summary>
+        [Fact]
+        public void TheNamedConstructorIsUsedRatherThanTheParameterlessOne()
+        {
+            CreatorContext context = new CreatorContext();
+            GeneratedCreatorHolder value = new GeneratedCreatorHolder(7, "seven");
+
+            string generated = Helper.Write(value, context.Options);
+
+            GeneratedCreatorHolder read =
+                Cbor.Deserialize<GeneratedCreatorHolder>(generated.HexToBytes(), context.Options);
+
+            // The parameterless constructor leaves Name at "unused"; only the named one carries it.
+            Assert.Equal("seven", read.Name);
+            Assert.Equal(7, read.Id);
+
+            // And the reflection path agrees, which is what makes this the right constructor rather
+            // than merely a working one.
+            Assert.Equal("seven", Cbor.Deserialize<GeneratedCreatorHolder>(generated.HexToBytes()).Name);
+        }
+
+        internal static GeneratedRecord SampleRecord() => new GeneratedRecord(7, "seven");
+
+        internal static GeneratedCreatorHolder SampleHolder() => new GeneratedCreatorHolder(7, "seven");
+    }
+}


### PR DESCRIPTION
A positional record failed twice over on the generated path: no parameterless constructor, so the emitted `() => new T()` could not build it, and `init`-only properties, so `(o, v) => o.X = v` does not compile for them either. Both stop mattering once the values arrive through the constructor.

## The mapping API already had all of it

`ObjectMapping.MapCreator(Delegate)` is public, and the generator configures mappings through that same fluent API, so a creator is directly emittable:

```csharp
objectMapping.MapCreator(new System.Func<int, string, R>((a0, a1) => new R(a0, a1)))
    .SetMemberNames("Id", "Name");
```

**The names are given explicitly rather than left to the lambda's parameter names**, which `CreatorMapping` would otherwise match on. A CBOR name set by `[CborProperty("my-name")]` or by a naming convention need not be a legal C# identifier, and a lambda's parameters have to be — so binding on parameter names would work until someone renamed a member and then fail in a way that pointed at the wrong thing.

## Selection, and one deliberate narrowing

Mirrors `DefaultObjectMappingConvention`: a `[CborConstructor]` wins; otherwise a type with no parameterless constructor is built through the one it has.

Where **several** are declared, none marked and none parameterless, that path takes `constructorInfos[0]`. Nothing guarantees Roslyn orders constructors as reflection does, so choosing one here could build a type through a *different* constructor than the reflection path uses — silently, and only for types that have several. That case keeps `CBOR1010`, whose remedy — add a parameterless constructor, or mark one — resolves the ambiguity for both paths at once. `SeveralUnmarkedConstructorsAreStillReported` pins it.

**Excluding implicitly declared constructors is what makes a record workable at all.** Its copy constructor is compiler-generated and `protected` while the primary constructor is neither, so a positional record has one candidate rather than two. Measured rather than assumed:

```
ctor params=2 implicit=False access=Public     (int Id, string Name)
ctor params=1 implicit=True  access=Protected  (R original)
```

## CBOR1006 is suppressed per member, not per type

An `init`-only member the creator supplies needs no setter. One it does *not* supply still has no way back and keeps the warning — `AnInitOnlyMemberTheCreatorDoesNotSupplyIsStillReported`.

A constructor parameter matching no serialized member is refused rather than emitted. The reflection path leaves it at its default; a creator that silently dropped it would make the two paths agree on the bytes and disagree on what the object comes back holding, which is the worse of the two failures.

## A behaviour change worth seeing

**A type with a single accessible parameterised constructor used to be `CBOR1010` and is now supported.** The existing test asserting that refusal has moved to a type with only a *private* constructor, which genuinely still has nothing to build it with. Flagging it because it is the one thing here a reviewer cannot see from the diff alone.

## Verification

**2030 library tests and 47 generator tests green on net10.0** with `CDDL_REQUIRED=1`, 0 skipped; four TFMs build; no new warnings. Both new types are in `GeneratedCorpusTests`, so byte identity against the reflection path is asserted, not just the round trip.

Proven on a real Native AOT binary — `PublishAot` in the csproj, gcc, no CoreCLR:

```
record   : A2624964076653656E736F7265616363656C -> Id=7 Sensor=accel
init-only: Id=3
ROUND TRIP OK
```

## Relationship to the others

Independent of #238 and #239 in substance, but all three add a `Sample` entry to `GeneratedCorpusTests`, so whichever merges second and third want a rebase keeping every side. Happy to do those as they land.

---
_Generated by [Claude Code](https://claude.ai/code)_
