### PR TITLE
Label CDDL Array entries with their member names, on request

### DIFF
--- a/src/Dahomey.Cbor.Generator/CborSourceGenerator.cs
+++ b/src/Dahomey.Cbor.Generator/CborSourceGenerator.cs
@@ -344,9 +344,32 @@ namespace Dahomey.Cbor.Generator
         /// </summary>
         public bool WritesDecimalFractions => DecimalFormat is "DecimalFraction";
 
+        /// <summary>
+        /// Whether an <c>Array</c> rule labels each entry with its member name, from
+        /// <c>[CborCddlSchema(MemberNames = true)]</c>. It rides here rather than being threaded
+        /// separately because every method that emits a shape already takes these options.
+        /// </summary>
+        public bool CddlMemberNames { get; private set; }
+
         public static GenerationOptions Read(INamedTypeSymbol contextSymbol, List<DiagnosticInfo> diagnostics)
         {
             GenerationOptions options = new GenerationOptions();
+
+            // Read before the early return below: this setting lives on [CborCddlSchema], so a context
+            // carrying that attribute and no [CborSourceGenerationOptions] must still see it.
+            AttributeData? schemaAttribute = contextSymbol.GetAttributes().FirstOrDefault(
+                a => a.AttributeClass?.ToDisplayString() == "Dahomey.Cbor.Attributes.CborCddlSchemaAttribute");
+
+            if (schemaAttribute is not null)
+            {
+                foreach (KeyValuePair<string, TypedConstant> named in schemaAttribute.NamedArguments)
+                {
+                    if (named.Key == "MemberNames" && named.Value.Value is bool memberNames)
+                    {
+                        options.CddlMemberNames = memberNames;
+                    }
+                }
+            }
 
             AttributeData? attribute = contextSymbol.GetAttributes().FirstOrDefault(
                 a => a.AttributeClass?.ToDisplayString() == "Dahomey.Cbor.Attributes.CborSourceGenerationOptionsAttribute");

--- a/src/Dahomey.Cbor.Generator/CddlEmitter.cs
+++ b/src/Dahomey.Cbor.Generator/CddlEmitter.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -362,6 +363,13 @@ namespace Dahomey.Cbor.Generator
                 builder.Append(",\n");
             }
 
