### PR TITLE
Add TimeSpanFormat.Duration, the RFC 9581 duration encoding

### DIFF
--- a/src/Dahomey.Cbor.Generator/CborSourceGenerator.cs
+++ b/src/Dahomey.Cbor.Generator/CborSourceGenerator.cs
@@ -327,6 +327,7 @@ namespace Dahomey.Cbor.Generator
         public string? DateTimeFormat { get; private set; }
         public string? TypedArrayMode { get; private set; }
         public string? DecimalFormat { get; private set; }
+        public string? TimeSpanFormat { get; private set; }
 
         /// <summary>
         /// Whether this context writes RFC 8746 typed arrays, which is the only half of
@@ -343,6 +344,13 @@ namespace Dahomey.Cbor.Generator
         /// reading tag 4 is unconditional and says nothing about the documents this context produces.
         /// </summary>
         public bool WritesDecimalFractions => DecimalFormat is "DecimalFraction";
+
+        /// <summary>
+        /// Whether a <c>System.TimeSpan</c> resolves to <c>TimeSpanConverter</c> rather than to the
+        /// object mapping. Unlike the two above this governs collection as well as the schema: the
+        /// setting decides which mechanism handles the type, not merely which bytes it emits.
+        /// </summary>
+        public bool WritesDurations => TimeSpanFormat is "Duration";
 
         public static GenerationOptions Read(INamedTypeSymbol contextSymbol, List<DiagnosticInfo> diagnostics)
         {
@@ -436,6 +444,14 @@ namespace Dahomey.Cbor.Generator
                         options.DecimalFormat = named.Value.Value switch
                         {
                             1 => "DecimalFraction",
+                            _ => null,
+                        };
+                        break;
+
+                    case "TimeSpanFormat":
+                        options.TimeSpanFormat = named.Value.Value switch
+                        {
+                            1 => "Duration",
                             _ => null,
                         };
                         break;

--- a/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
+++ b/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
@@ -329,6 +329,12 @@ namespace Dahomey.Cbor.Generator
 
                 case "Dahomey.Cbor.CborBigFloat":
                     return "#6.5([int, (int / #6.2(bstr) / #6.3(bstr))])";
+
+                // Reachable only under TimeSpanFormat.Duration -- otherwise the type is an object and
+                // never arrives here. The nanosecond entry is written only for a value that has a
+                // fractional part, so it is optional in the schema.
+                case "System.TimeSpan":
+                    return "#6.1002({1 => int, ? -9 => int})";
             }
 
             // Guid and DateTimeOffset have no scalar converter. Nor does System.Half: the only place

--- a/src/Dahomey.Cbor.Generator/Emitter.cs
+++ b/src/Dahomey.Cbor.Generator/Emitter.cs
@@ -353,6 +353,12 @@ namespace Dahomey.Cbor.Generator
                 wrote = true;
             }
 
+            if (options.TimeSpanFormat is not null)
+            {
+                builder.AppendLine($"{indent}        options.TimeSpanFormat = TimeSpanFormat.{options.TimeSpanFormat};");
+                wrote = true;
+            }
+
             if (wrote)
             {
                 builder.AppendLine();

--- a/src/Dahomey.Cbor.Generator/TypeCollector.cs
+++ b/src/Dahomey.Cbor.Generator/TypeCollector.cs
@@ -741,7 +741,7 @@ namespace Dahomey.Cbor.Generator
                 || type.ToDisplayString() is "System.Half" or "System.Guid" or "System.DateTimeOffset";
         }
 
