### PR TITLE
Write a Half as a half-float, not as its own fields, closes #240

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Where the discriminator is written, when it is written, and how to change its na
 | [Object mapping](docs/object-mapping.md) | `ObjectMappingRegistry`, `AutoMap`, adjusting a single member |
 | [Polymorphism](docs/polymorphism.md) | Discriminators, policies and conventions |
 | [Typed arrays](docs/typed-arrays.md) | RFC 8746, `TypedArrayMode`, and what reads what |
-| [Numbers](docs/numbers.md) | `BigInteger`, `decimal`, `CborDecimalFraction` and `CborBigFloat` |
+| [Numbers](docs/numbers.md) | `BigInteger`, `decimal`, `CborDecimalFraction`, `CborBigFloat` and `Half` |
 | [Strings](docs/strings.md) | Indefinite-length strings, and why tag 25 is not supported |
 | [Tuples](docs/tuples.md) | `ValueTuple` at any arity, and the Native AOT requirement |
 | [Deterministic encoding](docs/deterministic-encoding.md) | RFC 8949 §4.2, key ordering, and hashing |

--- a/docs/numbers.md
+++ b/docs/numbers.md
@@ -2,8 +2,8 @@
 
 [← back to the README](../README.md)
 
-Three encodings beyond the basic integers and floats: bignums (tags 2 and 3), decimal fractions
-(tag 4) and bigfloats (tag 5).
+Three encodings beyond the basic integers and floats — bignums (tags 2 and 3), decimal fractions
+(tag 4) and bigfloats (tag 5) — and one at the other end of the range, half-precision floats.
 
 ## Bignums (RFC 8949 §3.4.3)
 
@@ -156,3 +156,38 @@ Equality is structural over the pair as encoded, so `10e0` and `1e1` are the sam
 equal, and neither is normalised on the way out — a document round-trips byte for byte. Two encodings of
 one number are therefore two distinct dictionary keys, and under `CborOptions.Deterministic` they sort as
 the different byte strings they are.
+
+## Half-precision floats (RFC 8949 §3.3)
+
+A member typed `System.Half` reads and writes binary16 — major type 7, additional information 25.
+
+```csharp
+public class Reading
+{
+    public Half Temperature { get; set; }
+}
+```
+
+```csharp
+// (Half)1.5     -> F9 3E00
+// Half.MaxValue -> F9 7BFF   (65504)
+// Half.Epsilon  -> F9 0001   (the smallest subnormal)
+```
+
+**The writer emits binary16 and nothing wider**, where `float` and `double` members emit the shortest
+form that round-trips and so may go out as any of the three widths. That is what lets a generated CDDL
+schema describe a `Half` as `float16` where a `float` needs the prelude's looser `float`. A NaN of any
+payload is written as the canonical `F9 7E00`, so a deterministic encoding admits one spelling of NaN
+rather than 2046.
+
+Reading is as tolerant as a `float` member's, because it is the same reader: an integer, a text string,
+or any of the three float widths all decode. A value past binary16's range saturates to infinity, which
+is what the IEEE conversion does; it is not an error.
+
+`Half` is also the tenth [typed-array](typed-arrays.md) element type, tag 84 little-endian.
+
+> **The encoding changed.** Before `Half` had a converter it fell through to the object mapper and was
+> written as the struct's own members — a document no other decoder reads, and write-only besides, since
+> those members are computed or read-only and a read returned `default`. Such a document is now refused
+> with `Invalid major type Map` rather than silently yielding zero. Nothing that round-tripped before
+> round-trips differently now, because nothing round-tripped.

--- a/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
@@ -64,10 +64,28 @@ public partial class Context : CborSerializerContext { }
         [InlineData("object")]
         [InlineData("System.Guid")]
         [InlineData("System.DateTimeOffset")]
-        [InlineData("System.Half")]
         public void TypesWithNoConcreteConverterAreReported(string memberType)
         {
             AssertReports("CBOR1002", $@"
+public class Holder {{ public {memberType} Value {{ get; set; }} }}
+
+[CborSerializable(typeof(Holder))]
+public partial class Context : CborSerializerContext {{ }}
+");
+        }
+
+        /// <summary>
+        /// <c>Half</c> was in the list above until <c>HalfConverter</c> existed. It is the reason that
+        /// list is kept in step with <c>PrimitiveConverterProvider</c> by hand rather than derived from
+        /// it: while it was absent there, the reflection path did not refuse a <c>Half</c> — it wrote the
+        /// struct's internal fields, so the generator's refusal was the better of the two behaviours.
+        /// </summary>
+        [Theory]
+        [InlineData("System.Half")]
+        [InlineData("System.Half[]")]
+        public void AHalfIsNotReported(string memberType)
+        {
+            AssertClean($@"
 public class Holder {{ public {memberType} Value {{ get; set; }} }}
 
 [CborSerializable(typeof(Holder))]

--- a/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
@@ -56,9 +56,9 @@ public partial class Context : CborSerializerContext { }
         }
 
         /// <summary>
-        /// The four types classified as primitives that have no case in PrimitiveConverterProvider.
-        /// Each would fall through to ObjectConverterProvider and reach MakeGenericType at run time —
-        /// the exact failure a generated context exists to prevent, and invisible to the AOT analyzer.
+        /// The types with no case in PrimitiveConverterProvider. Each would fall through to
+        /// ObjectConverterProvider and reach MakeGenericType at run time — the exact failure a generated
+        /// context exists to prevent, and invisible to the AOT analyzer.
         /// </summary>
         [Theory]
         [InlineData("object")]
@@ -75,11 +75,15 @@ public partial class Context : CborSerializerContext {{ }}
         }
 
         /// <summary>
-        /// <c>Half</c> was in the list above until <c>HalfConverter</c> existed. It is the reason that
-        /// list is kept in step with <c>PrimitiveConverterProvider</c> by hand rather than derived from
-        /// it: while it was absent there, the reflection path did not refuse a <c>Half</c> — it wrote the
-        /// struct's internal fields, so the generator's refusal was the better of the two behaviours.
+        /// <c>HalfConverter</c> is a concrete converter, so a <c>Half</c> belongs on the other side of
+        /// that line — scalar and as an RFC 8746 typed-array element, which is the tenth element type.
         /// </summary>
+        /// <remarks>
+        /// The absence of a diagnostic is only half of what this has to be right about: a type in
+        /// neither <c>TypeCollector.IsPrimitive</c> nor <c>HasNoConcreteConverter</c> is also clean here,
+        /// while being collected as an object and written as its internal members.
+        /// <c>PrimitiveConverterProviderParityTests</c> in the library suite is what pins the other half.
+        /// </remarks>
         [Theory]
         [InlineData("System.Half")]
         [InlineData("System.Half[]")]

--- a/src/Dahomey.Cbor.Generator.Tests/EmissionTests.cs
+++ b/src/Dahomey.Cbor.Generator.Tests/EmissionTests.cs
@@ -174,5 +174,36 @@ namespace App
             Assert.Contains("options.DefaultNamingConvention", generated);
             Assert.Contains("someId", generated);
         }
