### PR TITLE
State a type's object format even when it is StringKeyMap

### DIFF
--- a/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
+++ b/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
@@ -255,11 +255,17 @@ namespace Dahomey.Cbor.Generator
                 case SpecialType.System_UInt32:
                     return "0..4294967295";
 
+                // Spelled out rather than as the prelude's `int` and `uint`, which are wider than the
+                // CLR types: a CBOR integer reaches -2^64..2^64-1, so `int` admits values no long can
+                // hold and `uint` is only coincidentally the right size. Being explicit also keeps
+                // these consistent with the narrower widths above, and tells a code generator reading
+                // the schema which integer width to declare -- given a bare `uint` it has to guess,
+                // and zcbor guesses 32 bits.
                 case SpecialType.System_Int64:
-                    return "int";
+                    return "-9223372036854775808..9223372036854775807";
 
                 case SpecialType.System_UInt64:
-                    return "uint";
+                    return "0..18446744073709551615";
 
                 // CborWriter.WriteSingle and WriteDouble both emit the shortest form that round-trips,
                 // unconditionally, so a double may arrive on the wire as float16, float32 or float64.

--- a/src/Dahomey.Cbor.Generator/Emitter.cs
+++ b/src/Dahomey.Cbor.Generator/Emitter.cs
@@ -404,10 +404,14 @@ namespace Dahomey.Cbor.Generator
             builder.AppendLine($"{indent}        options.Registry.ObjectMappingRegistry.Register<{fullName}>(objectMapping =>");
             builder.AppendLine($"{indent}        {{");
 
-            if (model.ObjectFormat != "StringKeyMap")
-            {
-                builder.AppendLine($"{indent}            objectMapping.SetObjectFormat(CborObjectFormat.{model.ObjectFormat});");
-            }
+            // Stated unconditionally, including for StringKeyMap. The mapping's own default is the
+            // *options* format, not StringKeyMap, so a type that declares
+            // [CborObjectFormat(StringKeyMap)] under a context whose options say Array loses its
+            // declaration if this line is skipped -- and then fails as
+            // "expecting all fields/properties to get a member index", which names neither the type's
+            // attribute nor the option that overrode it. The reflection path calls SetObjectFormat
+            // whenever the attribute is present, so saying it always is what keeps the two in step.
+            builder.AppendLine($"{indent}            objectMapping.SetObjectFormat(CborObjectFormat.{model.ObjectFormat});");
 
             if (model.Members.Count == 0)
             {

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -217,6 +217,16 @@ namespace Dahomey.Cbor.Tests
                 return GeneratedTupleTests.Sample();
             }
 
+            if (type == typeof(GeneratedKeptMapFormat))
+            {
+                return new GeneratedKeptMapFormat { Id = 7, Name = "n" };
+            }
+
+            if (type == typeof(GeneratedTakesArrayFormat))
+            {
+                return new GeneratedTakesArrayFormat { Id = 7, Name = "n" };
+            }
+
             if (type == typeof(GeneratedOverrideHolder))
             {
                 return new GeneratedOverrideHolder { Id = 7, Name = "seven" };

--- a/src/Dahomey.Cbor.Tests/GeneratedObjectFormatTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedObjectFormatTests.cs
@@ -1,0 +1,88 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// A type that declares <c>StringKeyMap</c> while its context's options say <c>Array</c> — the one
+    /// combination where "the default" differs between the two paths.
+    /// </summary>
+    /// <remarks>
+    /// An object mapping's own default object format is the *options* format, not <c>StringKeyMap</c>.
+    /// So a generated context that only stated the format when it was not <c>StringKeyMap</c> left this
+    /// type to inherit <c>Array</c> from the options, against its own attribute — and it failed as
+    /// "expecting all fields/properties to get a member index", which names neither the attribute nor
+    /// the option that overrode it. The reflection path calls <c>SetObjectFormat</c> whenever the
+    /// attribute is present, so it was never affected.
+    /// </remarks>
+    [CborObjectFormat(CborObjectFormat.StringKeyMap)]
+    public class GeneratedKeptMapFormat
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    /// <summary>A sibling taking the context's format, so both directions are covered by one context.</summary>
+    public class GeneratedTakesArrayFormat
+    {
+        [CborProperty(0)]
+        public int Id { get; set; }
+
+        [CborProperty(1)]
+        public string Name { get; set; }
+    }
+
+    [CborSerializable(typeof(GeneratedKeptMapFormat))]
+    [CborSerializable(typeof(GeneratedTakesArrayFormat))]
+    [CborSourceGenerationOptions(ObjectFormat = CborObjectFormat.Array)]
+    public partial class ArrayDefaultContext : CborSerializerContext
+    {
+    }
+
+    public class GeneratedObjectFormatTests
+    {
+        [Fact]
+        public void ATypeDeclaringMapFormatKeepsItUnderAnArrayDefault()
+        {
+            ArrayDefaultContext context = new ArrayDefaultContext();
+            GeneratedKeptMapFormat value = new GeneratedKeptMapFormat { Id = 7, Name = "n" };
+
+            string generated = Helper.Write(value, context.Options);
+
+            // A2 -- a map of two, not an array. The attribute wins over the context's option.
+            Assert.StartsWith("A2", generated, System.StringComparison.OrdinalIgnoreCase);
+
+            // And it is what the reflection path writes for the same type under the same option, which
+            // is the contract: the attribute wins there too.
+            CborOptions reflection = new CborOptions { ObjectFormat = CborObjectFormat.Array };
+            Assert.Equal(Helper.Write(value, reflection), generated, ignoreCase: true);
+
+            GeneratedKeptMapFormat read =
+                Cbor.Deserialize<GeneratedKeptMapFormat>(generated.HexToBytes(), context.Options);
+
+            Assert.Equal(7, read.Id);
+            Assert.Equal("n", read.Name);
+        }
+
+        /// <summary>
+        /// The other direction, so the fix cannot be "always emit StringKeyMap": a type with no
+        /// attribute still takes the context's <c>Array</c>.
+        /// </summary>
+        [Fact]
+        public void ATypeWithNoAttributeStillTakesTheContextFormat()
+        {
+            ArrayDefaultContext context = new ArrayDefaultContext();
+            GeneratedTakesArrayFormat value = new GeneratedTakesArrayFormat { Id = 7, Name = "n" };
+
+            string generated = Helper.Write(value, context.Options);
+
+            Assert.StartsWith("82", generated, System.StringComparison.OrdinalIgnoreCase);
+
+            CborOptions reflection = new CborOptions { ObjectFormat = CborObjectFormat.Array };
+            Assert.Equal(Helper.Write(value, reflection), generated, ignoreCase: true);
+        }
+    }
+}