+            // Labels are resolved for the whole rule before any is written, because uniqueness is a
+            // property of the rule rather than of a member: two members whose names fold to the same
+            // identifier can only be told apart by looking at both.
+            IReadOnlyDictionary<MemberModel, string> memberLabels = isArray && options.CddlMemberNames
+                ? BuildMemberLabels(model)
+                : EmptyLabels;
+
             foreach (MemberModel member in InWireOrder(model))
             {
                 string? reference = CddlTypeReference.Render(member.Type, byKey, referenceNames, options);
@@ -387,7 +395,15 @@ namespace Dahomey.Cbor.Generator
                 switch (model.ObjectFormat)
                 {
                     case "Array":
-                        // Positional: no key at all, just the value in wire order.
+                        // Positional: the value alone carries the encoding. A label, when asked for, is
+                        // documentation -- in an array context CDDL ignores the member key -- and is
+                        // what gives a downstream code generator a distinct name per position.
+                        if (memberLabels.TryGetValue(member, out string? label))
+                        {
+                            builder.Append(label);
+                            builder.Append(": ");
+                        }
+
                         break;
 
                     case "IntKeyMap":
@@ -418,6 +434,87 @@ namespace Dahomey.Cbor.Generator
             }
 
             builder.Append(isArray ? "]" : "}");
+        }
+
+        private static readonly IReadOnlyDictionary<MemberModel, string> EmptyLabels =
+            new Dictionary<MemberModel, string>();
+
+        /// <summary>
+        /// A distinct label for each member of an <c>Array</c> rule, derived from the C# member name.
+        /// </summary>
+        /// <remarks>
+        /// Two guarantees, both of which a consumer of the schema depends on. The label is an ASCII
+        /// identifier — <c>[A-Za-z_][A-Za-z0-9_]*</c> — which is narrower than RFC 8610's <c>id</c>
+        /// (that admits <c>-</c> and <c>.</c>), because the reason to emit a label at all is a code
+        /// generator turning it into an identifier in a language that does not. And it is unique within
+        /// the rule, since a generator naming a struct field after each label needs the fields to
+        /// differ.
+        /// <para>
+        /// A C# member name is already an identifier, so the folding only has work to do for the
+        /// Unicode ones, which arrive as <c>_XXXX</c> per code point. That is not injective, so a
+        /// numeric suffix settles whatever it collides with.
+        /// </para>
+        /// </remarks>
+        private static IReadOnlyDictionary<MemberModel, string> BuildMemberLabels(TypeModel model)
+        {
+            Dictionary<MemberModel, string> labels = new Dictionary<MemberModel, string>();
+            HashSet<string> taken = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (MemberModel member in InWireOrder(model))
+            {
+                string candidate = FoldToAsciiIdentifier(member.Name);
+                string unique = candidate;
+
+                for (int suffix = 2; !taken.Add(unique); suffix++)
+                {
+                    unique = candidate + suffix.ToString(CultureInfo.InvariantCulture);
+                }
+
+                labels[member] = unique;
+            }
+
+            return labels;
+        }
+
+        /// <summary>
+        /// Folds a C# member name to <c>[A-Za-z_][A-Za-z0-9_]*</c>, escaping anything outside it as the
+        /// code point in hex.
+        /// </summary>
+        private static string FoldToAsciiIdentifier(string name)
+        {
+            StringBuilder builder = new StringBuilder(name.Length);
+
+            for (int index = 0; index < name.Length; index++)
+            {
+                char character = name[index];
+
+                if (character == '_'
+                    || (character >= 'A' && character <= 'Z')
+                    || (character >= 'a' && character <= 'z')
+                    || (character >= '0' && character <= '9' && builder.Length > 0))
+                {
+                    builder.Append(character);
+                    continue;
+                }
+
+                int codePoint = character;
+
+                // A surrogate pair is one code point, so it escapes as one run rather than as two
+                // lone halves that no longer name the character the member was declared with.
+                if (char.IsHighSurrogate(character)
+                    && index + 1 < name.Length
+                    && char.IsLowSurrogate(name[index + 1]))
+                {
+                    codePoint = char.ConvertToUtf32(character, name[index + 1]);
+                    index++;
+                }
+
+                builder.Append('_').Append(codePoint.ToString("X4", CultureInfo.InvariantCulture));
+            }
+
+            // Total rather than defensive: a C# identifier cannot open with a digit and an escape opens
+            // with '_', so nothing a member name produces reaches this.
+            return builder.Length == 0 ? "_" : builder.ToString();
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlMemberNameTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlMemberNameTests.cs
@@ -1,0 +1,144 @@
+// Annotations-only nullable context: the pinned schemas below expect a bare tstr, not tstr / nil.
+// See CddlSchemaTests.cs for the fuller rationale.
+#nullable enable annotations
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Cddl
+{
+    [CborObjectFormat(CborObjectFormat.Array)]
+    public class CddlLabelledRow
+    {
+        [CborProperty(0)]
+        public int Id { get; set; }
+
+        [CborProperty(1)]
+        public string Name { get; set; }
+
+        /// <summary>Second member of the same type as Id, which is what an unlabelled rule cannot tell apart.</summary>
+        [CborProperty(2)]
+        public int Revision { get; set; }
+    }
+
+    /// <summary>
+    /// Two members whose names fold to the same ASCII identifier: `Café` escapes its non-ASCII
+    /// character as its code point, which is exactly what the other member is already called.
+    /// </summary>
+    [CborObjectFormat(CborObjectFormat.Array)]
+    public class CddlColliding
+    {
+        [CborProperty(0)]
+        public int Café { get; set; }
+
+        [CborProperty(1)]
+        public int Caf_00E9 { get; set; }
+    }
+
+    [CborObjectFormat(CborObjectFormat.IntKeyMap)]
+    public class CddlLabelledPacked
+    {
+        [CborProperty(1)]
+        public int Id { get; set; }
+
+        [CborProperty(2)]
+        public string Name { get; set; }
+    }
+
+    [CborSerializable(typeof(CddlLabelledRow))]
+    [CborSerializable(typeof(CddlColliding))]
+    [CborSerializable(typeof(CddlLabelledPacked))]
+    [CborCddlSchema(MemberNames = true)]
+    public partial class CddlMemberNameContext : CborSerializerContext
+    {
+    }
+
+    public class CddlMemberNameTests
+    {
+        private static readonly CddlMemberNameContext Context =
+            CborSerializerContext.Default<CddlMemberNameContext>();
+
+        private static string Schema =>
+            CddlMemberNameContext.CddlSchema.Replace("\r\n", "\n");
+
+        [Fact]
+        public void ArrayEntriesCarryTheirMemberNames()
+        {
+            Assert.Contains(
+                "CddlLabelledRow = [\n" +
+                "  Id: -2147483648..2147483647,\n" +
+                "  Name: tstr,\n" +
+                "  Revision: -2147483648..2147483647,\n" +
+                "]",
+                Schema);
+        }
+
+        /// <summary>
+        /// The reason the option exists: without labels the rule is three bare types, two of them
+        /// identical, and a generator naming a field per entry has nothing to tell positions 0 and 2
+        /// apart by.
+        /// </summary>
+        [Fact]
+        public void WithoutTheOptionTheEntriesAreBare()
+        {
+            string unlabelled = CddlFormatContext.CddlSchema.Replace("\r\n", "\n");
+
+            Assert.Contains("CddlRow = [\n  -2147483648..2147483647,\n  tstr,\n]", unlabelled);
+        }
+
+        [Fact]
+        public void LabelsThatFoldTogetherAreMadeUnique()
+        {
+            Assert.Contains(
+                "CddlColliding = [\n" +
+                "  Caf_00E9: -2147483648..2147483647,\n" +
+                "  Caf_00E92: -2147483648..2147483647,\n" +
+                "]",
+                Schema);
+        }
+
+        /// <summary>
+        /// The option is about the Array format alone. A map already names every entry by its key, and
+        /// a label there would be a second, contradictory name for the same position.
+        /// </summary>
+        [Fact]
+        public void MapFormatsAreUnaffected()
+        {
+            Assert.Contains(
+                "CddlLabelledPacked = {\n  1: -2147483648..2147483647,\n  2: tstr,\n}",
+                Schema);
+        }
+
+        /// <summary>
+        /// The labels are documentation: an array's member keys do not participate in validation, so
+        /// the bytes that validated against the unlabelled rule still validate against this one.
+        /// </summary>
+        [CddlFact]
+        public void LabelledOutputStillValidates()
+        {
+            CddlLabelledRow value = new CddlLabelledRow { Id = 7, Name = "foo", Revision = 3 };
+            byte[] cbor = Helper.Write(value, Context.Options).HexToBytes();
+
+            CddlResult result = CddlTool.Validate(Schema, "CddlLabelledRow", cbor);
+
+            Assert.True(result.Ok, result.Output);
+        }
+
+        /// <summary>
+        /// Labelling must not have turned the rule into something that accepts any order: the entries
+        /// are still positional, and a document in declared-name order rather than index order is
+        /// still wrong.
+        /// </summary>
+        [CddlFact]
+        public void LabellingDoesNotMakeTheRuleOrderInsensitive()
+        {
+            // ["foo", 7, 3] -- Name first, where the rule says Id first.
+            byte[] cbor = "8363666F6F0703".HexToBytes();
+
+            CddlResult result = CddlTool.Validate(Schema, "CddlLabelledRow", cbor);
+
+            Assert.False(result.Ok, result.Output);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -546,6 +546,23 @@ namespace Dahomey.Cbor.Tests
                 };
             }
 
+            if (type == typeof(Cddl.CddlLabelledRow))
+            {
+                // Id and Revision differ, so a rule that confused the two same-typed positions would
+                // be caught here rather than only in the schema assertions.
+                return new Cddl.CddlLabelledRow { Id = 7, Name = "foo", Revision = 3 };
+            }
+
+            if (type == typeof(Cddl.CddlColliding))
+            {
+                return new Cddl.CddlColliding { Café = 1, Caf_00E9 = 2 };
+            }
+
+            if (type == typeof(Cddl.CddlLabelledPacked))
+            {
+                return new Cddl.CddlLabelledPacked { Id = 7, Name = "foo" };
+            }
+
             throw new InvalidOperationException(
                 $"{type} is declared on a generated context but has no sample; add one to {nameof(Sample)}.");
         }

--- a/src/Dahomey.Cbor/Attributes/CborCddlSchemaAttribute.cs
+++ b/src/Dahomey.Cbor/Attributes/CborCddlSchemaAttribute.cs
@@ -21,5 +21,30 @@ namespace Dahomey.Cbor.Attributes
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class CborCddlSchemaAttribute : Attribute
     {
+        /// <summary>
+        /// Labels each entry of a <see cref="CborObjectFormat.Array"/> rule with its member name, as
+        /// RFC 8610 permits. Off by default, because the labels are documentation rather than part of
+        /// the encoding.
+        /// </summary>
+        /// <remarks>
+        /// An array rule is otherwise a list of bare types, which says nothing about what each
+        /// position means:
+        /// <code>
+        /// MeasurementRecord = [ uint, uint, float, ]        // MemberNames = false
+        /// MeasurementRecord = [ TimestampMs: uint, Sequence: uint, Depth: float, ]
+        /// </code>
+        /// In an array context a member key is documentation and does not change what validates
+        /// against the rule, so turning this on is not a wire change.
+        /// <para>
+        /// It matters to code generators, which is the reason it exists. A generator that derives C
+        /// struct fields from an array rule has only the entry's type to name a field after, so two
+        /// members of one type collide — three <c>float</c> members become three fields called
+        /// <c>MeasurementRecord_float</c>, which is not compilable output. The labels give each
+        /// position a distinct name.
+        /// </para>
+        /// Labels are derived from the C# member name, folded to an ASCII identifier and made unique
+        /// within the rule, so they are usable by generators that emit C identifiers from them.
+        /// </remarks>
+        public bool MemberNames { get; set; }
     }
 }


