### PR TITLE
Write a Guid as an RFC 9562 binary UUID, tag 37

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ class CustomObject2
 ```
 
 The last two options are for a type you cannot decorate because you do not own it — `System.Guid` in
-the example above.
+the example above. A converter registered either way takes precedence over the built-in one, so the
+example still governs; `System.Guid` itself no longer needs it, since it is written as an RFC 9562
+binary UUID out of the box.
 
 Converters are what the library uses internally for standard types and for classes discovered by
 reflection, so a converter of your own gets the same features and the same performance.

--- a/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Generator.Tests/DiagnosticTests.cs
@@ -56,13 +56,12 @@ public partial class Context : CborSerializerContext { }
         }
 
         /// <summary>
-        /// The four types classified as primitives that have no case in PrimitiveConverterProvider.
+        /// The three types classified as primitives that have no case in PrimitiveConverterProvider.
         /// Each would fall through to ObjectConverterProvider and reach MakeGenericType at run time —
         /// the exact failure a generated context exists to prevent, and invisible to the AOT analyzer.
         /// </summary>
         [Theory]
         [InlineData("object")]
-        [InlineData("System.Guid")]
         [InlineData("System.DateTimeOffset")]
         [InlineData("System.Half")]
         public void TypesWithNoConcreteConverterAreReported(string memberType)

--- a/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
+++ b/src/Dahomey.Cbor.Generator/CddlTypeReference.cs
@@ -329,9 +329,14 @@ namespace Dahomey.Cbor.Generator
 
                 case "Dahomey.Cbor.CborBigFloat":
                     return "#6.5([int, (int / #6.2(bstr) / #6.3(bstr))])";
+
+                // RFC 9562's binary UUID. Always tagged and always sixteen bytes, so no option
+                // reaches it and the size is part of the schema.
+                case "System.Guid":
+                    return "#6.37(bstr .size 16)";
             }
 
-            // Guid and DateTimeOffset have no scalar converter. Nor does System.Half: the only place
+            // DateTimeOffset has no scalar converter. Nor does System.Half: the only place
             // the library references it is the RFC 8746 typed-array element path, which writes
             // `#6.84(bstr)` -- a different representation entirely, not this method's concern.
             // System.Decimal reaches here only in its default encoding, which is likewise

--- a/src/Dahomey.Cbor.Generator/TypeCollector.cs
+++ b/src/Dahomey.Cbor.Generator/TypeCollector.cs
@@ -738,7 +738,7 @@ namespace Dahomey.Cbor.Generator
         private static bool HasNoConcreteConverter(ITypeSymbol type)
         {
             return type.SpecialType == SpecialType.System_Object
-                || type.ToDisplayString() is "System.Half" or "System.Guid" or "System.DateTimeOffset";
+                || type.ToDisplayString() is "System.Half" or "System.DateTimeOffset";
         }
 
         private static bool IsPrimitive(ITypeSymbol type)
@@ -774,10 +774,11 @@ namespace Dahomey.Cbor.Generator
                 case "System.Numerics.BigInteger":
                 case "Dahomey.Cbor.CborDecimalFraction":
                 case "Dahomey.Cbor.CborBigFloat":
+                case "System.Guid":
                     return true;
             }
 
-            // System.Half, System.Guid, System.DateTimeOffset and System.Object are deliberately absent.
+            // System.Half, System.DateTimeOffset and System.Object are deliberately absent.
             // PrimitiveConverterProvider has no case for any of them, so at run time they fall through
             // to ObjectConverterProvider and reach MakeGenericType -- the exact failure a generated
             // context exists to prevent, and one the AOT analyzer cannot see either. Classifying them

--- a/src/Dahomey.Cbor.Tests/Cddl/CddlDiagnosticTests.cs
+++ b/src/Dahomey.Cbor.Tests/Cddl/CddlDiagnosticTests.cs
@@ -140,9 +140,13 @@ namespace Harness
             Assert.DoesNotContain(diagnostics, d => d.Id == "CBOR1011");
         }
 