### PR DESCRIPTION
A type declaring `[CborObjectFormat(CborObjectFormat.StringKeyMap)]` loses that declaration on the generated path whenever its context's options say something else.

## The divergence

An object mapping's own default object format is the **options** format, not `StringKeyMap`. The emitter stated the format only when it was *not* `StringKeyMap`, so such a type inherited `Array` from the options, against its own attribute.

Same type, same options — `new CborOptions { ObjectFormat = CborObjectFormat.Array }`:

```
reflection : A2 6C4F70657261746F724E616D65 61 61 6B53616D706C65436F756E74 02      a map
generated  : CborException: expecting all fields/properties to get a member index
             in class/struct RecordingHeader
```

The reflection path calls `SetObjectFormat` whenever the attribute is present, so it was never affected.

**The failure names neither half of its own cause.** It arrives while the type is being registered, before a byte is written, and mentions neither the attribute that was ignored nor the option that overrode it — so the obvious reading is "this type is missing `[CborProperty(n)]` indexes", and adding them would be the wrong fix.

## The fix

State it unconditionally. One line per object type, and it cannot drift: the alternative is a condition that has to stay in step with how the context assigns `options.ObjectFormat`, which is what broke here in the first place.

## Tests

Both directions, because "always emit `StringKeyMap`" would pass the first alone:

- a type declaring `StringKeyMap` under an `Array` context keeps its map, and matches what the reflection path writes for the same type under the same option;
- a sibling with no attribute still takes the context's `Array`.

Both are in `GeneratedCorpusTests` as well, so byte identity with the reflection path is asserted rather than only the shape. Both fail with the old condition restored.

## How it was found

Replicating a consumer's serializer configuration to validate it under Native AOT — a model that is mostly `Array` format with one map-keyed type in it. Not an exotic shape, and it fails at context construction, so nothing that configuration touches works at all.

**2030 library tests and 42 generator tests green on net10.0** with `CDDL_REQUIRED=1`, 0 skipped; four TFMs build; no new warnings.

## Also in this diff: the 64-bit integer ranges

`CddlTypeReference` renders `Int64` and `UInt64` as explicit ranges rather than as the prelude's `int` and `uint`. That hunk is unrelated to the object-format fix above — it belongs to separate work and is here because it was in the tree when this branch was cut. Happy to split it into its own PR if you would rather review it on its own.

It is a narrowing, and correct independently: a CBOR integer reaches -2^64..2^64-1, so `int` admits values no `long` can hold and `uint` is only coincidentally the right width. Every narrower CLR integer type is already written as an explicit range, so this makes the 64-bit pair consistent with the rest of the switch.

It also matters to anything generating code from the schema. Given a bare `uint` a generator has to choose a width, and zcbor chooses 32 bits — which silently truncates a millisecond timestamp declared `ulong`.

---
_Generated by [Claude Code](https://claude.ai/code)_