### PR DESCRIPTION
An `Array` rule is a list of bare types, so nothing in the schema distinguishes two members that happen to share one:

```cddl
MeasurementRecord = [
  uint,
  uint,
  int,
  int,
]
```

That is fine for validation — the positions are ordered and CDDL needs no names — but it makes the schema unusable as an input to anything that generates code from it. A generator emitting a struct field per entry has only the entry's *type* to name the field after, so those four members become two fields called `MeasurementRecord_uint` and two called `MeasurementRecord_int`, which does not compile.

`[CborCddlSchema(MemberNames = true)]` labels each entry with its member name:

```cddl
MeasurementRecord = [
  TimestampMs: uint,
  Sequence: uint,
  DepthMicrometres: int,
  PressurePascals: int,
]
```

## This is not a wire change

RFC 8610 does not use a member key in an array context, so the labels are documentation and no document's validity changes. `LabelledOutputStillValidates` asserts the labelled rule accepts the same bytes, and `LabellingDoesNotMakeTheRuleOrderInsensitive` asserts it did not quietly become order-insensitive — both through the `cddl` gem rather than through this library's own idea of the schema.

Off by default, so no existing schema changes.

## What the labels are, precisely

Two guarantees, because a consumer depends on both:

* **An ASCII identifier**, `[A-Za-z_][A-Za-z0-9_]*`. That is deliberately narrower than RFC 8610's `id`, which also admits `-` and `.`: the reason to emit a label is a generator turning it into an identifier in a language that does not. Non-ASCII folds to the code point in hex, surrogate pairs as one run.
* **Unique within the rule.** The folding is not injective — a member called `Café` and one called `Caf_00E9` both fold to `Caf_00E9` — so a numeric suffix settles the collision. A generator naming a field per label needs the fields to differ.

## Scope

Array format only. A map rule already names every entry by its key, and a label there would be a second, contradictory name for the same position; `MapFormatsAreUnaffected` pins that `IntKeyMap` output is unchanged.

## Tests

Six new tests, plus three fixtures added to `GeneratedCorpusTests` so the labelled types are covered by the byte-identity corpus like any other.

**Two of the six fail without the emitter change** — `ArrayEntriesCarryTheirMemberNames` and `LabelsThatFoldTogetherAreMadeUnique`. Measured by reverting `CddlEmitter.cs` and `CborSourceGenerator.cs` to master while keeping the attribute property, so the test project still compiles and the option is simply ignored:

```
Failed: 2, Passed: 4, Total: 6
```

The other four are pins rather than evidence, and are worth having as pins: they assert the things that must stay true — that the unlabelled form is unchanged, that map formats are untouched, and the two `cddl`-gem checks above.

2036 library tests and 42 generator tests green on net10.0; all four TFMs build; no new warnings.

## Against the other open PRs

Merges cleanly against all six of #238, #239, #241, #242, #244 and #245, tested pairwise. The `GeneratedCorpusTests` addition lands at the end of `Sample` rather than at the top, which is where those PRs add, so it does not contend with them for the usual spot.