-        private static bool IsPrimitive(ITypeSymbol type)
+        private bool IsPrimitive(ITypeSymbol type)
         {
             switch (type.SpecialType)
             {
@@ -775,6 +775,12 @@ namespace Dahomey.Cbor.Generator
                 case "Dahomey.Cbor.CborDecimalFraction":
                 case "Dahomey.Cbor.CborBigFloat":
                     return true;
+
+                // The only classification that depends on an option. Under the default there is no
+                // TimeSpanConverter to resolve, so the type is collected as an object -- which is what
+                // the reflection path does with it too, and the corpus compares the two.
+                case "System.TimeSpan":
+                    return _options.WritesDurations;
             }
 
             // System.Half, System.Guid, System.DateTimeOffset and System.Object are deliberately absent.

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlDurationTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlDurationTests.cs
@@ -1,0 +1,67 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using Dahomey.Cbor.Tests.Extensions;
+using System;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests.Cddl
+{
+    public class CddlDurationHolder
+    {
+        public TimeSpan Elapsed { get; set; }
+    }
+
+    [CborSerializable(typeof(CddlDurationHolder))]
+    [CborCddlSchema]
+    [CborSourceGenerationOptions(TimeSpanFormat = TimeSpanFormat.Duration)]
+    public partial class CddlDurationContext : CborSerializerContext
+    {
+    }
+
+    public class CddlDurationTests
+    {
+        private static readonly CddlDurationContext Context =
+            CborSerializerContext.Default<CddlDurationContext>();
+
+        [Fact]
+        public void DurationIsTagOneThousandTwoOverAMap()
+        {
+            Assert.Contains(
+                "\"Elapsed\": #6.1002({1 => int, ? -9 => int}),",
+                CddlDurationContext.CddlSchema.Replace("\r\n", "\n"));
+        }
+
+        /// <summary>
+        /// A whole number of seconds, which omits the nanosecond entry the schema marks optional.
+        /// </summary>
+        [CddlFact]
+        public void AWholeSecondValidatesAgainstTheSchema()
+        {
+            byte[] cbor = Helper.Write(
+                new CddlDurationHolder { Elapsed = TimeSpan.FromSeconds(3723) },
+                Context.Options).HexToBytes();
+
+            CddlResult result = CddlTool.Validate(
+                CddlDurationContext.CddlSchema, "CddlDurationHolder", cbor);
+
+            Assert.True(result.Ok, result.Output);
+        }
+
+        /// <summary>
+        /// And one carrying a fraction, which writes it -- so both arms of the optional entry are
+        /// checked against the tool rather than only the shorter one.
+        /// </summary>
+        [CddlFact]
+        public void AFractionalValueValidatesAgainstTheSchema()
+        {
+            byte[] cbor = Helper.Write(
+                new CddlDurationHolder { Elapsed = new TimeSpan(0, 1, 2, 3, 500) },
+                Context.Options).HexToBytes();
+
+            CddlResult result = CddlTool.Validate(
+                CddlDurationContext.CddlSchema, "CddlDurationHolder", cbor);
+
+            Assert.True(result.Ok, result.Output);
+        }
+    }
+}

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -445,6 +445,22 @@ namespace Dahomey.Cbor.Tests
                 };
             }
 
+            // A fractional value and a negative one, so both the nanosecond entry and the sign
+            // convention are compared against the reflection path rather than only whole seconds.
+            if (type == typeof(GeneratedDurationHolder))
+            {
+                return new GeneratedDurationHolder
+                {
+                    Elapsed = new TimeSpan(0, 1, 2, 3, 500),
+                    Timeout = TimeSpan.FromSeconds(-30),
+                };
+            }
+
+            if (type == typeof(Cddl.CddlDurationHolder))
+            {
+                return new Cddl.CddlDurationHolder { Elapsed = new TimeSpan(0, 1, 2, 3, 500) };
+            }
+
             if (type == typeof(Cddl.CddlTypedArrays))
             {
                 return new Cddl.CddlTypedArrays
@@ -601,6 +617,7 @@ namespace Dahomey.Cbor.Tests
                 EnumFormat = generated.EnumFormat,
                 DateTimeFormat = generated.DateTimeFormat,
                 DecimalFormat = generated.DecimalFormat,
+                TimeSpanFormat = generated.TimeSpanFormat,
             };
 
             string reflectionBytes = WriteAs(type, Sample(type), reflection);

