### PR TITLE
Give DateTimeOffset a converter, keeping the offset it carries

### DIFF
--- a/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
@@ -56,14 +56,13 @@ public partial class Context : CborSerializerContext { }
         }
 
         /// <summary>
-        /// The four types classified as primitives that have no case in PrimitiveConverterProvider.
+        /// The three types classified as primitives that have no case in PrimitiveConverterProvider.
         /// Each would fall through to ObjectConverterProvider and reach MakeGenericType at run time —
         /// the exact failure a generated context exists to prevent, and invisible to the AOT analyzer.
         /// </summary>
         [Theory]
         [InlineData("object")]
         [InlineData("System.Guid")]
-        [InlineData("System.DateTimeOffset")]
         [InlineData("System.Half")]
         public void TypesWithNoConcreteConverterAreReported(string memberType)
         {

--- a/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
+++ b/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
@@ -329,9 +329,19 @@ namespace Dahomey.Cbor.Generator
 
                 case "Dahomey.Cbor.CborBigFloat":
                     return "#6.5([int, (int / #6.2(bstr) / #6.3(bstr))])";
+
+                // The same three forms a DateTime takes, since it is the same pair of tags. Only tag 0
+                // carries the offset; tag 1 names an instant and drops it.
+                case "System.DateTimeOffset":
+                    return options.DateTimeFormat switch
+                    {
+                        "Unix" => "#6.1(int)",
+                        "UnixMilliseconds" => "#6.1(float)",
+                        _ => "#6.0(tstr)",
+                    };
             }
 
-            // Guid and DateTimeOffset have no scalar converter. Nor does System.Half: the only place
+            // Guid has no scalar converter. Nor does System.Half: the only place
             // the library references it is the RFC 8746 typed-array element path, which writes
             // `#6.84(bstr)` -- a different representation entirely, not this method's concern.
             // System.Decimal reaches here only in its default encoding, which is likewise

--- a/src/Dahomey.Cbor.Generator/TypeCollector.cs
+++ b/src/Dahomey.Cbor.Generator/TypeCollector.cs
@@ -738,7 +738,7 @@ namespace Dahomey.Cbor.Generator
         private static bool HasNoConcreteConverter(ITypeSymbol type)
         {
             return type.SpecialType == SpecialType.System_Object
-                || type.ToDisplayString() is "System.Half" or "System.Guid" or "System.DateTimeOffset";
+                || type.ToDisplayString() is "System.Half" or "System.Guid";
         }
 
         private static bool IsPrimitive(ITypeSymbol type)
@@ -774,10 +774,11 @@ namespace Dahomey.Cbor.Generator
                 case "System.Numerics.BigInteger":
                 case "Dahomey.Cbor.CborDecimalFraction":
                 case "Dahomey.Cbor.CborBigFloat":
+                case "System.DateTimeOffset":
                     return true;
             }
 
-            // System.Half, System.Guid, System.DateTimeOffset and System.Object are deliberately absent.
+            // System.Half, System.Guid and System.Object are deliberately absent.
             // PrimitiveConverterProvider has no case for any of them, so at run time they fall through
             // to ObjectConverterProvider and reach MakeGenericType -- the exact failure a generated
             // context exists to prevent, and one the AOT analyzer cannot see either. Classifying them

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlDiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlDiagnosticTests.cs
@@ -162,11 +162,12 @@ namespace Harness
         // CddlScalarMappingTests pins what they render as.
 
         /// <summary>
-        /// DateTimeOffset has no scalar converter either -- only System.DateTime does, via
-        /// DateTimeConverter.
+        /// DateTimeOffset does render, unlike the Guid above: DateTimeOffsetConverter writes the same
+        /// pair of tags DateTimeConverter does. Kept here beside that case because the two sat together
+        /// as refusals, and which of them still is worth stating in one place.
         /// </summary>
         [Fact]
-        public void DateTimeOffsetHasNoCddlRepresentation()
+        public void DateTimeOffsetHasACddlRepresentation()
         {
             ImmutableArray<Diagnostic> diagnostics = CddlGeneratorHarness.Run(Preamble + @"
     public class Logged { public System.DateTimeOffset When { get; set; } }
@@ -177,8 +178,7 @@ namespace Harness
 }
 ");
 
-            Diagnostic reported = Assert.Single(diagnostics, d => d.Id == "CBOR1011");
-            Assert.Equal(DiagnosticSeverity.Error, reported.Severity);
+            Assert.DoesNotContain(diagnostics, d => d.Id == "CBOR1011");
         }
 
         /// <summary>

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlScalarMappingTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlScalarMappingTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 using Dahomey.Cbor.Attributes;
 using Dahomey.Cbor.Serialization;