-        /// <summary>Guid has no scalar CBOR converter at all, so it falls through the same way.</summary>
+        /// <summary>
+        /// Guid does render: GuidConverter writes RFC 9562's binary UUID, tag 37 over sixteen bytes.
+        /// Kept here because it sat beside the decimal above as a refusal, and which of the two still
+        /// is belongs in one place.
+        /// </summary>
         [Fact]
-        public void GuidHasNoCddlRepresentation()
+        public void GuidHasACddlRepresentation()
         {
             ImmutableArray<Diagnostic> diagnostics = CddlGeneratorHarness.Run(Preamble + @"
     public class Keyed { public System.Guid Key { get; set; } }
@@ -153,8 +157,7 @@ namespace Harness
 }
 ");
 
-            Diagnostic reported = Assert.Single(diagnostics, d => d.Id == "CBOR1011");
-            Assert.Equal(DiagnosticSeverity.Error, reported.Severity);
+            Assert.DoesNotContain(diagnostics, d => d.Id == "CBOR1011");
         }
 
         // char and BigInteger are deliberately absent from this file: both have concrete converters

--- a/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
+++ b/src/Dahomey.Cbor.Tests/GeneratedCorpusTests.cs
@@ -445,6 +445,17 @@ namespace Dahomey.Cbor.Tests
                 };
             }
 