--- a/src/Dahomey.Cbor.Tests/TimeSpanTests.cs
+++ b/src/Dahomey.Cbor.Tests/TimeSpanTests.cs
@@ -1,0 +1,152 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using System;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    public class GeneratedDurationHolder
+    {
+        public TimeSpan Elapsed { get; set; }
+        public TimeSpan? Timeout { get; set; }
+    }
+
+    /// <summary>
+    /// The setting has to be on the attribute, not on options handed to the base constructor.
+    /// </summary>
+    /// <remarks>
+    /// Unlike every other wire-format option, this one decides which <em>mechanism</em> handles the
+    /// type: under the default a TimeSpan is collected as an object, and under Duration it resolves to
+    /// TimeSpanConverter. That choice is made while the context is generated, so a value supplied at
+    /// run time arrives too late and the generated half would still carry the object mapping.
+    /// </remarks>
+    [CborSerializable(typeof(GeneratedDurationHolder))]
+    [CborSourceGenerationOptions(TimeSpanFormat = TimeSpanFormat.Duration)]
+    public partial class DurationContext : CborSerializerContext
+    {
+    }
+
+    public class TimeSpanTests
+    {
+        private static CborOptions Duration()
+        {
+            return new CborOptions { TimeSpanFormat = TimeSpanFormat.Duration };
+        }
+
+        [Theory]
+        // Tag 1002 over {1: seconds}, RFC 9581's duration. 3723 = 01:02:03.
+        [InlineData("D903EAA101190E8B", 0, 1, 2, 3, 0)]
+        [InlineData("D903EAA10100", 0, 0, 0, 0, 0)]
+        [InlineData("D903EAA101390E0F", 0, -1, 0, 0, 0)]
+        // A fractional part adds nanoseconds under key -9.
+        [InlineData("D903EAA20101281A1DCD6500", 0, 0, 0, 1, 500)]
+        // Both components go negative together, so the value is their sum in every case.
+        [InlineData("D903EAA20120283A1DCD64FF", 0, 0, 0, -1, -500)]
+        public void DurationRoundTrips(
+            string hexBuffer, int days, int hours, int minutes, int seconds, int milliseconds)
+        {
+            TimeSpan expected = new TimeSpan(days, hours, minutes, seconds, milliseconds);
+
+            Assert.Equal(expected, Helper.Read<TimeSpan>(hexBuffer, Duration()));
+            Helper.TestWrite(expected, hexBuffer, null, Duration());
+        }
+
+        /// <summary>
+        /// The finest value the type holds, so the nanosecond key is exercised at its own resolution
+        /// rather than only at a round number of milliseconds.
+        /// </summary>
+        [Fact]
+        public void OneTickIsAHundredNanoseconds()
+        {
+            Assert.Equal(TimeSpan.FromTicks(1), Helper.Read<TimeSpan>("D903EAA20100281864", Duration()));
+            Helper.TestWrite(TimeSpan.FromTicks(1), "D903EAA20100281864", null, Duration());
+        }
+
+        [Theory]
+        // RFC 9581 defines finer keys than this writes, and a peer may use them.
+        [InlineData("D903EAA201002201", 10000)]      // key -3, one millisecond
+        [InlineData("D903EAA201002501", 10)]         // key -6, one microsecond
+        public void TheOtherFractionalKeysAreRead(string hexBuffer, long expectedTicks)
+        {
+            Assert.Equal(TimeSpan.FromTicks(expectedTicks), Helper.Read<TimeSpan>(hexBuffer, Duration()));
+        }
+
+        /// <summary>
+        /// Not a form this writes, and not one RFC 9581 defines, but the obvious shape for a peer that
+        /// never adopted the tag.
+        /// </summary>
+        [Fact]
+        public void APlainNumberIsReadAsWholeSeconds()
+        {
+            Assert.Equal(TimeSpan.FromSeconds(3723), Helper.Read<TimeSpan>("190E8B", Duration()));
+        }
+
+        /// <summary>
+        /// RFC 9581 §3 defines keys this converter does not act on -- a timescale, a clock quality --
+        /// and none of them change the length being described, so an unrecognised one is skipped rather
+        /// than failing a document that is otherwise readable.
+        /// </summary>
+        [Fact]
+        public void AnUnrecognisedKeyIsSkipped()
+        {
+            // 1002({1: 3723, -1: 1}) -- key -1 is the timescale indicator.
+            Assert.Equal(
+                TimeSpan.FromSeconds(3723),
+                Helper.Read<TimeSpan>("D903EAA201190E8B2001", Duration()));
+        }
+
+        /// <summary>
+        /// The default is the historical encoding, and this is what keeps the option from being a wire
+        /// break: without asking for the duration form a TimeSpan is still the object mapping's map of
+        /// public properties, which is what every document written so far contains.
+        /// </summary>
+        [Fact]
+        public void TheDefaultIsUnchangedAndIsNotTheDurationTag()
+        {
+            string written = Helper.Write(new TimeSpan(1, 2, 3));
+
+            Assert.DoesNotContain("D903EA", written);
+            Assert.StartsWith("B0", written);   // a map of 16 members, as before
+            Assert.Equal(new TimeSpan(1, 2, 3), Helper.Read<TimeSpan>(written));
+        }
+
+        /// <summary>
+        /// The two forms are not interchangeable, which the option's own documentation states: there is
+        /// no converter under the default, so nothing reads tag 1002 there.
+        /// </summary>
+        [Fact]
+        public void TheDefaultDoesNotReadADuration()
+        {
+            Assert.ThrowsAny<Exception>(() => Helper.Read<TimeSpan>("D903EAA101190E8B"));
+        }
+
+        [Fact]
+        public void RoundTripsThroughAPocoMember()
+        {
+            GeneratedDurationHolder value = new GeneratedDurationHolder
+            {
+                Elapsed = new TimeSpan(0, 1, 2, 3, 500),
+                Timeout = TimeSpan.FromSeconds(-30),
+            };
+
+            GeneratedDurationHolder read =
+                Helper.Read<GeneratedDurationHolder>(Helper.Write(value, Duration()), Duration());
+
+            Assert.Equal(value.Elapsed, read.Elapsed);
+            Assert.Equal(value.Timeout, read.Timeout);
+        }
+
+        /// <summary>
+        /// 259 bytes against 8 for the same value, which is the practical reason to opt in.
+        /// </summary>
+        [Fact]
+        public void TheDurationFormIsFarSmaller()
+        {
+            int members = Helper.Write(new TimeSpan(1, 2, 3)).Length / 2;
+            int duration = Helper.Write(new TimeSpan(1, 2, 3), Duration()).Length / 2;
+
+            Assert.Equal(259, members);
+            Assert.Equal(8, duration);
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Attributes/CborSourceGenerationOptionsAttribute.cs
+++ b/src/Dahomey.Cbor/Attributes/CborSourceGenerationOptionsAttribute.cs
@@ -58,5 +58,15 @@ namespace Dahomey.Cbor.Attributes
         /// alone still reports CBOR1011 for such a member.
         /// </remarks>
         public DecimalFormat DecimalFormat { get; set; } = DecimalFormat.DecimalFloat;
+
+        /// <summary>
+        /// <see cref="CborOptions.TimeSpanFormat"/>.
+        /// </summary>
+        /// <remarks>
+        /// The one setting that decides which mechanism handles a type rather than only which bytes it
+        /// emits, so it has to be stated here: under the default a <see cref="TimeSpan"/> is collected
+        /// as an object, and a value supplied at run time arrives after the context is generated.
+        /// </remarks>
+        public TimeSpanFormat TimeSpanFormat { get; set; } = TimeSpanFormat.Members;
     }
 }