@@ -18,6 +19,9 @@ namespace Dahomey.Cbor.Tests.Cddl
         public BigInteger Big { get; set; }
         public CborDecimalFraction Price { get; set; }
         public CborBigFloat Scale { get; set; }
+
+        /// <summary>Tag 0, the only one of the pair that can carry an offset.</summary>
+        public DateTimeOffset When { get; set; }
 
         /// <summary>
         /// A tuple, which is a fixed heterogeneous array rather than a collection of one type -- the one
@@ -42,6 +46,16 @@ namespace Dahomey.Cbor.Tests.Cddl
         /// character and writes it as a text string -- not as an integer code point, which is the
         /// mapping a reader of the type alone would expect.
         /// </summary>
+        /// <summary>
+        /// The same tag a DateTime takes under the default format, since the two share an encoding --
+        /// only the offset inside the string differs, which CDDL does not distinguish.
+        /// </summary>
+        [Fact]
+        public void DateTimeOffsetIsTagZeroOverAString()
+        {
+            Assert.Contains("\"When\": #6.0(tstr),", CddlScalarsContext.CddlSchema.Replace("\r\n", "\n"));
+        }
+
         [Fact]
         public void CharIsATextString()
         {

--- a/src/Dahomey.Cbor.Tests/DateTimeOffsetTests.cs
+++ b/src/Dahomey.Cbor.Tests/DateTimeOffsetTests.cs
@@ -1,0 +1,165 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using System;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    public class GeneratedOffsetHolder
+    {
+        public DateTimeOffset Stamp { get; set; }
+        public DateTimeOffset? Optional { get; set; }
+    }
+
+    [CborSerializable(typeof(GeneratedOffsetHolder))]
+    public partial class OffsetContext : CborSerializerContext
+    {
+    }
+
+    public class DateTimeOffsetTests
+    {
+        private static DateTimeOffset At(int hours, int minutes = 0)
+        {
+            return new DateTimeOffset(2026, 8, 17, 1, 2, 3, new TimeSpan(hours, minutes, 0));
+        }
+
+        [Theory]
+        [InlineData("C07819323032362D30382D31375430313A30323A30332B30323A3030", 2)]
+        [InlineData("C07819323032362D30382D31375430313A30323A30332D30383A3030", -8)]
+        // A zero offset writes as "+00:00" rather than "Z": on a DateTimeOffset the offset is a value
+        // in its own right, and "K" renders it numerically. Both forms are RFC 3339 and both read back
+        // as the same instant at the same offset.
+        [InlineData("C07819323032362D30382D31375430313A30323A30332B30303A3030", 0)]
+        public void WriteKeepsTheOffset(string hexBuffer, int offsetHours)
+        {
+            Helper.TestWrite(At(offsetHours), hexBuffer);
+        }
+
+        [Fact]
+        public void WriteKeepsAMinutesBearingOffset()
+        {
+            Helper.TestWrite(At(5, 30), "C07819323032362D30382D31375430313A30323A30332B30353A3330");
+        }
+
+        [Theory]
+        [InlineData("C07819323032362D30382D31375430313A30323A30332B30323A3030", 2)]
+        [InlineData("C07819323032362D30382D31375430313A30323A30332D30383A3030", -8)]
+        [InlineData("C07819323032362D30382D31375430313A30323A30332B30303A3030", 0)]
+        // "Z" is an offset -- zero, stated -- and reads as one.
+        [InlineData("C074323032362D30382D31375430313A30323A30335A", 0)]
+        public void ReadKeepsTheOffset(string hexBuffer, int offsetHours)
+        {
+            DateTimeOffset value = Helper.Read<DateTimeOffset>(hexBuffer);
+
+            Assert.Equal(At(offsetHours), value);
+            Assert.Equal(TimeSpan.FromHours(offsetHours), value.Offset);
+        }
+
+        /// <summary>
+        /// The distinction the whole type exists for: two documents naming the same instant at
+        /// different offsets are equal as instants and are not interchangeable as values.
+        /// </summary>
+        [Fact]
+        public void TwoOffsetsNamingOneInstantAreEqualButNotIdentical()
+        {
+            DateTimeOffset berlin =
+                Helper.Read<DateTimeOffset>("C07819323032362D30382D31375430313A30323A30332B30323A3030");
+            DateTimeOffset utc =
+                Helper.Read<DateTimeOffset>("C074323032362D30382D31365432333A30323A30335A");
+
+            Assert.Equal(berlin, utc);
+            Assert.NotEqual(berlin.Offset, utc.Offset);
+            Assert.False(berlin.EqualsExact(utc));
+        }
+
+        [Fact]
+        public void FractionalSecondsSurvive()
+        {
+            const string hex = "C0781D323032362D30382D31375430313A30323A30332E3834312B30323A3030";
+
+            DateTimeOffset value = Helper.Read<DateTimeOffset>(hex);
+
+            Assert.Equal(841, value.Millisecond);
+            Assert.Equal(TimeSpan.FromHours(2), value.Offset);
+            Helper.TestWrite(value, hex);
+        }
+
+        /// <summary>
+        /// RFC 3339 section 5.6's own worked example, which crosses midnight and a month boundary.
+        /// </summary>
+        [Fact]
+        public void Rfc3339SectionFiveSixExample()
+        {
+            DateTimeOffset value =
+                Helper.Read<DateTimeOffset>("C07819313939362D31322D31395431363A33393A35372D30383A3030");
+
+            Assert.Equal(new DateTime(1996, 12, 20, 0, 39, 57, DateTimeKind.Utc), value.UtcDateTime);
+            Assert.Equal(TimeSpan.FromHours(-8), value.Offset);
+        }
+
+        /// <summary>
+        /// Tag 1 is a count of seconds since the epoch, so it names an instant and has nowhere to put
+        /// an offset. Both numeric formats therefore write the right moment and lose the offset, which
+        /// is a property of the encoding rather than of this converter.
+        /// </summary>
+        [Theory]
+        [InlineData("C11A6A82416B", DateTimeFormat.Unix)]
+        [InlineData("C1FB41DAA0905AC00000", DateTimeFormat.UnixMilliseconds)]
+        public void ANumericFormatKeepsTheInstantAndDropsTheOffset(string hexBuffer, DateTimeFormat format)
+        {
+            CborOptions options = new CborOptions { DateTimeFormat = format };
+
+            Helper.TestWrite(At(2), hexBuffer, null, options);
+
+            DateTimeOffset read = Helper.Read<DateTimeOffset>(hexBuffer, options);
+
+            Assert.Equal(At(2), read);                    // the same instant
+            Assert.Equal(TimeSpan.Zero, read.Offset);     // at a different offset
+        }
+
+        [Theory]
+        [InlineData("C07819323032362D31332D31375430313A30323A30332B30323A3030")]  // month 13
+        [InlineData("C07819323032362D30382D31375430313A30323A30332B31353A3030")]  // beyond 14 hours
+        [InlineData("C07819323032362D30382D31375430313A30323A30332B30323A3939")]  // 99 minutes
+        public void MalformedInputIsRefused(string hexBuffer)
+        {
+            Assert.Throws<CborException>(() => Helper.Read<DateTimeOffset>(hexBuffer));
+        }
+
+        /// <summary>
+        /// A string naming no offset is given one by <c>UnqualifiedTimeZoneDateTimeKind</c>, exactly as
+        /// constructing a <see cref="DateTimeOffset"/> from a <see cref="DateTime"/> of that kind does.
+        /// </summary>
+        [Fact]
+        public void AnUnqualifiedStringTakesTheOffsetTheOptionsAsk()
+        {
+            const string hex = "C073323032362D30382D31375430313A30323A3033";
+
+            DateTimeOffset utc = Helper.Read<DateTimeOffset>(
+                hex, new CborOptions { UnqualifiedTimeZoneDateTimeKind = DateTimeKind.Utc });
+
+            Assert.Equal(TimeSpan.Zero, utc.Offset);
+            Assert.Equal(new DateTime(2026, 8, 17, 1, 2, 3), utc.DateTime);
+        }
+
+        /// <summary>
+        /// Before this converter existed the reflection path mapped the struct over its public
+        /// properties: 807 bytes that read back as <c>default</c>, silently.
+        /// </summary>
+        [Fact]
+        public void RoundTripsThroughAPocoMember()
+        {
+            GeneratedOffsetHolder value = new GeneratedOffsetHolder
+            {
+                Stamp = At(2),
+                Optional = At(-8),
+            };
+
+            GeneratedOffsetHolder read = Helper.Read<GeneratedOffsetHolder>(Helper.Write(value));
+
+            Assert.Equal(value.Stamp, read.Stamp);
+            Assert.Equal(value.Stamp.Offset, read.Stamp.Offset);
+            Assert.Equal(value.Optional, read.Optional);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -445,6 +445,17 @@ namespace Dahomey.Cbor.Tests
                 };
             }
 
+            // Two different offsets, so the comparison catches a generated context that resolved a
+            // converter dropping them: the instants would still be right and the bytes would not.
+            if (type == typeof(GeneratedOffsetHolder))
+            {
+                return new GeneratedOffsetHolder
+                {
+                    Stamp = new DateTimeOffset(2026, 8, 17, 1, 2, 3, TimeSpan.FromHours(2)),
+                    Optional = new DateTimeOffset(1996, 12, 19, 16, 39, 57, TimeSpan.FromHours(-8)),
+                };
+            }
+
             if (type == typeof(Cddl.CddlTypedArrays))
             {
                 return new Cddl.CddlTypedArrays

--- a/src/Dahomey.Cbor/Serialization/Converters/DateTimeOffsetConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/DateTimeOffsetConverter.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// Reads and writes a <see cref="DateTimeOffset"/>, keeping the offset it carries.
+    /// </summary>
+    /// <remarks>
+    /// Only the tag 0 form can hold an offset. RFC 8949 tag 1 is a count of seconds since the epoch,
+    /// which names an instant and has nowhere to put the offset the value was observed at, so
+    /// <see cref="DateTimeFormat.Unix"/> and <see cref="DateTimeFormat.UnixMilliseconds"/> write the
+    /// correct instant with the offset dropped and read back at <see cref="TimeSpan.Zero"/>. That is a
+    /// property of the encoding rather than of this converter: a caller who needs the offset preserved
+    /// has to leave <see cref="CborOptions.DateTimeFormat"/> at <see cref="DateTimeFormat.ISO8601"/>.
+    /// </remarks>
+    public class DateTimeOffsetConverter : CborConverterBase<DateTimeOffset>
+    {
+        /// <summary>RFC 8949's own bound on a numeric offset, which DateTimeOffset shares.</summary>
+        private const int MaxOffsetMinutes = 14 * 60;
+
+        private readonly CborOptions _options;
+
+        public DateTimeOffsetConverter(CborOptions options)
+        {
+            _options = options;
+        }
+
+        public override DateTimeOffset Read(ref CborReader reader)
+        {
+            switch (reader.GetCurrentDataItemType())
+            {
+                case CborDataItemType.String:
+                    ReadOnlySpan<byte> rawString = reader.ReadRawString();
+
+                    if (!TryRead(rawString, out DateTimeOffset dateTimeOffset))
+                    {
+                        throw reader.BuildException(
+                            $"Invalid date format {Encoding.UTF8.GetString(rawString.ToArray())}");
+                    }
+
+                    return dateTimeOffset;
+
+                case CborDataItemType.Signed:
+                case CborDataItemType.Unsigned:
+                    return DateTimeOffset.FromUnixTimeSeconds(reader.ReadInt64());
+
+                case CborDataItemType.Double:
+                case CborDataItemType.Single:
+                    return DateTimeOffset.FromUnixTimeSeconds(0).AddSeconds(reader.ReadDouble());
+
+                default:
+                    throw reader.BuildException("Invalid date format");
+            }
+        }
+
+        public override void Write(ref CborWriter writer, DateTimeOffset value)
+        {
+            switch (_options.DateTimeFormat)
+            {
+                case DateTimeFormat.ISO8601:
+                    writer.WriteSemanticTag(0);
+                    // "K" on a DateTimeOffset is the numeric offset, so a zero offset writes as
+                    // "+00:00" rather than the "Z" a UTC DateTime produces. Both are RFC 3339 and both
+                    // read back here as the same instant at the same offset.
+                    writer.WriteString(
+                        value.ToString("yyyy-MM-dd'T'HH:mm:ss.FFFK", CultureInfo.InvariantCulture));
+                    break;
+
+                case DateTimeFormat.Unix:
+                    writer.WriteSemanticTag(1);
+                    writer.WriteInt64(value.ToUnixTimeSeconds());
+                    break;
+
+                case DateTimeFormat.UnixMilliseconds:
+                    writer.WriteSemanticTag(1);
+                    writer.WriteDouble((double)value.ToUnixTimeMilliseconds() / 1000.0);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// RFC 3339 <c>date-time</c>. Unlike <see cref="DateTimeConverter"/>, which converts an offset
+        /// away to reach UTC because <see cref="DateTime"/> has nowhere to keep it, the offset here is
+        /// the part worth keeping and the local time is stored beside it unmodified.
+        /// </summary>
+        private bool TryRead(ReadOnlySpan<byte> buffer, out DateTimeOffset value)
+        {
+            if (!TryReadInt32(ref buffer, 4, out int year)
+                || !TryReadByte(ref buffer, (byte)'-')
+                || !TryReadInt32(ref buffer, 2, out int month)
+                || !TryReadByte(ref buffer, (byte)'-')
+                || !TryReadInt32(ref buffer, 2, out int day)
+                || !TryReadByte(ref buffer, (byte)'T')
+                || !TryReadInt32(ref buffer, 2, out int hours)
+                || !TryReadByte(ref buffer, (byte)':')
+                || !TryReadInt32(ref buffer, 2, out int minutes)
+                || !TryReadByte(ref buffer, (byte)':')
+                || !TryReadInt32(ref buffer, 2, out int seconds))
+            {
+                value = default;
+                return false;
+            }
+
+            int milliseconds = 0;
+
+            if (TryReadByte(ref buffer, (byte)'.'))
+            {
+                if (!TryReadInt32(ref buffer, 1, out int digit))
+                {
+                    value = default;
+                    return false;
+                }
+
+                int places = 1;
+                milliseconds = digit;
+
+                while (TryReadInt32(ref buffer, 1, out digit))
+                {
+                    // Past three places the digits are finer than the milliseconds this reads, and are
+                    // dropped rather than refused -- a peer with a more precise clock is interoperating
+                    // correctly. Matches what DateTimeConverter accepts.
+                    if (places < 3)
+                    {
+                        milliseconds = milliseconds * 10 + digit;
+                        places++;
+                    }
+                }
+
+                for (; places < 3; places++)
+                {
+                    milliseconds *= 10;
+                }
+            }
+
+            if (!TryReadOffset(ref buffer, out TimeSpan? offset) || !buffer.IsEmpty)
+            {
+                value = default;
+                return false;
+            }
+
+            try
+            {
+                // An unqualified string names no offset, so the kind the options ask for decides one:
+                // Utc gives zero and Local the machine's, exactly as constructing a DateTimeOffset from
+                // a DateTime of that kind does.
+                if (offset is null)
+                {
+                    value = new DateTimeOffset(
+                        new DateTime(
+                            year, month, day, hours, minutes, seconds, milliseconds,
+                            _options.UnqualifiedTimeZoneDateTimeKind));
+
+                    return true;
+                }
+
+                value = new DateTimeOffset(
+                    year, month, day, hours, minutes, seconds, milliseconds, offset.Value);
+
+                return true;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // A component the calendar refuses -- month 13, February 30 -- or a local time the
+                // offset pushes outside DateTimeOffset's range. Refused as a format error rather than
+                // escaping as an exception a caller's catch(CborException) would miss.
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Reads the RFC 3339 <c>time-offset</c>, returning a null offset for a string that carries
+        /// none. <c>Z</c> is an offset -- zero, stated -- and is not the same as its absence.
+        /// </summary>
+        private static bool TryReadOffset(ref ReadOnlySpan<byte> buffer, out TimeSpan? offset)
+        {
+            offset = null;
+
+            if (buffer.IsEmpty)
+            {
+                return true;
+            }
+
+            if (TryReadByte(ref buffer, (byte)'Z'))
+            {
+                offset = TimeSpan.Zero;
+                return true;
+            }
+
+            bool negative;
+
+            if (TryReadByte(ref buffer, (byte)'-'))
+            {
+                negative = true;
+            }
+            else if (TryReadByte(ref buffer, (byte)'+'))
+            {
+                negative = false;
+            }
+            else
+            {
+                return false;
+            }
+
+            if (!TryReadInt32(ref buffer, 2, out int offsetHours)
+                || !TryReadByte(ref buffer, (byte)':')
+                || !TryReadInt32(ref buffer, 2, out int offsetMinutes))
+            {
+                return false;
+            }
+
+            int total = offsetHours * 60 + offsetMinutes;
+
+            // DateTimeOffset admits whole minutes within 14 hours, so anything wider is refused here
+            // rather than thrown from the constructor.
+            if (offsetMinutes > 59 || total > MaxOffsetMinutes)
+            {
+                return false;
+            }
+
+            offset = TimeSpan.FromMinutes(negative ? -total : total);
+            return true;
+        }
+
+        private static bool TryReadInt32(ref ReadOnlySpan<byte> buffer, int digits, out int value)
+        {
+            if (buffer.Length < digits)
+            {
+                value = default;
+                return false;
+            }
+
+            value = 0;
+
+            for (int i = 0; i < digits; i++)
+            {
+                byte digit = buffer[i];
+
+                if (digit < '0' || digit > '9')
+                {
+                    value = default;
+                    return false;
+                }
+
+                value = value * 10 + (digit - '0');
+            }
+
+            buffer = buffer.Slice(digits);
+            return true;
+        }
+
+        private static bool TryReadByte(ref ReadOnlySpan<byte> buffer, byte expected)
+        {
+            if (buffer.Length < 1 || buffer[0] != expected)
+            {
+                return false;
+            }
+
+            buffer = buffer.Slice(1);
+            return true;
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
@@ -53,6 +53,11 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
                 return new BigIntegerConverter();
             }
 
+            if (type == typeof(DateTimeOffset))
+            {
+                return new DateTimeOffsetConverter(options);
+            }
+
             if (type == typeof(CborDecimalFraction))
             {
                 return new DecimalFractionConverter();


### PR DESCRIPTION
Part of #247.

`DateTimeOffset` had no converter, so the reflection path mapped the struct over its public properties:

```
807 bytes for one timestamp, and it reads back as default
```

Silently — the document is well-formed CBOR, it just describes a `DateTimeOffset`'s internals rather than its value.

### The offset is the point

The tag 0 form carries it. It is written through `"K"` and parsed straight back into the `DateTimeOffset`, rather than converted away — which is the whole difference from `DateTimeConverter`, which *must* convert an offset to UTC because a `DateTime` has nowhere to keep one.

```
2026-08-17T01:02:03+02:00  ->  C0 78 19 ...2B30323A3030
1996-12-19T16:39:57-08:00  ->  C0 78 19 ...2D30383A3030      RFC 3339 §5.6's own example
```

A test pins the distinction the type exists for: two documents naming one instant at different offsets compare equal, and `EqualsExact` says they are not the same value.

### What the numeric formats cannot do

**RFC 8949 tag 1 is a count of seconds since the epoch, so it names an instant and has nowhere to put an offset.** Under `DateTimeFormat.Unix` and `UnixMilliseconds` a `DateTimeOffset` therefore writes the correct moment and reads back at `TimeSpan.Zero`.

That is a property of the encoding, not a shortcut here, and `ANumericFormatKeepsTheInstantAndDropsTheOffset` asserts both halves explicitly — the instant survives, the offset does not. A caller who needs the offset has to stay on `ISO8601`. Flagging it rather than leaving it to be discovered.

A zero offset writes as `+00:00` rather than the `Z` a UTC `DateTime` produces, because on this type the offset is a value in its own right and `K` renders it numerically. Both are RFC 3339; both read back identically.

### Two tests change sides

Worth reviewing, since neither is visible as a behaviour change in the diff alone:

- `DiagnosticTests.TypesWithNoConcreteConverterAreReported` drops its `System.DateTimeOffset` row — the type is no longer among those the generator refuses with CBOR1002.
- `DateTimeOffsetHasNoCddlRepresentation` becomes `DateTimeOffsetHasACddlRepresentation`.

`Guid` still covers the CBOR1011 path for a genuinely unsupported scalar, so no coverage is lost. Deleting the `IsPrimitive` case fails 3 `GeneratedCorpusTests` cases, which is how I checked the corpus binds rather than assuming it.

### Scope

No `#if` guard: `DateTimeOffset` exists on netstandard2.0, unlike the `DateOnly`/`TimeOnly` of #250.

`TimeSpan`, the other half of #247, is deliberately **not** here — it currently round-trips, so giving it a converter is a wire-format break rather than a fix, and it deserves its own decision. I'll open it separately.

Documentation: #250 adds `docs/dates-and-times.md`, and this type's rows belong on that page. I left it out here rather than adding a competing copy that would conflict; I'll fold it in as soon as either PR lands.

2045 library tests and 41 generator tests pass on net10.0 with `CDDL_REQUIRED=1`; all four TFMs build with no warnings.