+
+        /// <summary>
+        /// A <c>Half</c> is a scalar the emitter registers nothing for, and <c>Half[]</c> is the tenth
+        /// RFC 8746 element type, which makes it the one member shape that emits
+        /// <c>TypedArrayConverter&lt;System.Half&gt;</c>.
+        /// </summary>
+        /// <remarks>
+        /// A diagnostics-only assertion cannot see this: the converter named here has to be
+        /// <c>public</c> and its element type has to satisfy <c>where TI : unmanaged</c>, and both fail
+        /// at the consumer's compile rather than in the generator. <c>TypedArrayConverter&lt;TI&gt;</c>
+        /// has already been <c>internal</c> once, which compiled inside the library's own friend test
+        /// assembly and was CS0122 everywhere else.
+        /// </remarks>
+        [Fact]
+        public void AHalfMemberAndAHalfArrayCompile()
+        {
+            AssertCompiles(@"
+namespace App
+{
+    public class Readings
+    {
+        public System.Half Scalar { get; set; }
+        public System.Half[] Series { get; set; }
+    }
+
+    [CborSerializable(typeof(Readings))]
+    [CborSourceGenerationOptions(TypedArrayMode = Dahomey.Cbor.TypedArrayMode.ReadWriteLittleEndian)]
+    public partial class Context : CborSerializerContext { }
+}
+");
+        }
     }
 }

--- a/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
+++ b/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
@@ -315,24 +315,27 @@ namespace Dahomey.Cbor.Generator
                 return "(int / #6.2(bstr) / #6.3(bstr))";
             }
 
-            // The two RFC 8949 section 3.4.4 types, matched by name for the same reason. Both write
-            // their tag unconditionally over a two-element array, exponent first, and their mantissa
-            // through WriteBigInteger -- so the mantissa is the same three-way choice as above, for the
-            // same reason, and the exponent is a plain int because CborWriter.WriteInt32 emits one.
-            // A `decimal` under DecimalFormat.DecimalFraction renders identically to
-            // CborDecimalFraction, which is correct rather than a collision: the two write the same
-            // bytes, and the declared type is what decides which converter produces them.
+            // The remaining scalars with no SpecialType, each matched by name for the same reason as
+            // BigInteger above.
             switch (type.ToDisplayString())
             {
+                // The two RFC 8949 section 3.4.4 types. Both write their tag unconditionally over a
+                // two-element array, exponent first, and their mantissa through WriteBigInteger -- so
+                // the mantissa is the same three-way choice as above, for the same reason, and the
+                // exponent is a plain int because CborWriter.WriteInt32 emits one. A `decimal` under
+                // DecimalFormat.DecimalFraction renders identically to CborDecimalFraction, which is
+                // correct rather than a collision: the two write the same bytes, and the declared type
+                // is what decides which converter produces them.
                 case "Dahomey.Cbor.CborDecimalFraction":
                     return "#6.4([int, (int / #6.2(bstr) / #6.3(bstr))])";
 
                 case "Dahomey.Cbor.CborBigFloat":
                     return "#6.5([int, (int / #6.2(bstr) / #6.3(bstr))])";
 
-                // Written as binary16 and nothing wider, so `float16` is exact here where `float` --
-                // which the single/double row needs, since those emit the shortest round-tripping form
-                // -- would be looser than the writer.
+                // HalfConverter writes through CborWriter.WriteHalf, which emits binary16 and nothing
+                // wider -- unlike WriteSingle and WriteDouble, which pick the shortest form that round
+                // trips and so need the prelude's looser `float`. So `float16` is exact here rather
+                // than merely permitted.
                 case "System.Half":
                     return "float16";
             }

--- a/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
+++ b/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
@@ -329,14 +329,17 @@ namespace Dahomey.Cbor.Generator
 
                 case "Dahomey.Cbor.CborBigFloat":
                     return "#6.5([int, (int / #6.2(bstr) / #6.3(bstr))])";
+
+                // Written as binary16 and nothing wider, so `float16` is exact here where `float` --
+                // which the single/double row needs, since those emit the shortest round-tripping form
+                // -- would be looser than the writer.
+                case "System.Half":
+                    return "float16";
             }
 
-            // Guid and DateTimeOffset have no scalar converter. Nor does System.Half: the only place
-            // the library references it is the RFC 8746 typed-array element path, which writes
-            // `#6.84(bstr)` -- a different representation entirely, not this method's concern.
-            // System.Decimal reaches here only in its default encoding, which is likewise
-            // indescribable. Each falls through to CBOR1011 rather than asserting a row no converter
-            // backs.
+            // Guid and DateTimeOffset have no scalar converter. System.Decimal reaches here only in
+            // its default encoding, which is likewise indescribable. Each falls through to CBOR1011
+            // rather than asserting a row no converter backs.
             return null;
         }
 

--- a/src/Dahomey.Cbor.Generator/TypeCollector.cs
+++ b/src/Dahomey.Cbor.Generator/TypeCollector.cs
@@ -738,7 +738,7 @@ namespace Dahomey.Cbor.Generator
         private static bool HasNoConcreteConverter(ITypeSymbol type)
         {
             return type.SpecialType == SpecialType.System_Object
-                || type.ToDisplayString() is "System.Half" or "System.Guid" or "System.DateTimeOffset";
+                || type.ToDisplayString() is "System.Guid" or "System.DateTimeOffset";
         }
 
         private static bool IsPrimitive(ITypeSymbol type)
@@ -777,11 +777,21 @@ namespace Dahomey.Cbor.Generator
                     return true;
             }
 
-            // System.Half, System.Guid, System.DateTimeOffset and System.Object are deliberately absent.
+            // System.Guid, System.DateTimeOffset and System.Object are deliberately absent.
             // PrimitiveConverterProvider has no case for any of them, so at run time they fall through
             // to ObjectConverterProvider and reach MakeGenericType -- the exact failure a generated
             // context exists to prevent, and one the AOT analyzer cannot see either. Classifying them
             // as unsupported turns that into a build error. See UnsupportedReason.
+            //
+            // System.Half was in that list until HalfConverter existed, and it is the reason to keep
+            // this list and PrimitiveConverterProvider in step rather than approximating one from the
+            // other: while it was absent there, the reflection path did not refuse a Half -- it wrote
+            // the struct's internal fields.
+            if (type.ToDisplayString() == "System.Half")
+            {
+                return true;
+            }
+
             return false;
         }
 