--- a/src/Dahomey.Cbor/CborOptions.cs
+++ b/src/Dahomey.Cbor/CborOptions.cs
@@ -150,6 +150,50 @@ namespace Dahomey.Cbor
         DecimalFraction = 1,
     }
 
+    /// <summary>
+    /// How a <see cref="TimeSpan"/> is written.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="TimeSpan"/> has always been written by the object mapping, over its public
+    /// properties, and that round-trips -- so unlike the types with no working encoding at all, changing
+    /// it is a wire-format break rather than a fix. <see cref="Members"/> therefore stays the default and
+    /// no existing document changes shape underneath a caller who has not asked for it.
+    /// <para>
+    /// The setting governs reading as well as writing, which <see cref="DecimalFormat"/> does not need
+    /// to: there is no converter for a <see cref="TimeSpan"/> under <see cref="Members"/> at all, so the
+    /// object mapping reads it, and a converter that read tag 1002 as well would have to be registered
+    /// -- which would itself stop the historical form being readable. Documents in the two forms cannot
+    /// be read by one setting.
+    /// </para>
+    /// </remarks>
+    public enum TimeSpanFormat
+    {
+        /// <summary>
+        /// A map of the type's own public properties, as the object mapping produces. The historical
+        /// form, and the default.
+        /// </summary>
+        /// <remarks>
+        /// 259 bytes for a value of three components, and meaningful only to a decoder that knows the
+        /// CLR type's shape -- <c>Ticks</c>, <c>Days</c>, <c>TotalMicroseconds</c> and the rest. Keep it
+        /// for a contract whose only participants are Dahomey.Cbor, or while documents written by an
+        /// earlier version are still in circulation.
+        /// </remarks>
+        Members = 0,
+
+        /// <summary>
+        /// The RFC 9581 section 4 duration: tag 1002 over a map carrying whole seconds under key 1 and,
+        /// when the value has a fractional part, nanoseconds under key -9.
+        /// </summary>
+        /// <remarks>
+        /// Carries every value <see cref="TimeSpan"/> holds, since its resolution is 100ns and key -9 is
+        /// finer. A negative duration writes both components negative, so that the value is their sum in
+        /// every case; RFC 9581 does not pin the sign convention for a negative base, so a peer may
+        /// render <c>-1.5s</c> as <c>-2s + 0.5s</c> instead. Both read back here as the same
+        /// <see cref="TimeSpan"/>.
+        /// </remarks>
+        Duration = 1,
+    }
+
     public class CborOptions
     {
         public static CborOptions Default { get; } = new CborOptions()
@@ -273,6 +317,13 @@ namespace Dahomey.Cbor
         /// </para>
         /// </remarks>
         public DecimalFormat DecimalFormat { get; set; }
+
+        /// <summary>
+        /// How a <see cref="TimeSpan"/> is written and read. Defaults to
+        /// <see cref="TimeSpanFormat.Members"/>, the historical form, so no existing document changes
+        /// shape.
+        /// </summary>
+        public TimeSpanFormat TimeSpanFormat { get; set; }
 
         /// <summary>
         /// Semantic Tag to check if the discriminator is present when ObjectFormat is Array

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
@@ -53,6 +53,13 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
                 return new BigIntegerConverter();
             }
 