+            // Guid.Empty alongside a populated one: the all-zero value is the only shape where the
+            // big-endian swap is invisible, so a sample made of it alone would pass either way.
+            if (type == typeof(GeneratedGuidHolder))
+            {
+                return new GeneratedGuidHolder
+                {
+                    Id = Guid.Parse("01234567-89ab-cdef-0123-456789abcdef"),
+                    Optional = Guid.Empty,
+                };
+            }
+
             if (type == typeof(Cddl.CddlTypedArrays))
             {
                 return new Cddl.CddlTypedArrays

--- a/src/Dahomey.Cbor.Tests/GuidTests.cs
+++ b/src/Dahomey.Cbor.Tests/GuidTests.cs
@@ -1,0 +1,139 @@
+using Dahomey.Cbor.Attributes;
+using Dahomey.Cbor.Serialization;
+using System;
+using Xunit;
+
+namespace Dahomey.Cbor.Tests
+{
+    public class GeneratedGuidHolder
+    {
+        public Guid Id { get; set; }
+        public Guid? Optional { get; set; }
+    }
+
+    [CborSerializable(typeof(GeneratedGuidHolder))]
+    public partial class GuidContext : CborSerializerContext
+    {
+    }
+
+    public class GuidTests
+    {
+        private static readonly Guid Sample = Guid.Parse("01234567-89ab-cdef-0123-456789abcdef");
+
+        // D8 25 = tag 37, 50 = a byte string of 16.
+        private const string SampleHex = "D82550" + "0123456789ABCDEF0123456789ABCDEF";
+
+        /// <summary>
+        /// The byte order is the whole point. RFC 9562 lays a UUID out big-endian, so the payload reads
+        /// exactly as the canonical text does -- <c>01 23 45 67 89 ab ...</c>. The CLR's own
+        /// <see cref="Guid.ToByteArray()"/> would put <c>67 45 23 01</c> there instead, and a document
+        /// carrying that is not the UUID it claims to be to any other implementation of tag 37.
+        /// </summary>
+        [Fact]
+        public void WriteIsBigEndianAsTheRfcRequires()
+        {
+            Helper.TestWrite(Sample, SampleHex);
+        }
+
+        [Fact]
+        public void ReadIsBigEndianToo()
+        {
+            Assert.Equal(Sample, Helper.Read<Guid>(SampleHex));
+        }
+
+        /// <summary>
+        /// A concrete guard against the swap being applied on one side only, which would round-trip
+        /// perfectly while writing bytes no peer agrees with.
+        /// </summary>
+        [Fact]
+        public void ThePayloadIsNotTheClrByteOrder()
+        {
+            string written = Helper.Write(Sample);
+
+            Assert.Contains("0123456789ABCDEF", written, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("67452301", written, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Theory]
+        [InlineData("00000000-0000-0000-0000-000000000000")]
+        [InlineData("ffffffff-ffff-ffff-ffff-ffffffffffff")]
+        [InlineData("01234567-89ab-cdef-0123-456789abcdef")]
+        public void RoundTrips(string text)
+        {
+            Guid value = Guid.Parse(text);
+
+            Assert.Equal(value, Helper.Read<Guid>(Helper.Write(value)));
+        }
+
+        /// <summary>
+        /// The tag is skipped like any other on the read path, so an untagged byte string of the right
+        /// length is still a UUID -- which is what a peer that omits the tag sends.
+        /// </summary>
+        [Fact]
+        public void AnUntaggedByteStringIsRead()
+        {
+            Assert.Equal(Sample, Helper.Read<Guid>("50" + "0123456789ABCDEF0123456789ABCDEF"));
+        }
+
+        /// <summary>
+        /// Not a form this writes, but the shape a peer emitting the textual rendering would send.
+        /// </summary>
+        [Fact]
+        public void TheCanonicalTextFormIsRead()
+        {
+            Assert.Equal(
+                Sample,
+                Helper.Read<Guid>("7824" + BitConverter.ToString(
+                    System.Text.Encoding.UTF8.GetBytes("01234567-89ab-cdef-0123-456789abcdef")).Replace("-", "")));
+        }
+
+        [Theory]
+        [InlineData("4F" + "0123456789ABCDEF0123456789ABCD")]      // fifteen bytes
+        [InlineData("5100" + "0123456789ABCDEF0123456789ABCDEF")]  // seventeen
+        [InlineData("6C6E6F742D612D75756964")]                     // "not-a-uuid"
+        [InlineData("01")]                                         // an integer
+        public void MalformedInputIsRefused(string hexBuffer)
+        {
+            Assert.Throws<CborException>(() => Helper.Read<Guid>(hexBuffer));
+        }
+
+        /// <summary>
+        /// What this replaces. Without a converter the reflection path mapped the struct over its two
+        /// public properties -- <c>Variant</c> and <c>Version</c> -- so the value itself never reached
+        /// the document at all, and reading threw <see cref="ArgumentNullException"/>, which is not a
+        /// <see cref="CborException"/> and so escaped any caller catching one.
+        /// </summary>
+        [Fact]
+        public void TheValueSurvivesAPocoMember()
+        {
+            GeneratedGuidHolder value = new GeneratedGuidHolder { Id = Sample, Optional = Guid.Empty };
+
+            GeneratedGuidHolder read = Helper.Read<GeneratedGuidHolder>(Helper.Write(value));
+
+            Assert.Equal(Sample, read.Id);
+            Assert.Equal(Guid.Empty, read.Optional);
+        }
+
+        /// <summary>
+        /// The README documents Guid as the worked example of a converter for a type you do not own,
+        /// registered through <c>[CborConverter]</c> or <c>SetConverter</c>. Both bypass the provider
+        /// chain, so that example still governs and still produces its own bytes -- this addition makes
+        /// it unnecessary for Guid, not broken.
+        /// </summary>
+        [Fact]
+        public void AUserSuppliedConverterStillWins()
+        {
+            CborOptions options = new CborOptions();
+            options.Registry.ConverterRegistry.RegisterConverter(typeof(Guid), new GuidConverterOverride());
+
+            Assert.Equal("6169", Helper.Write(Sample, options));
+        }
+
+        private class GuidConverterOverride : Dahomey.Cbor.Serialization.Converters.CborConverterBase<Guid>
+        {
+            public override Guid Read(ref CborReader reader) => Guid.Parse(reader.ReadString());
+
+            public override void Write(ref CborWriter writer, Guid value) => writer.WriteString("i");
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/GuidConverter.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/GuidConverter.cs
@@ -1,0 +1,99 @@
+using System;
+
+namespace Dahomey.Cbor.Serialization.Converters
+{
+    /// <summary>
+    /// Reads and writes a <see cref="Guid"/> as an RFC 9562 §4 binary UUID, tag 37.
+    /// </summary>
+    /// <remarks>
+    /// The byte order is the RFC's, not the CLR's. <see cref="Guid.ToByteArray()"/> emits the first
+    /// three fields little-endian -- the layout Microsoft's GUID has always had -- while RFC 9562 lays
+    /// a UUID out big-endian throughout, and that is what every other implementation of tag 37 reads.
+    /// So the three fields are reversed on the way out and again on the way in; the trailing eight
+    /// bytes are a byte array in both and are left alone.
+    /// </remarks>
+    public class GuidConverter : CborConverterBase<Guid>
+    {
+        /// <summary>RFC 9562's tag for a binary UUID.</summary>
+        public const ulong BinaryUuidTag = 37;
+
+        private const int UuidLength = 16;
+
+        /// <summary>The canonical 8-4-4-4-12 rendering, which is what a text string carries.</summary>
+        private const int CanonicalTextLength = 36;
+
+        public override Guid Read(ref CborReader reader)
+        {
+            switch (reader.GetCurrentDataItemType())
+            {
+                case CborDataItemType.ByteString:
+                {
+                    ReadOnlySpan<byte> bytes = reader.ReadByteString();
+
+                    if (bytes.Length != UuidLength)
+                    {
+                        throw reader.BuildException(
+                            $"Invalid UUID length {bytes.Length}, expected {UuidLength} bytes");
+                    }
+
+                    byte[] clrOrder = bytes.ToArray();
+                    SwapFieldOrder(clrOrder);
+                    return new Guid(clrOrder);
+                }
+
+                // Not a form this writes, and not what tag 37 carries, but the shape a peer emitting
+                // the textual rendering of a UUID would send. Reading it costs nothing and refusing it
+                // would buy nothing.
+                case CborDataItemType.String:
+                {
+                    string text = reader.ReadString();
+
+                    if (text is null
+                        || text.Length != CanonicalTextLength
+                        || !Guid.TryParseExact(text, "D", out Guid parsed))
+                    {
+                        throw reader.BuildException($"Invalid UUID format {text}");
+                    }
+
+                    return parsed;
+                }
+
+                default:
+                    throw reader.BuildException("Invalid UUID format");
+            }
+        }
+
+        public override void Write(ref CborWriter writer, Guid value)
+        {
+            byte[] bytes = value.ToByteArray();
+            SwapFieldOrder(bytes);
+
+            writer.WriteSemanticTag(BinaryUuidTag);
+            writer.WriteByteString(bytes);
+        }
+
+        /// <summary>
+        /// Converts between the CLR's field order and RFC 9562's, in place. The operation is its own
+        /// inverse, so one method serves both directions.
+        /// </summary>
+        /// <remarks>
+        /// Done by hand rather than through <c>Guid.ToByteArray(bool bigEndian)</c>, which arrived in
+        /// .NET 8 and so does not exist on netstandard2.0. Spelling it out keeps every target on
+        /// identical arithmetic instead of forking the behaviour by framework.
+        /// </remarks>
+        private static void SwapFieldOrder(byte[] bytes)
+        {
+            Swap(bytes, 0, 3);
+            Swap(bytes, 1, 2);
+            Swap(bytes, 4, 5);
+            Swap(bytes, 6, 7);
+        }
+
+        private static void Swap(byte[] bytes, int left, int right)
+        {
+            byte swap = bytes[left];
+            bytes[left] = bytes[right];
+            bytes[right] = swap;
+        }
+    }
+}

--- a/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
+++ b/src/Dahomey.Cbor/Serialization/Converters/Providers/PrimitiveConverterProvider.cs
@@ -53,6 +53,11 @@ namespace Dahomey.Cbor.Serialization.Converters.Providers
                 return new BigIntegerConverter();
             }
 
+            if (type == typeof(Guid))
+            {
+                return new GuidConverter();
+            }
+
             if (type == typeof(CborDecimalFraction))
             {
                 return new DecimalFractionConverter();


### PR DESCRIPTION
The last row of #247, and the worst of the four.

A `Guid` had no converter, so the reflection path mapped the struct over its public properties — and in .NET those are `Variant` and `Version`, which are *metadata about* the value rather than the value:

```
A1 624964 A2 6756617269616E74 00 6756657273696F6E 0C
                "Variant": 0        "Version": 12
```

**Twenty-three bytes, none of which is the GUID.** The identifier is not merely verbose on the wire — it is absent from it. Reading then threw `ArgumentNullException` from `Guid`'s own constructor: not a `CborException`, so it escaped any caller catching one, the same contract hole #164, #166 and #167 closed elsewhere.

[Tag 37](https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml) is registered for exactly this — a byte string carrying a binary UUID, RFC 9562 §4:

```
01234567-89ab-cdef-0123-456789abcdef  ->  D8 25 50 0123456789ABCDEF0123456789ABCDEF
```

### The byte order is the part worth reviewing

RFC 9562 lays a UUID out **big-endian**, so the payload reads exactly as the canonical text does. `Guid.ToByteArray()` emits the first three fields **little-endian** — the layout a Microsoft GUID has always had. So the three fields are reversed on the way out and again on the way in.

`Guid.ToByteArray(bool bigEndian)` would do it, but it arrived in .NET 8 and does not exist on netstandard2.0. Spelling the swap out keeps every target on identical arithmetic instead of forking the behaviour by framework — the trap that bit the `double.Parse` work in #209.

**A round-trip test cannot see this.** Dropping the swap on *both* sides round-trips perfectly and writes bytes no other implementation agrees with. I verified that: with both swaps removed, `RoundTrips` still passes and four other cases fail, `ThePayloadIsNotTheClrByteOrder` among them. So the order is asserted directly against the canonical rendering rather than left to a round trip.

Worth noting the repository's existing sample `GuidConverter` uses `TryWriteBytes` and so writes the CLR order — a document it produces is not the UUID it claims to be to a peer reading tag 37. That is a sample in the test project, not shipped API, so this PR leaves it alone.

### Reading

Lenient in the two ways that cost nothing: an **untagged** 16-byte string (the tag is skipped like any other), and the **canonical text form**, which is what a peer emitting the textual rendering sends. Wrong lengths, a non-UUID string and a non-string item are all `CborException`.

### Two tests change sides

Neither is visible as a behaviour change in the diff alone:

- `DiagnosticTests.TypesWithNoConcreteConverterAreReported` drops its `System.Guid` row.
- `GuidHasNoCddlRepresentation` becomes `GuidHasACddlRepresentation`.

`decimal` in its default encoding still covers the CBOR1011 path, so no coverage is lost. CDDL renders `#6.37(bstr .size 16)`.

### The README example

`README.md` documents `Guid` as the worked example of a converter for a type you do not own. **That example still governs** — `[CborConverter]` and `SetConverter` both bypass the provider chain, which `AUserSuppliedConverterStillWins` now pins — so this makes it *unnecessary* for `Guid` rather than broken. I added one sentence saying so. If you would rather re-point the example at a type that still needs it, say which and I will.

2040 library tests and 41 generator tests pass on net10.0 with `CDDL_REQUIRED=1`; the solution builds with 0 warnings on all four TFMs.

Overlaps #251 in `PrimitiveConverterProvider`, `TypeCollector`, `CddlTypeReference`, `GeneratedCorpusTests` and `DiagnosticTests`, additively in each — whichever merges second wants a rebase keeping both sides.