--- a/src/Dahomey.Cbor.Generator/TypeCollector.cs
+++ b/src/Dahomey.Cbor.Generator/TypeCollector.cs
@@ -764,16 +764,22 @@ namespace Dahomey.Cbor.Generator
                     return true;
             }
 
-            // BigInteger has no SpecialType, but PrimitiveConverterProvider does resolve it to a
-            // concrete BigIntegerConverter, so it belongs with the cases above rather than with the
-            // unsupported types below. The same holds for the two RFC 8949 §3.4.4 types: without an
-            // entry here they are collected as objects and a generated context writes their Mantissa
-            // and Exponent as members, which is a green build and the wrong bytes.
+            // MATCHED PAIR: every case below duplicates a row of
+            // src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs. It
+            // cannot be shared -- the generator is an analyzer assembly and must not reference the
+            // runtime library -- so the two must be edited together. A type this list omits while the
+            // provider resolves it is collected as an object, and a generated context then writes its
+            // properties where the reflection path writes a scalar: a green build and the wrong bytes.
+            // A type this list names while the provider does not is worse, because nothing catches it
+            // until run time. PrimitiveConverterProviderParityTests is what holds the two in step.
+            //
+            // None of these has a SpecialType, so each is matched by name.
             switch (type.ToDisplayString())
             {
                 case "System.Numerics.BigInteger":
                 case "Dahomey.Cbor.CborDecimalFraction":
                 case "Dahomey.Cbor.CborBigFloat":
+                case "System.Half":
                     return true;
             }
 
@@ -782,16 +788,6 @@ namespace Dahomey.Cbor.Generator
             // to ObjectConverterProvider and reach MakeGenericType -- the exact failure a generated
             // context exists to prevent, and one the AOT analyzer cannot see either. Classifying them
             // as unsupported turns that into a build error. See UnsupportedReason.
-            //
-            // System.Half was in that list until HalfConverter existed, and it is the reason to keep
-            // this list and PrimitiveConverterProvider in step rather than approximating one from the
-            // other: while it was absent there, the reflection path did not refuse a Half -- it wrote
-            // the struct's internal fields.
-            if (type.ToDisplayString() == "System.Half")
-            {
-                return true;
-            }
-
             return false;
         }
 

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlDiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlDiagnosticTests.cs
@@ -157,9 +157,11 @@ namespace Harness
             Assert.Equal(DiagnosticSeverity.Error, reported.Severity);
         }
 
-        // char and BigInteger are deliberately absent from this file: both have concrete converters
-        // (CharConverter and BigIntegerConverter), so both render rather than raising CBOR1011.
-        // CddlScalarMappingTests pins what they render as.
+        // char, BigInteger and Half are deliberately absent from this file: each has a concrete
+        // converter (CharConverter, BigIntegerConverter and HalfConverter), so each renders rather than
+        // raising CBOR1011. CddlScalarMappingTests pins what they render as, where the row also reaches
+        // the gem's parse and instance checks -- which is the whole point of the split, since asserting
+        // here that a diagnostic stays silent says nothing about what was emitted instead.
 
         /// <summary>
         /// DateTimeOffset has no scalar converter either -- only System.DateTime does, via
@@ -179,31 +181,6 @@ namespace Harness
 
             Diagnostic reported = Assert.Single(diagnostics, d => d.Id == "CBOR1011");
             Assert.Equal(DiagnosticSeverity.Error, reported.Severity);
-        }
-
-        /// <summary>
-        /// Scalar System.Half renders as `float16`, which is exact rather than merely permitted:
-        /// HalfConverter writes binary16 and nothing wider, where the single/double row needs the
-        /// prelude's looser `float` because those emit the shortest form that round-trips.
-        /// </summary>
-        /// <remarks>
-        /// It had no representation until <c>HalfConverter</c> existed, when the only place the library
-        /// referenced <c>Half</c> was the RFC 8746 typed-array element path -- `#6.84(bstr)`, a
-        /// different representation entirely, and not a scalar member's.
-        /// </remarks>
-        [Fact]
-        public void ScalarHalfRendersAsFloat16()
-        {
-            ImmutableArray<Diagnostic> diagnostics = CddlGeneratorHarness.Run(Preamble + @"
-    public class Measurement { public System.Half Value { get; set; } }
-
-    [CborSerializable(typeof(Measurement))]
-    [CborCddlSchema]
-    public partial class HarnessContext : CborSerializerContext { }
-}
-");
-
-            Assert.DoesNotContain(diagnostics, d => d.Id == "CBOR1011");
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlDiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlDiagnosticTests.cs
@@ -182,12 +182,17 @@ namespace Harness
         }
 
         /// <summary>
-        /// Scalar System.Half has no converter either -- the only place the library references it is the
-        /// RFC 8746 typed-array element path, a different representation entirely (`#6.84(bstr)`), not a
-        /// scalar member's.
+        /// Scalar System.Half renders as `float16`, which is exact rather than merely permitted:
+        /// HalfConverter writes binary16 and nothing wider, where the single/double row needs the
+        /// prelude's looser `float` because those emit the shortest form that round-trips.
         /// </summary>
+        /// <remarks>
+        /// It had no representation until <c>HalfConverter</c> existed, when the only place the library
+        /// referenced <c>Half</c> was the RFC 8746 typed-array element path -- `#6.84(bstr)`, a
+        /// different representation entirely, and not a scalar member's.
+        /// </remarks>
         [Fact]