+            // Only when asked. Returning null under the default leaves a TimeSpan to the object
+            // mapping, which is what it has always been written by, so no document changes shape.
+            if (type == typeof(TimeSpan) && options.TimeSpanFormat == TimeSpanFormat.Duration)
+            {
+                return new TimeSpanConverter();
+            }
+
             if (type == typeof(CborDecimalFraction))
             {
                 return new DecimalFractionConverter();

--- a/src/Dahomey.Cbor/Serialization/Converters/TimeSpanConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/TimeSpanConverter.cs
@@ -1,0 +1,117 @@
+using System;
+
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// Reads and writes a <see cref="TimeSpan"/> as an RFC 9581 §4 duration, tag 1002.
+    /// </summary>
+    /// <remarks>
+    /// Registered only when <see cref="CborOptions.TimeSpanFormat"/> asks for it. Under the default
+    /// <see cref="TimeSpanFormat.Members"/> there is no converter for a <see cref="TimeSpan"/> at all
+    /// and the object mapping handles it, exactly as it always has -- which is what keeps this addition
+    /// from changing any document already in circulation.
+    /// </remarks>
+    public class TimeSpanConverter : CborConverterBase<TimeSpan>
+    {
+        /// <summary>RFC 9581's tag for a duration.</summary>
+        public const ulong DurationTag = 1002;
+
+        /// <summary>The base value, in whole seconds. RFC 9581 §3's key 1, shared with tag 1001.</summary>
+        private const int SecondsKey = 1;
+
+        private const int MillisecondsKey = -3;
+        private const int MicrosecondsKey = -6;
+        private const int NanosecondsKey = -9;
+
+        private const long NanosecondsPerTick = 100;
+
+        public override TimeSpan Read(ref CborReader reader)
+        {
+            // A plain number is accepted as whole seconds. Not a form this writes, and not one RFC 9581
+            // defines -- a duration is always a map there -- but it is the obvious shape for a peer that
+            // never adopted the tag, and refusing it would buy nothing.
+            switch (reader.GetCurrentDataItemType())
+            {
+                case CborDataItemType.Signed:
+                case CborDataItemType.Unsigned:
+                    return TimeSpan.FromTicks(
+                        checked(reader.ReadInt64() * TimeSpan.TicksPerSecond));
+
+                case CborDataItemType.Double:
+                case CborDataItemType.Single:
+                    return TimeSpan.FromSeconds(reader.ReadDouble());
+            }
+
+            reader.ReadBeginMap();
+
+            int size = reader.ReadSize();
+            long ticks = 0;
+
+            for (int read = 0; size == -1 || read < size; read++)
+            {
+                if (size == -1 && reader.IsBreak())
+                {
+                    break;
+                }
+
+                int key = reader.ReadInt32();
+
+                switch (key)
+                {
+                    case SecondsKey:
+                        ticks = checked(ticks + reader.ReadInt64() * TimeSpan.TicksPerSecond);
+                        break;
+
+                    case MillisecondsKey:
+                        ticks = checked(ticks + reader.ReadInt64() * TimeSpan.TicksPerMillisecond);
+                        break;
+
+                    case MicrosecondsKey:
+                        ticks = checked(ticks + reader.ReadInt64() * (TimeSpan.TicksPerMillisecond / 1000));
+                        break;
+
+                    case NanosecondsKey:
+                        // TimeSpan resolves to 100ns, so anything finer is truncated rather than
+                        // refused: a peer whose clock is more precise is interoperating correctly.
+                        ticks = checked(ticks + reader.ReadInt64() / NanosecondsPerTick);
+                        break;
+
+                    default:
+                        // RFC 9581 defines further keys -- a decimal or bigfloat base, a timescale, a
+                        // clock quality -- none of which change the length this reads. Skipping keeps
+                        // an unrecognised one from failing a document that is otherwise readable.
+                        reader.SkipDataItem();
+                        break;
+                }
+            }
+
+            return TimeSpan.FromTicks(ticks);
+        }
+
+        public override void Write(ref CborWriter writer, TimeSpan value)
+        {
+            long ticks = value.Ticks;
+            long seconds = ticks / TimeSpan.TicksPerSecond;
+
+            // Truncation is toward zero on both sides, so the remainder carries the sign of the value
+            // and the two components sum back to it without a case for negatives.
+            long remainder = ticks % TimeSpan.TicksPerSecond;
+
+            writer.WriteSemanticTag(DurationTag);
+
+            if (remainder == 0)
+            {
+                writer.WriteBeginMap(1);
+                writer.WriteInt32(SecondsKey);
+                writer.WriteInt64(seconds);
+                return;
+            }
+
+            writer.WriteBeginMap(2);
+            writer.WriteInt32(SecondsKey);
+            writer.WriteInt64(seconds);
+            writer.WriteInt32(NanosecondsKey);
+            writer.WriteInt64(remainder * NanosecondsPerTick);
+        }
+    }
+}


