### PR TITLE
Subtract a time zone offset to reach UTC, rather than adding it

### DIFF
--- a/src/Dahomey.Cbor.Tests/DateTimeTests.cs
+++ b/src/Dahomey.Cbor.Tests/DateTimeTests.cs
@@ -12,8 +12,15 @@ namespace Dahomey.Cbor.Tests
         [InlineData("1A4BFBAFFA", "2010-05-25T11:09:46Z")]
         [InlineData("74323031302D30352D32355431313A30393A34365A", "2010-05-25T11:09:46Z")]
         [InlineData("7818323031302D30352D32355431313A30393A34362E3132335A", "2010-05-25T11:09:46.123Z")]
-        [InlineData("781D323031392D30392D31315431303A31363A32382E3834312B30323A3030", "2019-09-11T12:16:28.841Z")]
-        [InlineData("781D323031392D30392D31315431303A31363A32382E3834312D30323A3030", "2019-09-11T08:16:28.841Z")]
+        // An offset is subtracted to reach UTC, so "+02:00" reads two hours earlier and "-02:00" two
+        // hours later -- not the reverse.
+        [InlineData("781D323031392D30392D31315431303A31363A32382E3834312B30323A3030", "2019-09-11T08:16:28.841Z")]
+        [InlineData("781D323031392D30392D31315431303A31363A32382E3834312D30323A3030", "2019-09-11T12:16:28.841Z")]
+        // RFC 3339 section 5.6's own worked example, which states this equivalence outright, and whose
+        // offset also carries the date across midnight.
+        [InlineData("7819313939362D31322D31395431363A33393A35372D30383A3030", "1996-12-20T00:39:57Z")]
+        // A minutes-bearing offset, so the two components are known to be applied in the same direction.
+        [InlineData("7819323031392D30392D31315431303A31363A32382B30353A3330", "2019-09-11T04:46:28Z")]
         public void ReadDateTime(string hexBuffer, string expectedISO8601)
         {
             DateTime expectedDateTime = DateTime.ParseExact(expectedISO8601,

--- a/src/Dahomey.Cbor/Serialization/Converters/DateTimeConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/DateTimeConverter.cs
@@ -172,7 +172,10 @@ namespace Dahomey.Cbor.Serialization.Converters
                     return false;
                 }
 
-                if (negative)
+                // The offset says how far the written clock runs ahead of UTC, so UTC is reached by
+                // subtracting it: RFC 3339 section 5.6 gives 1996-12-19T16:39:57-08:00 as equal to
+                // 1996-12-20T00:39:57Z, a negative offset moving the clock forward.
+                if (!negative)
                 {
                     offsetHours = -offsetHours;
                     offsetMinutes = -offsetMinutes;


### PR DESCRIPTION
Closes #248.

A `DateTime` written with an RFC 3339 numeric offset was read as the wrong instant, by **twice the offset**:

```
2019-09-11T10:16:28.841+02:00   ->  12:16:28.841Z   where it means  08:16:28.841Z
2019-09-11T10:16:28.841-02:00   ->  08:16:28.841Z   where it means  12:16:28.841Z
```

A trailing `Z` and an omitted offset were unaffected, so the failure is confined to documents carrying an offset -- and it is silent, since the value produced is well-formed and merely wrong.

The offset says how far the written clock runs ahead of UTC, so UTC is reached by subtracting it. RFC 3339 §5.6 states this outright, and its example is now a fixture:

> `1996-12-19T16:39:57-08:00` … "Note that this is equivalent to `1996-12-20T00:39:57Z` in UTC."

That case also carries the date across midnight, which nothing else here did.

### The two tests that change sides

**This PR corrects two passing tests rather than only adding to them**, which is the part worth reviewing rather than the one-line source change. `ReadDateTime`'s `+02:00` and `-02:00` cases had their expectations swapped, so the suite reported the defect as covered — a test asserting the reverse of the specification is why this survived. They are corrected in place rather than removed, so the diff shows the change of meaning.

A minutes-bearing offset (`+05:30`) joins them: no case used one, so the hours and minutes components were never known to be applied in the same direction.

### Scope

The two commented-out `WriteDateTime` cases are deliberately left alone. They concern what the *writer* emits for a non-UTC `DateTime`, whose offset comes from the machine's time zone, and that is a separate question from how a document is read.

`netstandard2.0;net8.0;net9.0;net10.0` all build clean; 2026 library tests and 42 generator tests pass on net10.0.