-        public void ScalarHalfHasNoCddlRepresentation()
+        public void ScalarHalfRendersAsFloat16()
         {
             ImmutableArray<Diagnostic> diagnostics = CddlGeneratorHarness.Run(Preamble + @"
     public class Measurement { public System.Half Value { get; set; } }
@@ -198,8 +203,7 @@ namespace Harness
 }
 ");
 
-            Diagnostic reported = Assert.Single(diagnostics, d => d.Id == "CBOR1011");
-            Assert.Equal(DiagnosticSeverity.Error, reported.Severity);
+            Assert.DoesNotContain(diagnostics, d => d.Id == "CBOR1011");
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlScalarMappingTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlScalarMappingTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.Serialization;
@@ -7,10 +8,10 @@ using Xunit;
 namespace Dahomey.Cbor.Tests.Cddl
 {
     /// <summary>
-    /// The two scalars whose CDDL is neither a prelude name nor a range, and which reach
+    /// The scalars whose CDDL is neither a prelude name nor a range, and which reach
     /// <c>CddlTypeReference.RenderPrimitive</c> by a route of their own: <c>char</c> is a
-    /// <c>SpecialType</c> that renders as text rather than as a number, and <c>BigInteger</c> has no
-    /// <c>SpecialType</c> at all and is matched by name.
+    /// <c>SpecialType</c> that renders as text rather than as a number, and <c>BigInteger</c>,
+    /// <c>Half</c> and the two §3.4.4 types have no <c>SpecialType</c> at all and are matched by name.
     /// </summary>
     public class CddlScalars
     {
@@ -18,6 +19,12 @@ namespace Dahomey.Cbor.Tests.Cddl
         public BigInteger Big { get; set; }
         public CborDecimalFraction Price { get; set; }
         public CborBigFloat Scale { get; set; }
+
+        /// <summary>
+        /// The one member whose row is narrower than the float family's, so it also proves the two are
+        /// rendered apart rather than by one shared branch.
+        /// </summary>
+        public Half Level { get; set; }
 
         /// <summary>
         /// A tuple, which is a fixed heterogeneous array rather than a collection of one type -- the one
@@ -77,6 +84,21 @@ namespace Dahomey.Cbor.Tests.Cddl
         }
 
         /// <summary>
+        /// <c>float16</c> and not the prelude's <c>float</c>: <c>CborWriter.WriteHalf</c> emits binary16
+        /// unconditionally, where <c>WriteSingle</c> and <c>WriteDouble</c> pick the shortest form that
+        /// round-trips and so may emit any of the three widths. The narrower row is what the writer
+        /// actually produces, and a schema that said <c>float</c> would admit documents this context
+        /// never writes.
+        /// </summary>
+        [Fact]
+        public void AHalfIsBinary16RatherThanTheWholeFloatFamily()
+        {
+            string schema = CddlScalarsContext.CddlSchema.Replace("\r\n", "\n");
+
+            Assert.Contains("\"Level\": float16,", schema);
+        }
+
+        /// <summary>
         /// A tuple is a fixed, heterogeneous array: one entry per element, in order, with the
         /// <c>Rest</c> chain flattened because that is what the writer emits. <c>[* X]</c> would say any
         /// length of one type, which is the one shape a tuple is not.
@@ -106,6 +128,7 @@ namespace Dahomey.Cbor.Tests.Cddl
                 // mantissa's choice rather than only the int one.
                 Scale = new CborBigFloat(BigInteger.Parse("18446744073709551616"), -1),
                 Pair = (7, "seven"),
+                Level = (Half)1.5f,
             };
 
             byte[] cbor = Helper.Write(value, Context.Options).HexToBytes();

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlTypedArrayTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlTypedArrayTests.cs
@@ -22,11 +22,9 @@ namespace Dahomey.Cbor.Tests.Cddl
         public float[] Samples { get; set; }
         public double[] Precise { get; set; }
 
-        // Half[] is deliberately absent, for the same reason it is absent from GeneratedTypedArrays:
-        // System.Half has no concrete converter in PrimitiveConverterProvider, so a context declaring
-        // Half[] is refused by CBOR1002 before typed arrays are reached. Nine of the ten RFC 8746
-        // element types are therefore all a generated schema can describe, and tag 84 is unreachable
-        // from here rather than untested.
+        // The tenth element type. It is the only one matched by name rather than by SpecialType, on
+        // both sides of the pair, so it is the row most likely to be missed by an edit to either.
+        public Half[] Levels { get; set; }
     }
 
     [CborSerializable(typeof(CddlTypedArrays))]
@@ -52,6 +50,7 @@ namespace Dahomey.Cbor.Tests.Cddl
             Balances = new[] { -1L, 2L },
             Samples = new[] { 1.5f },
             Precise = new[] { 1.25 },
+            Levels = new[] { (Half)1.5f },
         };
 
         /// <summary>
@@ -68,6 +67,7 @@ namespace Dahomey.Cbor.Tests.Cddl
         [InlineData("Offsets", 78)]    // sint32 little endian
         [InlineData("Ticks", 71)]      // uint64 little endian
         [InlineData("Balances", 79)]   // sint64 little endian
+        [InlineData("Levels", 84)]     // binary16 little endian
         [InlineData("Samples", 85)]    // binary32 little endian
         [InlineData("Precise", 86)]    // binary64 little endian
         public void EveryTypedArrayTagIsEmitted(string member, int tag)

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -140,6 +140,7 @@ namespace Dahomey.Cbor.Tests
                     Precise = new[] { 1.25, -3.5 },
                     Counts = new short[] { 1, -2, 300 },
                     Ticks = new ulong[] { 0, ulong.MaxValue },
+                    Levels = new[] { (System.Half)1.5f, System.Half.MaxValue },
                     Payload = new byte[] { 1, 2, 3 },
                 };
             }
@@ -463,6 +464,7 @@ namespace Dahomey.Cbor.Tests
                     Balances = new[] { -1L, 2L },
                     Samples = new[] { 1.5f },
                     Precise = new[] { 1.25 },
+                    Levels = new[] { (System.Half)1.5f },
                 };
             }
 
@@ -533,6 +535,7 @@ namespace Dahomey.Cbor.Tests
                     Initial = 'A',
                     Big = new System.Numerics.BigInteger(ulong.MaxValue) + System.Numerics.BigInteger.One,
                     Pair = (7, "seven"),
+                    Level = (System.Half)1.5f,
                 };
             }
 

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -217,6 +217,11 @@ namespace Dahomey.Cbor.Tests
                 return GeneratedTupleTests.Sample();
             }
 
+            if (type == typeof(Issues.Issue0240.HalfHolder))
+            {
+                return new Issues.Issue0240.HalfHolder { Value = (System.Half)1.5f };
+            }
+
             if (type == typeof(GeneratedOverrideHolder))
             {
                 return new GeneratedOverrideHolder { Id = 7, Name = "seven" };

--- a/src/Dahomey.Cbor.Tests/GeneratedTypedArrayTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedTypedArrayTests.cs
@@ -13,11 +13,10 @@ namespace Dahomey.Cbor.Tests
         public short[] Counts { get; set; }
         public ulong[] Ticks { get; set; }
 
-        // Half[] is deliberately absent. It is an RFC 8746 element type and the generator's element
-        // set names it, but System.Half has no concrete converter in PrimitiveConverterProvider, so a
-        // context declaring Half[] is refused by CBOR1002 before typed arrays are reached. That is the
-        // designed behaviour -- a loud refusal rather than a silent divergence -- and it is the one of
-        // the ten element types the generated path cannot carry.
+        // The tenth element type, and the only one whose element converter is not a SpecialType: it
+        // reaches the generated path through TypeCollector.IsPrimitive matching "System.Half" by name.
+        // Present here so tag 84 has the same byte-identity cover as the other nine.
+        public Half[] Levels { get; set; }
 
         /// <summary>
         /// byte[] is deliberately not a typed array: it stays a plain CBOR byte string, which is both
@@ -64,6 +63,7 @@ namespace Dahomey.Cbor.Tests
             Precise = new[] { 1.25, -3.5 },
             Counts = new short[] { 1, -2, 300 },
             Ticks = new ulong[] { 0, ulong.MaxValue },
+            Levels = new[] { (Half)1.5f, Half.MaxValue },
             Payload = new byte[] { 1, 2, 3 },
         };
 

