### PR TITLE
Clear the per-type cache with the conventions, closes #243

### DIFF
--- a/src/Dahomey.Cbor.Tests/Issues/Issue0243.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0243.cs
@@ -1,0 +1,93 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization.Conventions;
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// <c>ClearConventions</c> emptied the convention stack but left the per-type cache populated, so a
+    /// type whose convention had already been resolved kept the cleared one — and a convention
+    /// registered afterwards never governed it.
+    /// </summary>
+    /// <remarks>
+    /// The window this closed was narrower than it looked. Anything that resolves the hierarchy first
+    /// closes it: a previous <c>RegisterType</c>, an earlier read, or constructing a
+    /// <c>CborSerializerContext</c>, whose generated <c>Configure</c> builds every declared converter
+    /// before the caller can reach its <c>Options</c>.
+    /// </remarks>
+    public class Issue0243
+    {
+        /// <summary>{"_t": 99, "Id": 7} — a discriminator no type here registers.</summary>
+        private const string UnknownSubtype = "A2625F74186362496407";
+
+        [Fact]
+        public void AConventionRegisteredAfterAResolutionGoverns()
+        {
+            CborOptions options = new CborOptions { UnhandledNameMode = UnhandledNameMode.Silent };
+            DiscriminatorConventionRegistry registry = options.Registry.DiscriminatorConventionRegistry;
+
+            // Resolve the hierarchy first, which is what caches a convention for the base type.
+            registry.RegisterType<KnownChannel>();
+
+            registry.ClearConventions();
+            registry.RegisterConvention(
+                new DefaultDiscriminatorConvention<int>(options.Registry, "_t", typeof(FallbackChannel)));
+            registry.RegisterType<KnownChannel>();
+
+            BaseChannel channel = Cbor.Deserialize<BaseChannel>(UnknownSubtype.HexToBytes(), options);
+
+            Assert.IsType<FallbackChannel>(channel);
+            Assert.Equal(7, channel.Id);
+        }
+
+        /// <summary>
+        /// The same on options nothing has touched, which worked before and has to keep working — the
+        /// fix must not make the first registration depend on a prior resolution either.
+        /// </summary>
+        [Fact]
+        public void AConventionRegisteredBeforeAnyResolutionStillGoverns()
+        {
+            CborOptions options = new CborOptions { UnhandledNameMode = UnhandledNameMode.Silent };
+            DiscriminatorConventionRegistry registry = options.Registry.DiscriminatorConventionRegistry;
+
+            registry.ClearConventions();
+            registry.RegisterConvention(
+                new DefaultDiscriminatorConvention<int>(options.Registry, "_t", typeof(FallbackChannel)));
+            registry.RegisterType<KnownChannel>();
+
+            Assert.IsType<FallbackChannel>(
+                Cbor.Deserialize<BaseChannel>(UnknownSubtype.HexToBytes(), options));
+        }
+
+        /// <summary>
+        /// Clearing and registering nothing leaves a hierarchy undiscriminated, rather than leaving the
+        /// old conventions quietly in force. This is the half a cache that outlives the clear hides.
+        /// </summary>
+        [Fact]
+        public void ClearingWithoutRegisteringLeavesNothingResolving()
+        {
+            CborOptions options = new CborOptions();
+            DiscriminatorConventionRegistry registry = options.Registry.DiscriminatorConventionRegistry;
+
+            registry.RegisterType<KnownChannel>();
+            registry.ClearConventions();
+
+            Assert.Null(registry.GetConvention(typeof(BaseChannel)));
+        }
+
+        public abstract class BaseChannel
+        {
+            public int Id { get; set; }
+        }
+
+        [CborIntDiscriminator(1)]
+        public class KnownChannel : BaseChannel
+        {
+        }
+
+        public class FallbackChannel : BaseChannel
+        {
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
+++ b/src/Dahomey.Cbor/Serialization/Conventions/DiscriminatorConventionRegistry.cs
@@ -89,6 +89,18 @@ namespace Dahomey.Cbor.Serialization.Conventions
         public void ClearConventions()
         {
             _conventions.Clear();
+
+            // The per-type cache has to go with them. It holds resolutions made by the conventions
+            // being cleared, and GetConvention answers from it without asking anything -- so leaving it
+            // would keep a cleared convention governing every type already resolved, and make a
+            // convention registered afterwards inert for exactly those types. The window that closed in
+            // was narrow and invisible: a previous RegisterType, an earlier read, or constructing a
+            // CborSerializerContext, whose generated Configure builds every declared converter before
+            // the caller can reach its Options.
+            _conventionsByType.Clear();
+
+            // Anything holding an answer of its own asks again, the same way RegisterConvention says so.
+            Interlocked.Increment(ref _version);
         }
 
         public IDiscriminatorConvention? GetConvention(Type type)


### PR DESCRIPTION
Closes #243.

`ClearConventions` emptied `_conventions` and left `_conventionsByType` populated. `GetConvention` answers from that cache without asking anything, so a type whose convention had already been resolved kept the **cleared** one — and a convention registered afterwards never governed it.

```
convention registered first     -> Fallback
after the type already resolved -> CborException: Unknown type discriminator: 99
```

Same options object, same convention, same document; only the order differs.

## The fix

Both halves of the registry's state move together, and `Version` is bumped the way `RegisterConvention` already bumps it, so anything holding an answer of its own asks again.

## What I left alone, and why it is your call

`RegisterConvention` still cannot displace a cached entry, so a convention added after a type resolved is inert for that type **without** a `ClearConventions` call. That is the debatable half — displacing would let a late registration override a resolution already handed out, which is a different promise from the one this method makes today — and the documented way to install a custom convention is `Clear` then `Register`, which works now.

I have implemented the half I think is indefensible as it stands: a method called `ClearConventions` leaving a cleared convention in force. Say if you want the other half and I will add it.

## Tests

Three, and the middle one is the reason the fix is not just "clear the dictionary":

- a convention registered **after** a resolution now governs — the report;
- a convention registered **before** any resolution still governs — worked before, and the fix must not make the first registration depend on a prior one;
- clearing **without** registering leaves nothing resolving — the half a surviving cache hides, and the one that says the two pieces of state are actually consistent rather than merely both written to.

The first and third fail without the change; the second passes either way, which is what a control is for.

## Why it is worth fixing rather than documenting

It reads as already fixed. #224 addressed the neighbouring case — `GetConvention` memoising `null`, so `RegisterType` after a first read was a silent no-op — and the natural reading of that fix is that registration order no longer matters. For conventions it still did.

Found while validating a consumer's configuration under a generated context: `DefaultDiscriminatorConvention<int>` with a `fallbackType` is their forward-compatibility story for documents written by a newer build, and a `CborSerializerContext` resolves every declared type in its constructor — so there was no order available through the obvious API at all.

**2027 library tests and 42 generator tests green on net10.0** with `CDDL_REQUIRED=1`, 0 skipped; four TFMs build.

---
_Generated by [Claude Code](https://claude.ai/code)_
