### PR TITLE
Give DateOnly and TimeOnly converters of their own

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Where the discriminator is written, when it is written, and how to change its na
 | [Polymorphism](docs/polymorphism.md) | Discriminators, policies and conventions |
 | [Typed arrays](docs/typed-arrays.md) | RFC 8746, `TypedArrayMode`, and what reads what |
 | [Numbers](docs/numbers.md) | `BigInteger`, `decimal`, `CborDecimalFraction` and `CborBigFloat` |
+| [Dates and times](docs/dates-and-times.md) | `DateTime`, `DateOnly`, `TimeOnly` and `DateTimeFormat` |
 | [Strings](docs/strings.md) | Indefinite-length strings, and why tag 25 is not supported |
 | [Tuples](docs/tuples.md) | `ValueTuple` at any arity, and the Native AOT requirement |
 | [Deterministic encoding](docs/deterministic-encoding.md) | RFC 8949 §4.2, key ordering, and hashing |

--- a/docs/dates-and-times.md
+++ b/docs/dates-and-times.md
@@ -1,0 +1,71 @@
+# Dates and times
+
+[← back to the README](../README.md)
+
+`DateTime`, `DateOnly` and `TimeOnly` each have a converter. Which encoding they write is chosen by one
+option, `CborOptions.DateTimeFormat`, so a document keeps one shape throughout.
+
+| `DateTimeFormat` | `DateTime` | `DateOnly` | `TimeOnly` |
+|---|---|---|---|
+| `ISO8601` (default) | tag 0 over an RFC 3339 date-time | tag 1004 over an RFC 3339 `full-date` | an RFC 3339 `partial-time`, untagged |
+| `Unix` | tag 1 over seconds since the epoch | tag 100 over days since 1970-01-01 | seconds since midnight, untagged |
+| `UnixMilliseconds` | tag 1 over fractional seconds | tag 100 over days since 1970-01-01 | fractional seconds since midnight, untagged |
+
+Reading ignores the setting: every form above is accepted whichever one is configured, tagged or not.
+The option describes what this end emits, and a peer's choice is not yours to make.
+
+## `DateOnly` (RFC 8943)
+
+```csharp
+public class Invoice
+{
+    public DateOnly Issued { get; set; }
+}
+```
+
+```csharp
+// 2026-08-17 -> D9 03EC 6A 323032362D30382D3137   (tag 1004, "2026-08-17")
+// 2026-08-17 -> D8 64 19 50CA                     (tag 100, 20682 days)
+```
+
+Both tags are registered by [RFC 8943](https://www.rfc-editor.org/rfc/rfc8943.html) for exactly this: a
+date with no time of day and no time zone. A date before the epoch is a negative day count, which that
+definition allows.
+
+Both numeric formats write the day count. A date has no time of day to carry milliseconds, so there is
+nothing for `UnixMilliseconds` to make finer.
+
+## `TimeOnly`
+
+```csharp
+// 01:02:03     -> 68 30313A30323A3033         ("01:02:03")
+// 01:02:03.841 -> 6C 30313A30323A30332E383431 ("01:02:03.841")
+// 01:02:03     -> 19 0E8B                     (3723 seconds since midnight)
+```
+
+Alone among these types, `TimeOnly` is written **untagged**. The CBOR tag registry has nothing for a time
+of day — tags 0, 1, 4 and 5 are whole instants, and 1002 and 1003 are a duration and a period — so there
+is no number to use, and occupying an unassigned one would produce documents another decoder is entitled
+to reject.
+
+The fraction is written only when there is one, at the width it needs, and a fraction finer than 100ns in
+an incoming document is truncated rather than refused: a peer whose clock is more precise than `TimeOnly`
+is interoperating correctly.
+
+`DateTimeFormat.Unix` writes whole seconds, so a `TimeOnly` carrying a fraction does not survive a round
+trip through that setting. This is the same narrowing `Unix` already applies to a `DateTime`.
+
+A `DateTime` read from a string carrying a numeric offset is converted to UTC, and the offset itself is
+not retained — `DateTime` has nowhere to put it, only a `DateTimeKind`. A string with no offset and no
+`Z` is given the kind named by `CborOptions.UnqualifiedTimeZoneDateTimeKind`.
+
+## What has no converter
+
+`System.DateTimeOffset` and `System.TimeSpan` have none. Both are structs with public properties, so the
+reflection path maps them as objects and writes those properties as a map: valid CBOR, but large — a
+`TimeSpan` takes 259 bytes — and a `DateTimeOffset` does not read back at all, arriving as `default`.
+
+A source-generated context refuses `DateTimeOffset` at build time with `CBOR1002`. It does not refuse
+`TimeSpan`, which is collected as an object and generates that same map.
+
+Write a [custom converter](../README.md#custom-converters) for either if you need one.

--- a/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
+++ b/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
@@ -329,6 +329,24 @@ namespace Dahomey.Cbor.Generator
 
                 case "Dahomey.Cbor.CborBigFloat":
                     return "#6.5([int, (int / #6.2(bstr) / #6.3(bstr))])";
+
+                // The two RFC 8943 tags, chosen by the same option that governs a DateTime: 1004 over
+                // a full-date string, 100 over a count of days. Both numeric formats write the day
+                // count, since a date has no time of day to carry milliseconds.
+                case "System.DateOnly":
+                    return options.DateTimeFormat is "Unix" or "UnixMilliseconds"
+                        ? "#6.100(int)"
+                        : "#6.1004(tstr)";
+
+                // Untagged, alone among the date and time types: no registered tag describes a time of
+                // day, so TimeOnlyConverter writes none and the schema must not claim one.
+                case "System.TimeOnly":
+                    return options.DateTimeFormat switch
+                    {
+                        "Unix" => "int",
+                        "UnixMilliseconds" => "float",
+                        _ => "tstr",
+                    };
             }
 
             // Guid and DateTimeOffset have no scalar converter. Nor does System.Half: the only place

--- a/src/Dahomey.Cbor.Generator/TypeCollector.cs
+++ b/src/Dahomey.Cbor.Generator/TypeCollector.cs
@@ -774,6 +774,10 @@ namespace Dahomey.Cbor.Generator
                 case "System.Numerics.BigInteger":
                 case "Dahomey.Cbor.CborDecimalFraction":
                 case "Dahomey.Cbor.CborBigFloat":
+                // Reachable only from a target where these exist at all; on netstandard2.0 the
+                // library compiles no converter for them and the consumer has no type to name.
+                case "System.DateOnly":
+                case "System.TimeOnly":
                     return true;
             }
 

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlDateOnlyTimeOnlyTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlDateOnlyTimeOnlyTests.cs
@@ -1,0 +1,116 @@
+using System;
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Cddl
+{
+    public class CddlDateHolder
+    {
+        public DateOnly Date { get; set; }
+        public TimeOnly Time { get; set; }
+    }
+
+    [CborSerializable(typeof(CddlDateHolder))]
+    [CborCddlSchema]
+    public partial class CddlDateIso8601Context : CborSerializerContext
+    {
+    }
+
+    [CborSerializable(typeof(CddlDateHolder))]
+    [CborCddlSchema]
+    [CborSourceGenerationOptions(DateTimeFormat = DateTimeFormat.Unix)]
+    public partial class CddlDateUnixContext : CborSerializerContext
+    {
+    }
+
+    [CborSerializable(typeof(CddlDateHolder))]
+    [CborCddlSchema]
+    [CborSourceGenerationOptions(DateTimeFormat = DateTimeFormat.UnixMilliseconds)]
+    public partial class CddlDateUnixMillisecondsContext : CborSerializerContext
+    {
+    }
+
+    public class CddlDateOnlyTimeOnlyTests
+    {
+        private static readonly CddlDateIso8601Context Iso8601Context =
+            CborSerializerContext.Default<CddlDateIso8601Context>();
+
+        private static readonly CddlDateUnixContext UnixContext =
+            CborSerializerContext.Default<CddlDateUnixContext>();
+
+        private static readonly CddlDateUnixMillisecondsContext UnixMillisecondsContext =
+            CborSerializerContext.Default<CddlDateUnixMillisecondsContext>();
+
+        private static readonly CddlDateHolder Value = new CddlDateHolder
+        {
+            Date = new DateOnly(2026, 8, 17),
+            Time = new TimeOnly(1, 2, 3, 841),
+        };
+
+        [Fact]
+        public void Iso8601RendersRfc8943FullDateAndAnUntaggedTime()
+        {
+            string schema = CddlDateIso8601Context.CddlSchema;
+
+            Assert.Contains("\"Date\": #6.1004(tstr),", schema);
+            Assert.Contains("\"Time\": tstr,", schema);
+        }
+
+        [Fact]
+        public void UnixRendersRfc8943EpochDayAndAnUntaggedInt()
+        {
+            string schema = CddlDateUnixContext.CddlSchema;
+
+            Assert.Contains("\"Date\": #6.100(int),", schema);
+            Assert.Contains("\"Time\": int,", schema);
+        }
+
+        /// <summary>
+        /// A date has no time of day to carry milliseconds, so it is the same day count under both
+        /// numeric formats -- unlike the time beside it, which does move.
+        /// </summary>
+        [Fact]
+        public void UnixMillisecondsKeepsTheDayCountAndFloatsOnlyTheTime()
+        {
+            string schema = CddlDateUnixMillisecondsContext.CddlSchema;
+
+            Assert.Contains("\"Date\": #6.100(int),", schema);
+            Assert.Contains("\"Time\": float,", schema);
+        }
+
+        [CddlFact]
+        public void Iso8601RoundTripsAgainstTheSchema()
+        {
+            byte[] cbor = Helper.Write(Value, Iso8601Context.Options).HexToBytes();
+
+            CddlResult result = CddlTool.Validate(
+                CddlDateIso8601Context.CddlSchema, "CddlDateHolder", cbor);
+
+            Assert.True(result.Ok, result.Output);
+        }
+
+        [CddlFact]
+        public void UnixRoundTripsAgainstTheSchema()
+        {
+            byte[] cbor = Helper.Write(Value, UnixContext.Options).HexToBytes();
+
+            CddlResult result = CddlTool.Validate(
+                CddlDateUnixContext.CddlSchema, "CddlDateHolder", cbor);
+
+            Assert.True(result.Ok, result.Output);
+        }
+
+        [CddlFact]
+        public void UnixMillisecondsRoundTripsAgainstTheSchema()
+        {
+            byte[] cbor = Helper.Write(Value, UnixMillisecondsContext.Options).HexToBytes();
+
+            CddlResult result = CddlTool.Validate(
+                CddlDateUnixMillisecondsContext.CddlSchema, "CddlDateHolder", cbor);
+
+            Assert.True(result.Ok, result.Output);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/DateOnlyTimeOnlyTests.cs
+++ b/src/Dahomey.Cbor.Tests/DateOnlyTimeOnlyTests.cs
@@ -1,0 +1,176 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using System;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    public class GeneratedDateHolder
+    {
+        public DateOnly Date { get; set; }
+        public TimeOnly Time { get; set; }
+        public DateOnly? OptionalDate { get; set; }
+    }
+
+    /// <summary>
+    /// Exercises the source-generated path, which a run-time test cannot reach.
+    /// </summary>
+    /// <remarks>
+    /// The regression this guards is silent in the same way the RFC 8949 section 3.4.4 structs are.
+    /// Both are non-generic structs, so without an entry in <c>TypeCollector.IsPrimitive</c>
+    /// <c>Classify</c> falls through to <c>TypeKind.Object</c> and the emitted context writes their
+    /// public properties as a map -- <c>Year</c>, <c>Month</c>, <c>DayNumber</c> and the rest -- which
+    /// builds green and produces the wrong bytes. What catches it is the <c>GeneratedCorpusTests</c>
+    /// comparison against the reflection path.
+    /// </remarks>
+    [CborSerializable(typeof(GeneratedDateHolder))]
+    public partial class DateContext : CborSerializerContext
+    {
+    }
+
+    public class DateOnlyTimeOnlyTests
+    {
+        [Theory]
+        // Tag 1004 over an RFC 3339 full-date string, which is what RFC 8943 registers it for.
+        [InlineData("D903EC6A323032362D30382D3137", 2026, 8, 17, DateTimeFormat.ISO8601)]
+        [InlineData("D903EC6A313937302D30312D3031", 1970, 1, 1, DateTimeFormat.ISO8601)]
+        // Tag 100 over days since 1970-01-01, RFC 8943's other registered encoding. 20682 days.
+        [InlineData("D8641950CA", 2026, 8, 17, DateTimeFormat.Unix)]
+        [InlineData("D86400", 1970, 1, 1, DateTimeFormat.Unix)]
+        // A date before the epoch is a negative count, which the tag's own definition allows.
+        [InlineData("D86438B4", 1969, 7, 4, DateTimeFormat.Unix)]
+        public void WriteDateOnly(string hexBuffer, int year, int month, int day, DateTimeFormat format)
+        {
+            Helper.TestWrite(
+                new DateOnly(year, month, day), hexBuffer, null, new CborOptions { DateTimeFormat = format });
+        }
+
+        [Theory]
+        [InlineData("D903EC6A323032362D30382D3137", 2026, 8, 17)]
+        [InlineData("D8641950CA", 2026, 8, 17)]
+        // Either encoding is read whatever DateTimeFormat is set to: that option describes what this
+        // end writes, and a peer's choice is not ours to make.
+        [InlineData("6A323032362D30382D3137", 2026, 8, 17)]
+        [InlineData("1950CA", 2026, 8, 17)]
+        // A leap day, which is the one date a wrong month-length table gets wrong.
+        [InlineData("D903EC6A323032342D30322D3239", 2024, 2, 29)]
+        public void ReadDateOnly(string hexBuffer, int year, int month, int day)
+        {
+            Assert.Equal(new DateOnly(year, month, day), Helper.Read<DateOnly>(hexBuffer));
+        }
+
+        [Theory]
+        [InlineData("6830313A30323A3033")]           // "01:02:03"
+        [InlineData("6C30313A30323A30332E383431")]   // "01:02:03.841"
+        [InlineData("7032333A35393A35392E39393939393939")]  // "23:59:59.9999999", the largest there is
+        [InlineData("6830303A30303A3030")]           // "00:00:00", midnight, whose ticks are zero
+        public void TimeOnlyRoundTrips(string hexBuffer)
+        {
+            TimeOnly value = Helper.Read<TimeOnly>(hexBuffer);
+
+            // Written untagged: the CBOR tag registry has nothing for a time of day, and occupying an
+            // unassigned number would produce documents another decoder may reject.
+            Helper.TestWrite(value, hexBuffer);
+        }
+
+        [Theory]
+        [InlineData("6830313A30323A3033", 1, 2, 3, 0)]
+        [InlineData("6C30313A30323A30332E383431", 1, 2, 3, 841)]
+        // A fraction finer than 100ns is truncated rather than refused -- a peer with a more precise
+        // clock is interoperating correctly, and TimeOnly has nowhere to put the rest.
+        [InlineData("7232333A35393A35392E393939393939393939", 23, 59, 59, 999)]
+        public void ReadTimeOnly(string hexBuffer, int hours, int minutes, int seconds, int milliseconds)
+        {
+            TimeOnly value = Helper.Read<TimeOnly>(hexBuffer);
+
+            Assert.Equal(hours, value.Hour);
+            Assert.Equal(minutes, value.Minute);
+            Assert.Equal(seconds, value.Second);
+            Assert.Equal(milliseconds, value.Millisecond);
+        }
+
+        [Theory]
+        // Seconds since midnight, under both numeric formats. 3723 = 01:02:03.
+        [InlineData("190E8B", 1, 2, 3)]
+        [InlineData("00", 0, 0, 0)]
+        [InlineData("FB40AD160000000000", 1, 2, 3)]
+        public void ReadTimeOnlyFromSecondsSinceMidnight(string hexBuffer, int hours, int minutes, int seconds)
+        {
+            Assert.Equal(new TimeOnly(hours, minutes, seconds), Helper.Read<TimeOnly>(hexBuffer));
+        }
+
+        [Theory]
+        [InlineData("190E8B", DateTimeFormat.Unix)]
+        [InlineData("FA4568B000", DateTimeFormat.UnixMilliseconds)]  // narrowed to a single, which holds 3723 exactly
+        public void WriteTimeOnlyAsSecondsSinceMidnight(string hexBuffer, DateTimeFormat format)
+        {
+            Helper.TestWrite(
+                new TimeOnly(1, 2, 3), hexBuffer, null, new CborOptions { DateTimeFormat = format });
+        }
+
+        [Theory]
+        [InlineData("6A323032362D31332D3137")]   // month 13
+        [InlineData("6A323032352D30322D3239")]   // 2025 is not a leap year
+        [InlineData("6A323032362D30382D3030")]   // day 0
+        [InlineData("69323032362D382D3137")]     // an unpadded month, which full-date does not admit
+        [InlineData("6B323032362D30382D31375A")] // a trailing designator
+        public void MalformedDateIsRefused(string hexBuffer)
+        {
+            Assert.Throws<CborException>(() => Helper.Read<DateOnly>(hexBuffer));
+        }
+
+        [Theory]
+        [InlineData("6832343A30303A3030")]       // 24:00:00 is a legal instant but not a time of day
+        [InlineData("6830313A36303A3033")]       // minute 60
+        [InlineData("6830313A30323A3630")]       // a leap second, which TimeOnly has no room for
+        [InlineData("6930313A30323A30332E")]     // a separator with no fraction after it
+        [InlineData("6730313A30323A33")]         // an unpadded second
+        public void MalformedTimeIsRefused(string hexBuffer)
+        {
+            Assert.Throws<CborException>(() => Helper.Read<TimeOnly>(hexBuffer));
+        }
+
+        [Theory]
+        [InlineData("1A7FFFFFFF")]               // a day count far past DateOnly.MaxValue
+        [InlineData("3A7FFFFFFF")]               // and far before its minimum
+        public void OutOfRangeDayCountIsRefused(string hexBuffer)
+        {
+            Assert.Throws<CborException>(() => Helper.Read<DateOnly>(hexBuffer));
+        }
+
+        [Theory]
+        [InlineData("1A00015180")]             // 86400 seconds is the next midnight, not a time
+        [InlineData("20")]                       // -1
+        [InlineData("FB7FF8000000000000")]       // NaN, which fails every range comparison
+        public void OutOfRangeSecondsAreRefused(string hexBuffer)
+        {
+            Assert.Throws<CborException>(() => Helper.Read<TimeOnly>(hexBuffer));
+        }
+
+        /// <summary>
+        /// The whole reason these converters exist: without them the reflection path maps each type as
+        /// an object over its public properties, which throws for one and silently drops the seconds of
+        /// the other.
+        /// </summary>
+        [Fact]
+        public void BothTypesRoundTripThroughAPocoMember()
+        {
+            Container value = new Container
+            {
+                Date = new DateOnly(2026, 8, 17),
+                Time = new TimeOnly(1, 2, 3, 841),
+            };
+
+            Container read = Helper.Read<Container>(Helper.Write(value));
+
+            Assert.Equal(value.Date, read.Date);
+            Assert.Equal(value.Time, read.Time);
+        }
+
+        public class Container
+        {
+            public DateOnly Date { get; set; }
+            public TimeOnly Time { get; set; }
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -195,6 +195,20 @@ namespace Dahomey.Cbor.Tests
                 };
             }
 
+            // A date carrying no time and a time carrying no date. Both are non-generic structs whose
+            // public properties would serialize as a perfectly valid map, so only the comparison against
+            // the reflection path says whether the context resolved their concrete converters. The
+            // nullable member is here because Nullable<T> reaches the element type by a different route.
+            if (type == typeof(GeneratedDateHolder))
+            {
+                return new GeneratedDateHolder
+                {
+                    Date = new DateOnly(2026, 8, 17),
+                    Time = new TimeOnly(1, 2, 3, 841),
+                    OptionalDate = new DateOnly(1969, 7, 4),
+                };
+            }
+
             // Both encodings of tag 4 in one type. The corpus runs it under two contexts differing only
             // in DecimalFormat, so the decimal member moves between the FC form and tag 4 while the two
             // struct members stay put -- which is the cohabitation, checked against the reflection path
@@ -442,6 +456,18 @@ namespace Dahomey.Cbor.Tests
                 return new Cddl.CddlDateTimeFormatHolder
                 {
                     Stamp = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+                };
+            }
+
+            // Carried by three contexts differing only in DateTimeFormat, so the date stays a day count
+            // across both numeric settings while the time beside it moves from an integer to a float.
+            // The fractional second is what makes that visible: whole seconds would render the same.
+            if (type == typeof(Cddl.CddlDateHolder))
+            {
+                return new Cddl.CddlDateHolder
+                {
+                    Date = new DateOnly(2026, 8, 17),
+                    Time = new TimeOnly(1, 2, 3, 841),
                 };
             }
 

--- a/src/Dahomey.Cbor/Serialization/Converters/DateOnlyConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/DateOnlyConverter.cs
@@ -1,0 +1,169 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// Reads and writes a <see cref="DateOnly"/> using the two encodings RFC 8943 registers for a
+    /// date with no time of day: tag 1004 over an RFC 3339 <c>full-date</c> string, and tag 100 over
+    /// the number of days since 1970-01-01.
+    /// </summary>
+    /// <remarks>
+    /// Which one is written follows <see cref="CborOptions.DateTimeFormat"/>, so a document keeps one
+    /// shape throughout rather than encoding its dates differently from its timestamps. Both are read
+    /// whichever is configured, since that setting describes what this end emits and says nothing
+    /// about what a peer sent.
+    /// </remarks>
+    public class DateOnlyConverter : CborConverterBase<DateOnly>
+    {
+        /// <summary>RFC 8943's tag for an RFC 3339 <c>full-date</c> string.</summary>
+        public const ulong FullDateTag = 1004;
+
+        /// <summary>RFC 8943's tag for a count of days since 1970-01-01.</summary>
+        public const ulong EpochDayTag = 100;
+
+        private static readonly DateOnly _epoch = new DateOnly(1970, 1, 1);
+
+        private readonly CborOptions _options;
+
+        public DateOnlyConverter(CborOptions options)
+        {
+            _options = options;
+        }
+
+        public override DateOnly Read(ref CborReader reader)
+        {
+            switch (reader.GetCurrentDataItemType())
+            {
+                case CborDataItemType.String:
+                    ReadOnlySpan<byte> rawString = reader.ReadRawString();
+
+                    if (!TryRead(rawString, out DateOnly dateOnly))
+                    {
+                        throw reader.BuildException(
+                            $"Invalid date format {Encoding.UTF8.GetString(rawString.ToArray())}");
+                    }
+
+                    return dateOnly;
+
+                case CborDataItemType.Signed:
+                case CborDataItemType.Unsigned:
+                    return ReadEpochDay(ref reader);
+
+                default:
+                    throw reader.BuildException("Invalid date format");
+            }
+        }
+
+        public override void Write(ref CborWriter writer, DateOnly value)
+        {
+            switch (_options.DateTimeFormat)
+            {
+                case DateTimeFormat.ISO8601:
+                    writer.WriteSemanticTag(FullDateTag);
+                    writer.WriteString(value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+                    break;
+
+                // A date has no time of day to carry milliseconds, so both numeric formats are the
+                // same count of whole days rather than one of them being a finer-grained variant.
+                case DateTimeFormat.Unix:
+                case DateTimeFormat.UnixMilliseconds:
+                    writer.WriteSemanticTag(EpochDayTag);
+                    writer.WriteInt32(value.DayNumber - _epoch.DayNumber);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// A day count is bounded by <see cref="DateOnly"/>'s own range, which is far narrower than
+        /// the integer that carries it, so a hostile or merely mistaken document is refused rather
+        /// than throwing <see cref="ArgumentOutOfRangeException"/> from the arithmetic.
+        /// </summary>
+        private DateOnly ReadEpochDay(ref CborReader reader)
+        {
+            long days = reader.ReadInt64();
+
+            long dayNumber = days + _epoch.DayNumber;
+
+            if (dayNumber < DateOnly.MinValue.DayNumber || dayNumber > DateOnly.MaxValue.DayNumber)
+            {
+                throw reader.BuildException($"Date out of range: {days} days since the epoch");
+            }
+
+            return DateOnly.FromDayNumber((int)dayNumber);
+        }
+
+        /// <summary>
+        /// RFC 3339 <c>full-date</c>, which is exactly ten characters and admits no alternatives --
+        /// no shortened year, no omitted separator, no trailing time.
+        /// </summary>
+        private static bool TryRead(ReadOnlySpan<byte> buffer, out DateOnly value)
+        {
+            if (buffer.Length != 10
+                || !TryReadInt32(ref buffer, 4, out int year)
+                || !TryReadByte(ref buffer, (byte)'-')
+                || !TryReadInt32(ref buffer, 2, out int month)
+                || !TryReadByte(ref buffer, (byte)'-')
+                || !TryReadInt32(ref buffer, 2, out int day))
+            {
+                value = default;
+                return false;
+            }
+
+            // Guarding the components keeps a malformed date a CborException rather than the
+            // ArgumentOutOfRangeException the constructor would raise, and February's length makes
+            // the day check unavoidable in any case.
+            if (year < 1 || year > 9999
+                || month < 1 || month > 12
+                || day < 1 || day > DateTime.DaysInMonth(year, month))
+            {
+                value = default;
+                return false;
+            }
+
+            value = new DateOnly(year, month, day);
+            return true;
+        }
+
+        private static bool TryReadInt32(ref ReadOnlySpan<byte> buffer, int digits, out int value)
+        {
+            if (buffer.Length < digits)
+            {
+                value = default;
+                return false;
+            }
+
+            value = 0;
+
+            for (int i = 0; i < digits; i++)
+            {
+                byte digit = buffer[i];
+
+                if (digit < '0' || digit > '9')
+                {
+                    value = default;
+                    return false;
+                }
+
+                value = value * 10 + (digit - '0');
+            }
+
+            buffer = buffer.Slice(digits);
+            return true;
+        }
+
+        private static bool TryReadByte(ref ReadOnlySpan<byte> buffer, byte expected)
+        {
+            if (buffer.Length < 1 || buffer[0] != expected)
+            {
+                return false;
+            }
+
+            buffer = buffer.Slice(1);
+            return true;
+        }
+    }
+}
+#endif

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
@@ -53,6 +53,18 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
                 return new BigIntegerConverter();
             }
 
+#if NET6_0_OR_GREATER
+            if (type == typeof(DateOnly))
+            {
+                return new DateOnlyConverter(options);
+            }
+
+            if (type == typeof(TimeOnly))
+            {
+                return new TimeOnlyConverter(options);
+            }
+#endif
+
             if (type == typeof(CborDecimalFraction))
             {
                 return new DecimalFractionConverter();

--- a/src/Dahomey.Cbor/Serialization/Converters/TimeOnlyConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TimeOnlyConverter.cs
@@ -1,0 +1,199 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// Reads and writes a <see cref="TimeOnly"/> as an RFC 3339 <c>partial-time</c> string, or as a
+    /// count of seconds since midnight.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately untagged, unlike <see cref="DateOnlyConverter"/>. The CBOR tag registry has
+    /// nothing for a time of day -- tags 0, 1, 4 and 5 are whole instants, and 1002 and 1003 are a
+    /// duration and a period -- so there is no number to use, and occupying an unassigned one would
+    /// leave documents that another decoder is entitled to reject.
+    /// </remarks>
+    public class TimeOnlyConverter : CborConverterBase<TimeOnly>
+    {
+        private const long TicksPerSecond = TimeSpan.TicksPerSecond;
+        private const long SecondsPerDay = 24 * 60 * 60;
+
+        private readonly CborOptions _options;
+
+        public TimeOnlyConverter(CborOptions options)
+        {
+            _options = options;
+        }
+
+        public override TimeOnly Read(ref CborReader reader)
+        {
+            switch (reader.GetCurrentDataItemType())
+            {
+                case CborDataItemType.String:
+                    ReadOnlySpan<byte> rawString = reader.ReadRawString();
+
+                    if (!TryRead(rawString, out TimeOnly timeOnly))
+                    {
+                        throw reader.BuildException(
+                            $"Invalid time format {Encoding.UTF8.GetString(rawString.ToArray())}");
+                    }
+
+                    return timeOnly;
+
+                case CborDataItemType.Signed:
+                case CborDataItemType.Unsigned:
+                    return FromSeconds(ref reader, reader.ReadInt64());
+
+                case CborDataItemType.Double:
+                case CborDataItemType.Single:
+                    return FromSeconds(ref reader, reader.ReadDouble());
+
+                default:
+                    throw reader.BuildException("Invalid time format");
+            }
+        }
+
+        public override void Write(ref CborWriter writer, TimeOnly value)
+        {
+            switch (_options.DateTimeFormat)
+            {
+                case DateTimeFormat.ISO8601:
+                    // "FFFFFFF" rather than "fffffff": a whole second is written as "01:02:03", and
+                    // the fraction appears only when there is one, at the width it needs.
+                    writer.WriteString(value.ToString("HH:mm:ss.FFFFFFF", CultureInfo.InvariantCulture));
+                    break;
+
+                // Whole seconds, so a value carrying a fraction does not round-trip through this
+                // format. That matches what DateTimeFormat.Unix already does to a DateTime.
+                case DateTimeFormat.Unix:
+                    writer.WriteInt64(value.Ticks / TicksPerSecond);
+                    break;
+
+                case DateTimeFormat.UnixMilliseconds:
+                    writer.WriteDouble((double)(value.Ticks / TimeSpan.TicksPerMillisecond) / 1000.0);
+                    break;
+            }
+        }
+
+        private static TimeOnly FromSeconds(ref CborReader reader, long seconds)
+        {
+            if (seconds < 0 || seconds >= SecondsPerDay)
+            {
+                throw reader.BuildException($"Time out of range: {seconds} seconds since midnight");
+            }
+
+            return new TimeOnly(seconds * TicksPerSecond);
+        }
+
+        private static TimeOnly FromSeconds(ref CborReader reader, double seconds)
+        {
+            // NaN fails every comparison, so it has to be refused by asking whether the value is in
+            // range rather than whether it is out of it.
+            if (!(seconds >= 0 && seconds < SecondsPerDay))
+            {
+                throw reader.BuildException($"Time out of range: {seconds} seconds since midnight");
+            }
+
+            return new TimeOnly((long)(seconds * TicksPerSecond));
+        }
+
+        /// <summary>
+        /// RFC 3339 <c>partial-time</c>: <c>HH:mm:ss</c>, optionally followed by a fraction. A
+        /// fraction finer than 100ns is truncated rather than refused, since a peer whose clock is
+        /// more precise than <see cref="TimeOnly"/> is interoperating correctly.
+        /// </summary>
+        private static bool TryRead(ReadOnlySpan<byte> buffer, out TimeOnly value)
+        {
+            if (!TryReadInt32(ref buffer, 2, out int hours)
+                || !TryReadByte(ref buffer, (byte)':')
+                || !TryReadInt32(ref buffer, 2, out int minutes)
+                || !TryReadByte(ref buffer, (byte)':')
+                || !TryReadInt32(ref buffer, 2, out int seconds))
+            {
+                value = default;
+                return false;
+            }
+
+            long ticks = 0;
+
+            if (TryReadByte(ref buffer, (byte)'.'))
+            {
+                // A separator with no digit after it is malformed, so the first one is required.
+                if (!TryReadInt32(ref buffer, 1, out int digit))
+                {
+                    value = default;
+                    return false;
+                }
+
+                int places = 1;
+                ticks = digit;
+
+                while (TryReadInt32(ref buffer, 1, out digit))
+                {
+                    if (places < 7)
+                    {
+                        ticks = ticks * 10 + digit;
+                        places++;
+                    }
+                }
+
+                for (; places < 7; places++)
+                {
+                    ticks *= 10;
+                }
+            }
+
+            // 24:00:00 is a legal RFC 3339 instant but not a legal time of day, and TimeOnly has no
+            // room for a leap second either.
+            if (!buffer.IsEmpty || hours > 23 || minutes > 59 || seconds > 59)
+            {
+                value = default;
+                return false;
+            }
+
+            value = new TimeOnly(((hours * 60L + minutes) * 60L + seconds) * TicksPerSecond + ticks);
+            return true;
+        }
+
+        private static bool TryReadInt32(ref ReadOnlySpan<byte> buffer, int digits, out int value)
+        {
+            if (buffer.Length < digits)
+            {
+                value = default;
+                return false;
+            }
+
+            value = 0;
+
+            for (int i = 0; i < digits; i++)
+            {
+                byte digit = buffer[i];
+
+                if (digit < '0' || digit > '9')
+                {
+                    value = default;
+                    return false;
+                }
+
+                value = value * 10 + (digit - '0');
+            }
+
+            buffer = buffer.Slice(digits);
+            return true;
+        }
+
+        private static bool TryReadByte(ref ReadOnlySpan<byte> buffer, byte expected)
+        {
+            if (buffer.Length < 1 || buffer[0] != expected)
+            {
+                return false;
+            }
+
+            buffer = buffer.Slice(1);
+            return true;
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Neither type had a converter, so both fell through to the object mapping and were serialized over their public properties:

```
DateOnly   throws: "Type mismatch between creator argument and field or property named dayNumber"
TimeOnly   76 bytes, and 01:02:03 reads back as 01:02 -- the seconds are gone, since Ticks is not settable
```

The `TimeOnly` case is the one worth noting: it is silent, and it loses data in a type whose whole purpose is to carry it.

### `DateOnly` — RFC 8943

[RFC 8943](https://www.rfc-editor.org/rfc/rfc8943.html) registers two tags for exactly this, a date with no time of day and no time zone, and both are used:

```
2026-08-17  ->  D9 03EC 6A 323032362D30382D3137   tag 1004, "2026-08-17"
2026-08-17  ->  D8 64 19 50CA                     tag 100, 20682 days
```

Which one is written follows `CborOptions.DateTimeFormat`, so a document keeps one shape throughout rather than encoding its dates differently from its timestamps. Both numeric formats write the day count -- a date has no time of day for `UnixMilliseconds` to make finer.

### `TimeOnly` — untagged, deliberately

The CBOR tag registry has nothing for a time of day. Tags 0, 1, 4 and 5 are whole instants; 1002 and 1003 are a duration and a period. So there is no number to use, and occupying an unassigned one would produce documents another decoder is entitled to reject -- the position `decimal` is already in with major type 7 / additional value 28, which RFC 8949 reserves.

It is an RFC 3339 `partial-time` string, or seconds since midnight under the numeric formats:

```
01:02:03      ->  68 30313A30323A3033
01:02:03.841  ->  6C 30313A30323A30332E383431
01:02:03      ->  19 0E8B                        3723 seconds since midnight
```

**`DateTimeFormat.Unix` writes whole seconds, so a `TimeOnly` carrying a fraction does not round-trip through that setting.** That is the same narrowing `Unix` already applies to a `DateTime`, but it is worth stating rather than leaving to be discovered.

Reading accepts every form above whichever format is configured, tagged or not: the option describes what this end emits and says nothing about what a peer sent.

### The generator half

`TypeCollector.IsPrimitive` gains both. Without it `Classify` falls through to `TypeKind.Object`, and a generated context writes `Year`, `Month`, `DayNumber` and the rest as a map — a green build and the wrong bytes, the same silent shape the §3.4.4 structs already guard against. Deleting either case makes two `GeneratedCorpusTests` cases fail, which is how I checked the coverage binds rather than assuming it.

CDDL renders `#6.1004(tstr)` / `#6.100(int)` for the date and a bare `tstr` / `int` / `float` for the time. The three schema tests are `[CddlFact]`, so they were validated against the Ruby `cddl` tool rather than compared to a string I wrote.

### Scope

`#if NET6_0_OR_GREATER`, as `HalfHelpers` already is — on netstandard2.0 there is no type to name.

`DateTimeOffset` and `TimeSpan` are **not** addressed here and still serialize as property maps (#247). `docs/dates-and-times.md` says so explicitly rather than leaving the omission implicit, including that the generator refuses the first and not the second.

2076 library tests and 42 generator tests pass on net10.0 with `CDDL_REQUIRED=1`; all four TFMs build with no warnings.