--- a/src/Dahomey.Cbor.Tests/Helper.cs
+++ b/src/Dahomey.Cbor.Tests/Helper.cs
@@ -42,6 +42,14 @@ namespace Dahomey.Cbor.Tests
                 Assert.Equal(collection, (ICollection)sequenceValue);
                 Assert.Equal(collection, (ICollection)fragmentizedSequenceValue);
             }
+            // IEEE 754 says NaN equals nothing, itself included, so Assert.Equal cannot state "all
+            // three readers agree" for it. Mirrors the same branch in the CborReader-method overload
+            // below; without it a NaN fixture fails here for a reason that is not the reader's.
+            else if (value is Half half && Half.IsNaN(half))
+            {
+                Assert.True(Half.IsNaN((Half)(object)sequenceValue));
+                Assert.True(Half.IsNaN((Half)(object)fragmentizedSequenceValue));
+            }
             else if (value is IEquatable<T> equatable)
             {
                 Assert.Equal(value, sequenceValue);

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0240.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0240.cs
@@ -7,20 +7,28 @@ using Xunit;
 namespace Dahomey.Cbor.Tests.Issues
 {
     /// <summary>
-    /// A <see cref="Half"/> was written as its own internal fields, because
-    /// <c>PrimitiveConverterProvider</c> had no case for it and it fell through to
-    /// <c>ObjectConverterProvider</c> like any other struct.
+    /// Declared for <see cref="Issue0240.AGeneratedContextWritesWhatTheReflectionPathWrites"/>, and for
+    /// the side effect: a context in this assembly enrols every type it declares in
+    /// <c>GeneratedCorpusTests</c>, which is what owes <c>HalfHolder</c> a sample there and what keeps
+    /// the generated and reflection paths byte-identical as options are added.
     /// </summary>
-    /// <remarks>
-    /// Silently, and as a document no other decoder can read — reading it back depended on
-    /// <c>Half</c>'s private layout. Everything needed to encode it properly was already here:
-    /// <c>CborWriter.WriteHalf</c>, <c>CborReader.ReadHalf</c> and <c>CborPrimitive.HalfFloat</c>.
-    /// </remarks>
     [CborSerializable(typeof(Issue0240.HalfHolder))]
     public partial class HalfContext : CborSerializerContext
     {
     }
 
+    /// <summary>
+    /// Issue #240: a <see cref="Half"/> was written as its own internal members, because
+    /// <c>PrimitiveConverterProvider</c> had no case for it and it fell through to
+    /// <c>ObjectConverterProvider</c> like any other struct.
+    /// </summary>
+    /// <remarks>
+    /// Silently, and as a document no other decoder can read — and write-only besides, since all five
+    /// of those members are computed or read-only, so reading such a document back yielded
+    /// <c>default</c> rather than the value written. Everything needed to encode it properly was
+    /// already here: <c>CborWriter.WriteHalf</c>, <c>CborReader.ReadHalf</c> and
+    /// <c>CborPrimitive.HalfFloat</c>.
+    /// </remarks>
     public class Issue0240
     {
         [Fact]
@@ -30,35 +38,32 @@ namespace Dahomey.Cbor.Tests.Issues
             Helper.TestWrite((Half)1.5f, "F93E00");
         }
 
-        [Fact]
-        public void AHalfRoundTrips()
-        {
-            Assert.Equal((Half)1.5f, Helper.Read<Half>("F93E00"));
-        }
-
         /// <summary>
         /// The shape the issue reported: as a member, where it was a map of the struct's internals.
         /// </summary>
         [Fact]
         public void AHalfMemberIsANumberRatherThanAnObject()
         {
-            string hex = Helper.Write(new HalfHolder { Value = (Half)1.5f });
+            // A1 6556616C7565 F93E00 -- {"Value": 1.5}, one member holding a number. The exact bytes
+            // are what says it is not a map of the struct's own members, which is what a type with no
+            // concrete converter is written as.
+            const string hex = "A16556616C7565F93E00";
 
-            // A1 6556616C7565 F93E00 -- {"Value": 1.5}, one member holding a number.
-            Assert.Equal("A16556616C7565F93E00", hex, ignoreCase: true);
-            Assert.DoesNotContain("4269617365644578706F6E656E74", hex, StringComparison.OrdinalIgnoreCase);
+            Helper.TestWrite(new HalfHolder { Value = (Half)1.5f }, hex);
 
             Assert.Equal((Half)1.5f, Helper.Read<HalfHolder>(hex).Value);
         }
 
         /// <summary>
         /// The reader is as tolerant as <c>ReadSingle</c> is, because it is the same reader: a sender
-        /// that wrote the value as an integer or as a wider float is still read. That is not a policy
-        /// this converter chose — it defers to <c>CborReader.ReadHalf</c>.
+        /// that wrote the value as an integer, as a text string or as a wider float is still read. That
+        /// is not a policy this converter chose — it defers to <c>CborReader.ReadHalf</c>.
         /// </summary>
         [Theory]
+        [InlineData("F93E00", 1.5)]              // binary16, what the writer emits
         [InlineData("03", 3)]                    // a positive integer
         [InlineData("20", -1)]                   // a negative integer
+        [InlineData("63312E35", 1.5)]            // a text string, "1.5"
         [InlineData("FA3FC00000", 1.5)]          // binary32
         [InlineData("FB3FF8000000000000", 1.5)]  // binary64
         public void AHalfIsReadFromWhateverShapeTheSenderChose(string hex, double expected)
@@ -73,22 +78,65 @@ namespace Dahomey.Cbor.Tests.Issues
         [Fact]
         public void AValuePastTheRangeSaturates()
         {
+            // FA 7F7FFFFF -- binary32 float.MaxValue, ~3.4028235E38, far past binary16's 65504.
             Assert.Equal(Half.PositiveInfinity, Helper.Read<Half>("FA7F7FFFFF"));
         }
 
         /// <summary>
-        /// A generated context over the same shapes, so the corpus holds both paths to the same bytes —
-        /// and so the RFC 8746 element path is covered too, which is the one place the library already
-        /// referenced <c>Half</c> before this converter existed.
+        /// The one value the writer does not pass through: <c>CborWriter.InternalWriteHalf</c> replaces
+        /// any NaN with the canonical quiet one, so a payload-carrying or negative NaN does not reach
+        /// the wire. Without that a deterministic encoding would admit 2046 spellings of NaN.
         /// </summary>
+        [Theory]
+        [InlineData("F97E00")]  // the canonical quiet NaN
+        [InlineData("F97E01")]  // a quiet NaN carrying a payload
+        [InlineData("F9FE00")]  // a negative quiet NaN
+        public void EveryNaNIsWrittenAsTheCanonicalOne(string hex)
+        {
+            Half read = Helper.Read<Half>(hex);
+
+            Assert.True(Half.IsNaN(read));
+
+            // F9 7E00 -- binary16 quiet NaN, whatever the sender's spelling was.
+            Helper.TestWrite(read, "F97E00");
+        }
+
+        /// <summary>
+        /// The boundary values, so the fixtures are not all one exactly-representable number:
+        /// negative zero keeps its sign, the largest finite value is not rounded to infinity, and the
+        /// smallest subnormal does not flush to zero.
+        /// </summary>
+        [Theory]
+        [InlineData("F98000")]  // -0.0
+        [InlineData("F97BFF")]  // 65504, Half.MaxValue
+        [InlineData("F9FBFF")]  // -65504, Half.MinValue
+        [InlineData("F90001")]  // 5.9604645E-08, Half.Epsilon, the smallest subnormal
+        public void TheEdgesOfBinary16RoundTripByteForByte(string hex)
+        {
+            Helper.TestWrite(Helper.Read<Half>(hex), hex);
+        }
+
+        /// <summary>
+        /// The generated path resolves the same converter, so a context writes the bytes the reflection
+        /// path writes. Declaring <see cref="HalfContext"/> also enrols <see cref="HalfHolder"/> in
+        /// <c>GeneratedCorpusTests</c>, which is what keeps the two in step as options are added.
+        /// </summary>
+        /// <remarks>
+        /// A fresh <c>CborOptions</c> on the reflection side rather than null: null resolves to the
+        /// process-wide <c>CborOptions.Default</c>, whose registry state depends on which tests ran
+        /// before this one. The RFC 8746 element path is a separate shape and lives in
+        /// <c>GeneratedTypedArrayTests</c>, which carries a <c>Half[]</c> member for it.
+        /// </remarks>
         [Fact]
         public void AGeneratedContextWritesWhatTheReflectionPathWrites()
         {
-            HalfContext context = new HalfContext();
+            HalfContext context = CborSerializerContext.Default<HalfContext>();
             HalfHolder value = new HalfHolder { Value = (Half)1.5f };
 
-            Assert.Equal(Helper.Write(value), Helper.Write(value, context.Options), ignoreCase: true);
-            Assert.Equal((Half)1.5f, Helper.Read<HalfHolder>(Helper.Write(value, context.Options)).Value);
+            string generated = Helper.Write(value, context.Options);
+
+            Assert.Equal(Helper.Write(value, new CborOptions()), generated, ignoreCase: true);
+            Assert.Equal((Half)1.5f, Helper.Read<HalfHolder>(generated).Value);
         }
 
         public class HalfHolder

--- a/src/Dahomey.Cbor.Tests/Issues/Issue0240.cs
+++ b/src/Dahomey.Cbor.Tests/Issues/Issue0240.cs
@@ -1,0 +1,99 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using System;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Issues
+{
+    /// <summary>
+    /// A <see cref="Half"/> was written as its own internal fields, because
+    /// <c>PrimitiveConverterProvider</c> had no case for it and it fell through to
+    /// <c>ObjectConverterProvider</c> like any other struct.
+    /// </summary>
+    /// <remarks>
+    /// Silently, and as a document no other decoder can read — reading it back depended on
+    /// <c>Half</c>'s private layout. Everything needed to encode it properly was already here:
+    /// <c>CborWriter.WriteHalf</c>, <c>CborReader.ReadHalf</c> and <c>CborPrimitive.HalfFloat</c>.
+    /// </remarks>
+    [CborSerializable(typeof(Issue0240.HalfHolder))]
+    public partial class HalfContext : CborSerializerContext
+    {
+    }
+
+    public class Issue0240
+    {
+        [Fact]
+        public void AHalfIsWrittenAsAHalfFloat()
+        {
+            // F9 3E00 -- major type 7, additional value 25, binary16 1.5
+            Helper.TestWrite((Half)1.5f, "F93E00");
+        }
+
+        [Fact]
+        public void AHalfRoundTrips()
+        {
+            Assert.Equal((Half)1.5f, Helper.Read<Half>("F93E00"));
+        }
+
+        /// <summary>
+        /// The shape the issue reported: as a member, where it was a map of the struct's internals.
+        /// </summary>
+        [Fact]
+        public void AHalfMemberIsANumberRatherThanAnObject()
+        {
+            string hex = Helper.Write(new HalfHolder { Value = (Half)1.5f });
+
+            // A1 6556616C7565 F93E00 -- {"Value": 1.5}, one member holding a number.
+            Assert.Equal("A16556616C7565F93E00", hex, ignoreCase: true);
+            Assert.DoesNotContain("4269617365644578706F6E656E74", hex, StringComparison.OrdinalIgnoreCase);
+
+            Assert.Equal((Half)1.5f, Helper.Read<HalfHolder>(hex).Value);
+        }
+
+        /// <summary>
+        /// The reader is as tolerant as <c>ReadSingle</c> is, because it is the same reader: a sender
+        /// that wrote the value as an integer or as a wider float is still read. That is not a policy
+        /// this converter chose — it defers to <c>CborReader.ReadHalf</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("03", 3)]                    // a positive integer
+        [InlineData("20", -1)]                   // a negative integer
+        [InlineData("FA3FC00000", 1.5)]          // binary32
+        [InlineData("FB3FF8000000000000", 1.5)]  // binary64
+        public void AHalfIsReadFromWhateverShapeTheSenderChose(string hex, double expected)
+        {
+            Assert.Equal((Half)expected, Helper.Read<Half>(hex));
+        }
+
+        /// <summary>
+        /// A value past binary16's range saturates to infinity rather than throwing, which is what the
+        /// IEEE conversion does and what a caller declaring <c>Half</c> has asked for.
+        /// </summary>
+        [Fact]
+        public void AValuePastTheRangeSaturates()
+        {
+            Assert.Equal(Half.PositiveInfinity, Helper.Read<Half>("FA7F7FFFFF"));
+        }
+
+        /// <summary>
+        /// A generated context over the same shapes, so the corpus holds both paths to the same bytes —
+        /// and so the RFC 8746 element path is covered too, which is the one place the library already
+        /// referenced <c>Half</c> before this converter existed.
+        /// </summary>
+        [Fact]
+        public void AGeneratedContextWritesWhatTheReflectionPathWrites()
+        {
+            HalfContext context = new HalfContext();
+            HalfHolder value = new HalfHolder { Value = (Half)1.5f };
+
+            Assert.Equal(Helper.Write(value), Helper.Write(value, context.Options), ignoreCase: true);
+            Assert.Equal((Half)1.5f, Helper.Read<HalfHolder>(Helper.Write(value, context.Options)).Value);
+        }
+
+        public class HalfHolder
+        {
+            public Half Value { get; set; }
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/PrimitiveConverterProviderParityTests.cs
+++ b/src/Dahomey.Cbor.Tests/PrimitiveConverterProviderParityTests.cs
@@ -1,0 +1,111 @@
+using Dahomey.Cbor.Serialization.Converters.Providers;
+using Dahomey.Cbor.Tests.Cddl;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    /// <summary>
+    /// Holds <c>PrimitiveConverterProvider</c> and the generator's <c>TypeCollector.IsPrimitive</c> in
+    /// step. The two are a MATCHED PAIR that cannot share a list — the generator is an analyzer
+    /// assembly and must not reference the runtime library — so nothing but a test can catch a one-sided
+    /// edit.
+    /// </summary>
+    /// <remarks>
+    /// Both directions are failures, and the dangerous one is silent. A type the collector omits while
+    /// the provider resolves it is not refused: it is a struct, so it falls to <c>TypeKind.Object</c>
+    /// and the generated context registers an <c>ObjectConverter</c> over members the reflection path
+    /// never writes — a green build and the wrong bytes. That is why the assertion inspects the emitted
+    /// source rather than only the diagnostics: with the type absent from both <c>IsPrimitive</c> and
+    /// <c>HasNoConcreteConverter</c>, no diagnostic is reported at all. In the other direction a type
+    /// the collector names while the provider resolves nothing is registered nowhere and reaches
+    /// <c>ObjectConverterProvider</c> and <c>MakeGenericType</c> at run time — under Native AOT, the
+    /// exact failure a generated context exists to prevent.
+    /// <para>
+    /// Scoped to the scalars both sides decide by name, plus the two both sides refuse. Collections,
+    /// arrays, enums and the object model reach the provider too, but the collector classifies them by
+    /// their own kinds rather than through <c>IsPrimitive</c>, so a blanket equivalence over every type
+    /// the provider answers would compare two lists that were never meant to match.
+    /// </para>
+    /// </remarks>
+    public class PrimitiveConverterProviderParityTests
+    {
+        /// <summary>
+        /// The member type as C# source, the runtime type behind it, and the fully qualified name the
+        /// emitter would spell if the type were collected as an object.
+        /// </summary>
+        public static IEnumerable<object[]> ScalarsDecidedByName()
+        {
+            yield return new object[]
+            {
+                "System.Numerics.BigInteger", typeof(System.Numerics.BigInteger), "global::System.Numerics.BigInteger",
+            };
+            yield return new object[]
+            {
+                "Dahomey.Cbor.CborDecimalFraction", typeof(CborDecimalFraction), "global::Dahomey.Cbor.CborDecimalFraction",
+            };
+            yield return new object[]
+            {
+                "Dahomey.Cbor.CborBigFloat", typeof(CborBigFloat), "global::Dahomey.Cbor.CborBigFloat",
+            };
+            yield return new object[] { "System.Half", typeof(Half), "global::System.Half" };
+            yield return new object[] { "System.Guid", typeof(Guid), "global::System.Guid" };
+            yield return new object[] { "System.DateTimeOffset", typeof(DateTimeOffset), "global::System.DateTimeOffset" };
+        }
+
+        [Theory]
+        [MemberData(nameof(ScalarsDecidedByName))]
+        public void TheGeneratorCarriesExactlyWhatTheProviderResolves(
+            string memberType, Type type, string qualifiedName)
+        {
+            bool providerResolves =
+                new PrimitiveConverterProvider().GetConverter(type, new CborOptions()) != null;
+
+            (ImmutableArray<Diagnostic> diagnostics, string generated) =
+                CddlGeneratorHarness.RunAndGetGeneratedSources($@"
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+
+namespace Harness
+{{
+    public class Holder {{ public {memberType} Value {{ get; set; }} }}
+
+    [CborSerializable(typeof(Holder))]
+    public partial class HarnessContext : CborSerializerContext {{ }}
+}}
+");
+
+            bool refused = diagnostics.Any(diagnostic => diagnostic.Id == "CBOR1002");
+
+            // The member's own mapping names the type either way, so the marker has to be the
+            // registration the emitter writes only for a type collected as an object.
+            bool mappedAsAnObject = generated.Contains($"ObjectConverter<{qualifiedName}>");
+
+            if (providerResolves)
+            {
+                Assert.False(
+                    refused,
+                    $"PrimitiveConverterProvider resolves {memberType}, but the generator refuses it with "
+                        + "CBOR1002. Add it to TypeCollector.IsPrimitive.");
+
+                Assert.False(
+                    mappedAsAnObject,
+                    $"PrimitiveConverterProvider resolves {memberType}, but the generator collected it as an "
+                        + "object and registered an ObjectConverter over its members. The generated context "
+                        + "writes different bytes from the reflection path. Add it to TypeCollector.IsPrimitive.");
+            }
+            else
+            {
+                Assert.True(
+                    refused,
+                    $"PrimitiveConverterProvider resolves no converter for {memberType}, so at run time it "
+                        + "reaches ObjectConverterProvider and MakeGenericType. The generator has to refuse it "
+                        + "with CBOR1002. Add it to TypeCollector.HasNoConcreteConverter.");
+            }
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/HalfConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/HalfConverter.cs
@@ -1,0 +1,30 @@
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// <see cref="System.Half"/> as RFC 8949's binary16 — major type 7, additional value 25.
+    /// </summary>
+    /// <remarks>
+    /// Without this, <c>Half</c> reached <c>ObjectConverterProvider</c> and was mapped like any other
+    /// struct, so a member typed <c>Half</c> was written as its own internal fields —
+    /// <c>BiasedExponent</c>, <c>Exponent</c>, <c>Significand</c>, <c>_value</c> — silently, and as a
+    /// document no other decoder can read.
+    /// <para>
+    /// Both directions defer to <see cref="CborReader"/> and <see cref="CborWriter"/>, which already had
+    /// the half-float primitive: the reader accepts the same shapes <c>ReadSingle</c> does — an integer,
+    /// a text string, any of the float widths — so a <c>Half</c> member is exactly as tolerant of what a
+    /// sender chose as a <c>float</c> member is, rather than having a policy of its own.
+    /// </para>
+    /// </remarks>
+    public class HalfConverter : CborConverterBase<System.Half>
+    {
+        public override System.Half Read(ref CborReader reader)
+        {
+            return reader.ReadHalf();
+        }
+
+        public override void Write(ref CborWriter writer, System.Half value)
+        {
+            writer.WriteHalf(value);
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/HalfConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/HalfConverter.cs
@@ -4,15 +4,18 @@ namespace Dahomey.Cbor.Serialization.Converters
     /// <see cref="System.Half"/> as RFC 8949's binary16 — major type 7, additional value 25.
     /// </summary>
     /// <remarks>
-    /// Without this, <c>Half</c> reached <c>ObjectConverterProvider</c> and was mapped like any other
-    /// struct, so a member typed <c>Half</c> was written as its own internal fields —
-    /// <c>BiasedExponent</c>, <c>Exponent</c>, <c>Significand</c>, <c>_value</c> — silently, and as a
-    /// document no other decoder can read.
+    /// A <c>Half</c> needs a concrete converter or it reaches <c>ObjectConverterProvider</c> and is
+    /// mapped like any other struct — written as the struct's own internal members and read back as
+    /// <c>default</c>, because every one of them is computed or read-only. That failure is silent in
+    /// both directions, which is what makes the registration in <c>PrimitiveConverterProvider</c>
+    /// load-bearing rather than a convenience.
     /// <para>
-    /// Both directions defer to <see cref="CborReader"/> and <see cref="CborWriter"/>, which already had
-    /// the half-float primitive: the reader accepts the same shapes <c>ReadSingle</c> does — an integer,
-    /// a text string, any of the float widths — so a <c>Half</c> member is exactly as tolerant of what a
-    /// sender chose as a <c>float</c> member is, rather than having a policy of its own.
+    /// Both directions defer to <see cref="CborReader"/> and <see cref="CborWriter"/>, which already
+    /// carry the half-float primitive: the reader accepts the same shapes <c>ReadSingle</c> does — an
+    /// integer, a text string, any of the float widths — so a <c>Half</c> member is exactly as tolerant
+    /// of what a sender chose as a <c>float</c> member is, rather than having a policy of its own. The
+    /// writer emits binary16 and nothing wider, where <c>WriteSingle</c> and <c>WriteDouble</c> pick the
+    /// shortest form that round trips; a NaN of any payload goes out as the canonical <c>F9 7E00</c>.
     /// </para>
     /// </remarks>
     public class HalfConverter : CborConverterBase<System.Half>

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
@@ -48,6 +48,14 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
             }
 
             // Not a TypeCode, so it cannot join the switch above.
+            //
+            // MATCHED PAIR: the four scalars below are duplicated by name in
+            // src/Dahomey.Cbor.Generator/TypeCollector.cs (IsPrimitive) and rendered by name in
+            // CddlTypeReference.RenderPrimitive. They cannot be shared -- the generator is an analyzer
+            // assembly and must not reference this one -- so a converter added or removed here has to
+            // be mirrored there. PrimitiveConverterProviderParityTests is what catches a one-sided
+            // edit; without a mirror, a generated context maps the type as an object and writes
+            // different bytes from this path, with no diagnostic.
             if (type == typeof(Half))
             {
                 return new HalfConverter();

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
@@ -48,6 +48,11 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
             }
 
             // Not a TypeCode, so it cannot join the switch above.
+            if (type == typeof(Half))
+            {
+                return new HalfConverter();
+            }
+
             if (type == typeof(BigInteger))
             {
                 return new BigIntegerConverter();


### PR DESCRIPTION
Closes #240.

`PrimitiveConverterProvider` had no case for `System.Half`, so it fell through to `ObjectConverterProvider` and was mapped like any other struct:

```
before : A1 6156 A5 6E4269617365644578706F6E656E74 0F … 665F76616C7565 193E00
         {"V": {"BiasedExponent":15,"Exponent":0,"Significand":1536,
                "TrailingSignificand":512,"_value":15872}}      -- all five of Half's own members
after  : A1 6556616C7565 F93E00
         {"Value": 1.5}
```

No exception, and a document no other decoder can read. **It did not round-trip either**: all five of those members are get-only or `readonly`, so a read could set none of them and returned `default`. The old encoding was write-only, which is what makes this change safe — nothing that round-tripped before round-trips differently now, because nothing round-tripped.

Such a document now fails with `Invalid major type Map` rather than silently yielding zero. That is a behaviour change and `docs/numbers.md` carries it as a note.

## The open question answered itself

I asked in the issue whether a `Half` should read only from a half-float or from any numeric item the way `float` does. **The library had already decided**: `CborReader.ReadHalf()` exists and is tolerant in exactly the way `ReadSingle` is. The converter defers to it and to `CborWriter.WriteHalf` in both directions, so a `Half` member is precisely as tolerant of what a sender chose as a `float` member is, rather than acquiring a policy of its own. A theory covers an integer, a negative integer, binary32 and binary64, plus saturation to infinity past binary16's range.

Nothing new was needed — `WriteHalf`, `ReadHalf` and `CborPrimitive.HalfFloat = 25` were all already there, and `Half` resolves on all four target frameworks, so there is no conditional compilation.

## Two consequential changes

**The generator stops refusing `Half`.** That refusal was the *better* of the two behaviours while the converter was missing, which is exactly why the generator's "no concrete converter" list is kept in step with `PrimitiveConverterProvider` by hand rather than derived from it: the reflection path did not refuse a `Half`, it wrote the struct. `Half[]` was already reachable through the RFC 8746 typed-array path; the scalar was the gap.

**CDDL renders a scalar `Half` as `float16`**, which is exact rather than merely permitted — this converter writes binary16 and nothing wider, where the single/double row needs the prelude's looser `float` because those emit the shortest form that round-trips. `ScalarHalfHasNoCddlRepresentation` becomes `ScalarHalfRendersAsFloat16`; flagging it because a test changing sides is the one thing not visible in the diff.

## Verification

**2050 library tests and 44 generator tests green on net10.0** with `CDDL_REQUIRED=1`, 0 skipped; four TFMs build; no new warnings.

`HalfHolder` is in `GeneratedCorpusTests`, so the generated and reflection paths are held to the same bytes rather than only to a round trip.

## Holding the provider and the collector in step

This change edits `PrimitiveConverterProvider` **and** `TypeCollector.IsPrimitive`, which are a matched pair that cannot share a list — the generator is an analyzer assembly and must not reference the runtime library. `PrimitiveConverterProviderParityTests` is new and exists for that: only a test can catch a one-sided edit.

The dangerous direction is the silent one. A type the collector omits while the provider resolves it is not *refused* — it is a struct, so it falls to `TypeKind.Object` and the generated context registers an `ObjectConverter` over members the reflection path never writes: a green build and the wrong bytes. That is why the assertion reads the emitted source rather than only the diagnostics.

Both guards this PR adds are proven to bind, by making the edit and running it:

* weakening `float16` to `float` fails `AHalfIsBinary16RatherThanTheWholeFloatFamily`;
* dropping `Half` from the collector alone fails the parity test.

The `float16` assertion also moved to `CddlScalarMappingTests`, which reaches the reference `cddl` tool — it had first landed in the diagnostics file, which never does, so the row had neither a parse check nor an instance check.

`README.md` and `docs/numbers.md` document `Half` now.

---
_Generated by [Claude Code](https://claude.ai/code)_