### PR DESCRIPTION
The last row of #247, and **the one that is not a defect** — which shapes the whole design.

A `TimeSpan` has always been written by the object mapping, over its public properties:

```
new TimeSpan(1, 2, 3)  ->  259 bytes    B0 65 5469636B73 1B00000008AB14B780 64 44617973 00 ...
```

Large, and meaningful only to a decoder that knows the CLR type's shape — but it **round-trips**, which is why nobody noticed. So unlike `DateOnly` (throws), `TimeOnly` (loses its seconds) and `DateTimeOffset` (reads back as `default`), there is nothing broken here to fix. Changing the encoding unasked would be a wire break, not a repair.

### So it follows `DecimalFormat`

`TimeSpanFormat.Members` is the default and nothing about it changes. `TimeSpanFormat.Duration` opts in to [RFC 9581 §4](https://www.rfc-editor.org/rfc/rfc9581.html)'s duration, tag 1002:

```
01:02:03      ->  D9 03EA A1 01 19 0E8B                    8 bytes, against 259
01:02:03.500  ->  D9 03EA A2 01 190E8B 28 1A1DCD6500       nanoseconds under key -9
```

**One difference from `DecimalFormat` worth reviewing.** That option leaves reading alone, because a `decimal` always has a converter. A `TimeSpan` has none under the default — the object mapping reads it — and registering one that also read tag 1002 would itself stop the historical form being readable. So this setting governs reading too, and documents in the two forms cannot be read by one setting. `TheDefaultDoesNotReadADuration` asserts that rather than leaving it implied.

### Reading is deliberately lenient

- Keys **-3** and **-6** are read as well as **-9**, since the RFC defines them and a peer may use them.
- An **unrecognised key is skipped**. The further keys §3 defines — a timescale, a clock quality — do not change the length being described, so failing on one would reject a document that is otherwise readable.
- A **plain number** is read as whole seconds. Not a form the RFC defines, and not one this writes, but the obvious shape for a peer that never adopted the tag.

### The sign convention, which the RFC does not pin

A negative duration writes **both components negative**, so the value is their sum in every case and no special case is needed. RFC 9581 leaves the convention for a negative base open, so a peer may render `-1.5s` as `-2s + 0.5s` instead; both read back here as the same `TimeSpan`. Flagging it because it is the one place this could disagree with another implementation.

### The generator, and a genuine trap

**This is the only generation option that decides which *mechanism* handles a type**, rather than only which bytes it emits. Under `Members` a `TimeSpan` is collected as an object; under `Duration` it resolves to `TimeSpanConverter`. That choice is made while the context is generated, so it must be stated on `[CborSourceGenerationOptions]` — a value handed to the base constructor arrives too late, and the generated half would still carry the object mapping.

I hit exactly that while writing the tests: the corpus failed with the generated context writing a property map against the reflection path's tag 1002. `DurationContext`'s doc comment records it. If you would rather this were a diagnostic than a comment, say so and I will add one.

The corpus also had to carry `TimeSpanFormat` onto the reflection side, alongside `EnumFormat`, `DateTimeFormat` and `DecimalFormat`. Deleting the `TypeCollector` case fails 2 corpus cases; that is how I checked it binds.

The CDDL is `#6.1002({1 => int, ? -9 => int})`, validated against the Ruby `cddl` tool at both arms of the optional entry rather than compared to a string I wrote.

2045 library tests and 42 generator tests pass on net10.0 with `CDDL_REQUIRED=1`; all four TFMs build with no warnings.

Independent of #251 in content — cut from `master`, and neither needs the other. They do overlap in four files (`PrimitiveConverterProvider`, `TypeCollector`, `CddlTypeReference`, `GeneratedCorpusTests`), and in each the two additions sit apart, so whichever merges second wants a rebase keeping both sides rather than the merge button.
